### PR TITLE
Do not access an un-indexed field

### DIFF
--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -40,7 +40,6 @@ messageToMail ignoredTag m = do
     tgs <- tags m
     NotmuchMail <$>
       (decodeUtf8 . fromMaybe "" <$> messageHeader "Subject" m) <*>
-      (decodeUtf8 . fromMaybe "" <$> messageHeader "To" m) <*>
       (decodeUtf8 . fromMaybe "" <$> messageHeader "From" m) <*>
       messageFilename m <*>
       messageDate m <*>

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -246,7 +246,6 @@ data ParsedMail
 -- | an email from the notmuch database
 data NotmuchMail = NotmuchMail
     { _mailSubject :: T.Text
-    , _mailTo :: T.Text
     , _mailFrom :: T.Text
     , _mailFilepath :: String
     , _mailDate :: UTCTime
@@ -256,9 +255,6 @@ data NotmuchMail = NotmuchMail
 
 mailSubject :: Lens' NotmuchMail T.Text
 mailSubject = lens _mailSubject (\m s -> m { _mailSubject = s })
-
-mailTo :: Lens' NotmuchMail T.Text
-mailTo = lens _mailTo (\m t -> m { _mailTo = t })
 
 mailFrom :: Lens' NotmuchMail T.Text
 mailFrom = lens _mailFrom (\m f -> m { _mailFrom = f })

--- a/test/TestMail.hs
+++ b/test/TestMail.hs
@@ -18,5 +18,5 @@ testMailHasBeenMoved = testCase "does not crash" $ do
   msg <- parseMail m
   Left "/path/does/not/exist: openFile: does not exist (No such file or directory)" @?= msg
   where
-    m = NotmuchMail "" "" "" "/path/does/not/exist" t ["unread"] True
+    m = NotmuchMail "" "" "/path/does/not/exist" t ["unread"] True
     t = UTCTime (fromGregorian 2017 7 7) (secondsToDiffTime 39292)


### PR DESCRIPTION
Accessing a notmuch un-indexed field results in notmuch parsing the
mail. This results in an open file descriptor which in turn ends up
open more FDs than the GC can close. The end result is during setting up
the terminal, vty needs to read the terminfo file which the system
denies.

Issue: #49