### PR TITLE
add explicit type signatures to HLint annotations

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -27,6 +27,18 @@ communication is the key here rather than hacking away.
   - Data.Semigroup.<> > Data.Monoid.<>
   - and so on...
 
+
+### Style
+
+- HLint is your friend.  But not always.  If you want to suppress a
+  hint (e.g.  suppressing "Avoid lambda" for consistent and
+  refactoring-friendly lens definitoions), be sure to include an
+  explicit type annotation so that it will play nice with
+  ``OverloadedStrings``.
+
+    {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
+
+
 ## UI Development
 
 For development, we've put a bit of consideration to what type of users we'd

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -15,7 +15,7 @@ import qualified Data.CaseInsensitive as CI
 
 import Error
 
-{-# ANN module "HLint: ignore Avoid lambda" #-}
+{-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
 
 -- | The global application mode

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -7,7 +7,7 @@ import Control.Lens.Getter (view)
 import qualified Graphics.Vty        as V
 import Types
 
-{-# ANN module "HLint: ignore Avoid lambda" #-}
+{-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
 displayMailKeybindings :: [Keybinding]
 displayMailKeybindings =


### PR DESCRIPTION
When loading the modules in GHCi with -XOverloadedStrings, the type
of the annotation is ambiguous.  Add explicit type annotations so
the modules can be loaded in the REPL.

Also add a note to HACKING about including this annotation.