### PR TITLE
Build hs-notmuch against newer notmuch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install:
   - mkdir -p ~/.local/bin
   - export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:$PATH
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - mkdir -p /tmp/notmuch
+  - curl -L https://notmuchmail.org/releases/notmuch-$NOTMUCHVER.tar.gz | tar xz --wildcards --strip-components=1 -C /tmp/notmuch
+  - pushd /tmp/notmuch && ./configure --without-emacs --without-ruby && make && sudo make install && popd
 
 script:
   - stack --system-ghc --no-terminal --skip-ghc-check install
@@ -21,6 +24,13 @@ matrix:
   include:
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
-  - env: STACK_YAML="stack.yaml" GHCVER=8.0.2
-    compiler: ": #stack default"
-    addons: {apt: {packages: [ghc-8.0.2, notmuch, libnotmuch-dev, libtalloc-dev, tmux], sources: [hvr-ghc]}}
+  - env: STACK_YAML="stack.yaml" NOTMUCHVER=0.24.2
+    compiler: ": #stack default - notmuch: 0.24.2"
+    addons: {apt: {packages: [ghc-8.0.2, tmux, g++, libxapian-dev, libgmime-2.6-dev, libtalloc-dev, zlib1g-dev], sources: [hvr-ghc]}}
+
+  - env: STACK_YAML="stack.yaml" NOTMUCHVER=0.25
+    compiler: ": #stack default - notmuch: 0.25"
+    addons: {apt: {packages: [ghc-8.0.2, tmux, g++, libxapian-dev, libgmime-2.6-dev, libtalloc-dev, zlib1g-dev], sources: [hvr-ghc]}}
+
+  allow_failures:
+  - env: STACK_YAML="stack.yaml" NOTMUCHVER=0.25


### PR DESCRIPTION
This installs notmuch locally since the notmuch version available via
system packages is very, very outdated. Furthermore it has a regression
in a macro on which hs-notmuch is dependend upon. Result is failing tests.

To circumvent this problem, install our own supported version of notmuch
and build hs-notmuch against this version.