### PR TITLE
Defer parsing the filename when viewing mail

### DIFF
--- a/src/Error.hs
+++ b/src/Error.hs
@@ -29,6 +29,7 @@ data Error
   = NotmuchError Status
   | InvalidTag B.ByteString
   | MessageNotFound B.ByteString -- message id
+  | FileReadError FilePath IOError -- ^ failed to read a file
   | GenericError String
   deriving (Show)
 

--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -63,11 +63,7 @@ setNotmuchMailTags dbpath m = do
 tagsToMessage
   :: (MonadError Error m, MonadIO m)
   => [Tag] -> NotmuchMail -> Database RW -> m ()
-tagsToMessage xs m db =
-  let msgId = view mailId m
-  in
-    findMessage db msgId
-    >>= maybe (throwError (MessageNotFound msgId)) (messageSetTags xs)
+tagsToMessage xs msg db = getMessage db (view mailId msg) >>= messageSetTags xs
 
 -- | Get message by message ID, throwing MessageNotFound if not found
 --

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -252,7 +252,6 @@ data ParsedMail
 data NotmuchMail = NotmuchMail
     { _mailSubject :: T.Text
     , _mailFrom :: T.Text
-    , _mailFilepath :: String
     , _mailDate :: UTCTime
     , _mailTags :: [T.Text]
     , _mailId :: ByteString
@@ -263,9 +262,6 @@ mailSubject = lens _mailSubject (\m s -> m { _mailSubject = s })
 
 mailFrom :: Lens' NotmuchMail T.Text
 mailFrom = lens _mailFrom (\m f -> m { _mailFrom = f })
-
-mailFilepath :: Lens' NotmuchMail String
-mailFilepath = lens _mailFilepath (\m fp -> m { _mailFilepath = fp })
 
 mailDate :: Lens' NotmuchMail UTCTime
 mailDate = lens _mailDate (\m d -> m { _mailDate = d })

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -3,7 +3,7 @@
 module UI.Status.Main where
 
 import Brick.Types (Widget)
-import Brick.Widgets.Core (str, withAttr, (<+>))
+import Brick.Widgets.Core (str, withAttr, (<+>), strWrap)
 import qualified Brick.Widgets.List  as L
 import Control.Lens.Getter (view)
 import Data.Maybe (fromMaybe)
@@ -16,7 +16,7 @@ import Config.Main (statusbarAttr, statusbarErrorAttr)
 statusbar :: AppState -> Widget Name
 statusbar s =
     case view asError s of
-        Just e -> withAttr statusbarErrorAttr $ str (show e)
+        Just e -> withAttr statusbarErrorAttr $ strWrap (show e)
         Nothing ->
             let l = view (asMailIndex . miListOfMails) s
                 total = str $ show $ length $ view L.listElementsL l


### PR DESCRIPTION
This gives us a slight speed increase when populating the index for
results with lots of mails. Fixes issue #60.

Issue: #51