### PR TITLE
bump min supported GHC to 8.0 (base >= 4.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An MUA built around [*notmuch*](https://notmuchmail.org/).
 
 ## requirements
 
-- GHC >= 7.10
+- GHC >= 8.0
 - a bunch of uncontroversial Haskell dependencies
 - notmuch
 - not much else (*geddit?*)

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -33,7 +33,7 @@ library
                      , Config.Main
                      , Storage.Notmuch
                      , Storage.ParsedMail
-  build-depends:       base >= 4.8 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , lens
                      , brick >= 0.20
                      , text-zipper
@@ -56,7 +56,7 @@ executable purebred
   ghc-options:         -Wall -threaded
   main-is:             Main.hs
   default-language:    Haskell2010
-  build-depends:       base >= 4.8 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , purebred
                      , brick
                      , optparse-applicative >= 0.13


### PR DESCRIPTION
Now that all the platforms that *I* use have GHC >= 8, bump
the min bound.

Features that arrived in GHC 8.0 that may be useful include:

- `Data.Semigroup` in *base* (less need to depend on *semigroups* library)
- `Strict` and `StrictData` language extensions
- injective type families