### PR TITLE
HACKING: avoid infix optic functions, require explicit import lists

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -13,6 +13,11 @@ communication is the key here rather than hacking away.
 
 - optics are your friend
 
+- use `view`, `review`, `set`, `over` and so on instead of the
+  infix optic functions from lens
+
+- use explicit import list or qualified imports
+
 - no perf optimisations without measurements (preferably in the commit
   message)
 


### PR DESCRIPTION
add some stuff to HACKING.

The import list thing is hopefully uncontroversial.

The optic thing is a strong preference I have (mainly because I can never remember
what they are, but the "word" ones are much more human friendly and therefore readable (IMO).

If you agree, no need to wholesale refactor.  Drive-bys are fine.