### PR TITLE
Fix regression when manipulating tags

### DIFF
--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -107,4 +107,4 @@ searchInputEventDefault s ev =
     E.handleEditorEvent ev (view (asMailIndex . miSearchEditor) s) >>=
     \ed ->
          M.continue $
-         set (asMailIndex . miSearchEditor) ed s & set asAppMode BrowseMail
+         set (asMailIndex . miSearchEditor) ed s


### PR DESCRIPTION
This fixes a regression introduced with
0069c0280c5106113d101c998b7cd23f098974ec since it would change the focus
back to the mail index upon editing the tags.