### PR TITLE
Refactor Keybindings

### DIFF
--- a/configs/config.hs
+++ b/configs/config.hs
@@ -4,28 +4,24 @@ Example configuration, which uses more mutt-alike keybindings
 import Purebred
 import Data.List (union)
 
-myIndexKeybindings :: [Keybinding]
+myIndexKeybindings :: [Keybinding (List Name NotmuchMail)]
 myIndexKeybindings =
-    [ Keybinding "Quits the application" (EvKey (KChar 'q') []) halt
+    [ Keybinding (EvKey (KChar 'q') []) haltApp
     , Keybinding
-          "Manipulate the notmuch database query"
           (EvKey (KChar '/') [])
           focusSearch
-    , Keybinding "display an e-mail" (EvKey KEnter []) displayMail
-    , Keybinding "mail index down" (EvKey KDown []) mailIndexDown
-    , Keybinding "mail index down" (EvKey (KChar 'j') []) mailIndexDown
-    , Keybinding "mail index up" (EvKey KUp []) mailIndexUp
-    , Keybinding "mail index up" (EvKey (KChar 'k') []) mailIndexUp
-    , Keybinding "Switch between editor and main" (EvKey (KChar '\t') []) toggleComposeEditorAndMain
-    , Keybinding "compose new mail" (EvKey (KChar 'm') []) composeMail]
+    , Keybinding (EvKey KEnter []) displayMail
+    , Keybinding (EvKey KDown []) mailIndexDown
+    , Keybinding (EvKey (KChar 'j') []) mailIndexDown
+    , Keybinding (EvKey KUp []) mailIndexUp
+    , Keybinding (EvKey (KChar 'k') []) mailIndexUp
+    , Keybinding (EvKey (KChar '\t') []) switchComposeEditor
+    , Keybinding (EvKey (KChar 'm') []) composeMail]
 
-myMailKeybindings :: [Keybinding]
+myMailKeybindings :: [Keybinding a]
 myMailKeybindings =
-    [ Keybinding
-          "Return to list of mails"
-          (EvKey (KChar 'q') [])
-          (\s ->
-                continue $ set asAppMode Main $ s)]
+    [ Keybinding (EvKey (KChar 'q') []) backToIndex
+    ]
 
 main :: IO ()
 main = purebred $ tweak defaultConfig where

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -23,6 +23,7 @@ library
                      , Error
                      , Types
                      , UI.Keybindings
+                     , UI.Actions
                      , UI.Draw.Main
                      , UI.Index.Keybindings
                      , UI.Index.Main

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -85,6 +85,7 @@ defaultConfig =
       , _mvPreferedContentType = "text/plain"
       , _mvHeadersToShow = (`elem` ["subject", "to", "from"])
       , _mvKeybindings = displayMailKeybindings
+      , _mvIndexKeybindings = []
       }
     , _confIndexView = IndexViewSettings
       { _ivKeybindings = indexKeybindings

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -1,10 +1,12 @@
 module Purebred (
   module Types,
+  module UI.Actions,
   module UI.Index.Keybindings,
   module UI.Mail.Keybindings,
   Event(..),
   Key(..),
   Modifier(..),
+  List(..),
   getDatabasePath,
   defaultConfig,
   defaultColorMap,
@@ -35,6 +37,7 @@ import Data.Maybe (fromMaybe, isJust)
 
 import UI.Index.Keybindings
 import UI.Mail.Keybindings
+import UI.Actions
 import Storage.Notmuch (getDatabasePath)
 import Config.Main (defaultConfig, defaultColorMap)
 import Types
@@ -42,6 +45,7 @@ import Types
 -- re-exports for configuration
 import Graphics.Vty.Input.Events (Event(..), Key(..), Modifier(..))
 import Brick.Main (halt, continue, defaultMain)
+import Brick.Widgets.List (List(..))
 import Control.Lens.Lens ((&))
 import Control.Lens.Setter (over, set)
 import Control.Lens.Getter (view)

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1,0 +1,246 @@
+{-# LANGUAGE OverloadedStrings #-}
+module UI.Actions
+       (backToIndex, haltApp, focusSearch, displayMail, setUnread,
+        applySearchTerms, mailIndexUp, mailIndexDown, switchComposeEditor,
+        composeMail, replyMail, scrollUp, scrollDown, toggleHeaders, send,
+        reset, updateStateWithParsedMail, updateReadState, initialCompose)
+       where
+
+import Brick.Main (continue, halt, vScrollPage)
+import qualified Brick.Types as T
+import qualified Brick.Widgets.Edit as E
+import qualified Brick.Widgets.List as L
+import Network.Mail.Mime (Address(..), renderSendMail, simpleMail')
+import Data.Semigroup ((<>))
+import Data.Vector (Vector)
+import Data.Text (unlines)
+import Data.Text.Lazy.IO (readFile)
+import Prelude hiding (readFile, unlines)
+import Control.Lens (set, over, view, (&), _Just)
+import Control.Lens.Fold ((^?!))
+import Control.Monad ((>=>))
+import Control.Monad.Except (runExceptT)
+import Control.Monad.IO.Class (liftIO)
+import Data.Text.Zipper (currentLine, gotoEOL)
+import Data.Text (Text)
+import Storage.Notmuch (getMessages, addTag, removeTag, setNotmuchMailTags)
+import Storage.ParsedMail (parseMail, getTo, getFrom, getSubject)
+import Types
+import Error
+
+backToIndex :: Action a
+backToIndex =
+    Action
+    { _aDescription = "back to the index"
+    , _aAction = continue . set asAppMode BrowseMail
+    }
+
+haltApp :: Action a
+haltApp =
+    Action
+    { _aDescription = "quit the application"
+    , _aAction = halt
+    }
+
+composeMail :: Action (L.List Name NotmuchMail)
+composeMail =
+    Action
+    { _aDescription = "compose a new mail"
+    , _aAction = continue . set asAppMode GatherHeaders
+    }
+
+focusSearch :: Action (L.List Name NotmuchMail)
+focusSearch =
+    Action
+    { _aDescription = "Manipulate the notmuch database query"
+    , _aAction = (continue
+                   . set asAppMode SearchMail
+                   . over (asMailIndex . miSearchEditor) (E.applyEdit gotoEOL))
+    }
+
+displayMail :: Action (L.List Name NotmuchMail)
+displayMail =
+    Action
+    { _aDescription = "display an e-mail"
+    , _aAction = \s ->
+                      do s' <-
+                             liftIO $
+                             updateStateWithParsedMail s >>=
+                             updateReadState removeTag
+                         continue s'
+    }
+
+setUnread :: Action (L.List Name NotmuchMail)
+setUnread =
+    Action
+    { _aDescription = "toggle unread"
+    , _aAction = (liftIO . updateReadState addTag >=> continue)
+    }
+
+applySearchTerms :: Action (E.Editor Text Name)
+applySearchTerms =
+    Action
+    { _aDescription = "apply search"
+    , _aAction = applySearch
+    }
+
+mailIndexUp :: Action (L.List Name NotmuchMail)
+mailIndexUp =
+    Action
+    { _aDescription = "mail index up one e-mail"
+    , _aAction = mailIndexEvent L.listMoveUp
+    }
+
+mailIndexDown :: Action (L.List Name NotmuchMail)
+mailIndexDown =
+    Action
+    { _aDescription = "mail index down one e-mail"
+    , _aAction = mailIndexEvent L.listMoveDown
+    }
+
+switchComposeEditor :: Action (L.List Name NotmuchMail)
+switchComposeEditor =
+    Action
+    { _aDescription = "switch to compose editor"
+    , _aAction = \s -> case view (asCompose . cTmpFile) s of
+                          Just _ -> continue $ set asAppMode ComposeEditor s
+                          Nothing -> continue s
+    }
+
+replyMail :: Action (L.List Name NotmuchMail)
+replyMail =
+    Action
+    { _aDescription = "reply to an e-mail"
+    , _aAction = replyToMail
+    }
+
+scrollUp :: Scrollable a => Action (T.Widget a)
+scrollUp = Action
+  { _aDescription = "scrolling up"
+  , _aAction = (\s -> vScrollPage (makeViewportScroller s) T.Up >> continue s)
+  }
+
+scrollDown :: Scrollable a => Action (T.Widget a)
+scrollDown = Action
+  { _aDescription = "scrolling down"
+  , _aAction = (\s -> vScrollPage (makeViewportScroller s) T.Down >> continue s)
+  }
+
+toggleHeaders :: Action (T.Widget Name)
+toggleHeaders = Action
+  { _aDescription = "toggle mail headers"
+  , _aAction = (continue . go)
+  }
+  where
+    go :: AppState -> AppState
+    go s = case view (asMailView . mvHeadersState) s of
+      Filtered -> set (asMailView . mvHeadersState) ShowAll s
+      ShowAll -> set (asMailView . mvHeadersState) Filtered s
+
+send :: Action (E.Editor Text Name)
+send = Action
+  { _aDescription = "send mail"
+  , _aAction = sendMail
+  }
+
+reset :: Action (E.Editor Text Name)
+reset = Action
+  { _aDescription = "cancel compose"
+  , _aAction = continue . set asCompose initialCompose . set asAppMode BrowseMail
+  }
+
+applySearch :: AppState -> T.EventM Name (T.Next AppState)
+applySearch s =
+   runExceptT (getMessages searchterms (view (asConfig . confNotmuch) s))
+   >>= continue . ($ s) . either setError reloadListOfMails
+     where searchterms = currentLine $ view (asMailIndex . miSearchEditor . E.editContentsL) s
+
+updateStateWithParsedMail :: AppState -> IO AppState
+updateStateWithParsedMail s = ($ s) <$>
+    case L.listSelectedElement (view (asMailIndex . miListOfMails) s) of
+        Just (_,m) -> either
+            (\e -> setError e . set asAppMode BrowseMail)
+            (\pmail -> set (asMailView . mvMail) (Just pmail) . set asAppMode ViewMail)
+            <$> runExceptT (parseMail m (view (asConfig . confNotmuch . nmDatabase) s))
+        Nothing -> pure id
+
+updateReadState :: (NotmuchMail -> Text -> NotmuchMail) -> AppState -> IO AppState
+updateReadState op s =
+    ($ s) <$> case L.listSelectedElement (view (asMailIndex . miListOfMails) s) of
+        Just (_,m) ->
+            let newTag = view (asConfig . confNotmuch . nmNewTag) s
+                dbpath = view (asConfig . confNotmuch . nmDatabase) s
+            in either setError updateMailInList
+               <$> runExceptT (setNotmuchMailTags dbpath (op m newTag))
+        Nothing -> pure $ setError (GenericError "No mail selected to update tags")
+
+updateMailInList :: NotmuchMail -> AppState -> AppState
+updateMailInList m s =
+    let l = L.listModify (const m) (view (asMailIndex . miListOfMails) s)
+    in set (asMailIndex . miListOfMails) l s
+
+setError :: Error -> AppState -> AppState
+setError = set asError . Just
+
+reloadListOfMails :: Vector NotmuchMail -> AppState -> AppState
+reloadListOfMails vec =
+  set (asMailIndex . miListOfMails) (L.list ListOfMails vec 1)
+  . set asAppMode BrowseMail
+
+mailIndexEvent
+    :: (L.List Name NotmuchMail -> L.List Name NotmuchMail)
+    -> AppState
+    -> T.EventM n (T.Next AppState)
+mailIndexEvent fx s =
+    continue $
+    set
+        (asMailIndex . miListOfMails)
+        (fx $ view (asMailIndex . miListOfMails) s)
+        s
+
+replyToMail :: AppState -> T.EventM Name (T.Next AppState)
+replyToMail s =
+  continue . ($ s)
+  =<< case L.listSelectedElement (view (asMailIndex . miListOfMails) s) of
+    Just (_, m) -> either handleErr handleMail
+                   <$> runExceptT (parseMail m (view (asConfig . confNotmuch . nmDatabase) s))
+    Nothing -> pure id
+  where
+    handleErr e = set asAppMode BrowseMail . setError e
+    handleMail pmail =
+      set (asCompose . cTo) (E.editor GatherHeadersTo Nothing $ getFrom pmail)
+      . set (asCompose . cFrom) (E.editor GatherHeadersFrom Nothing $ getTo pmail)
+      . set (asCompose . cSubject)
+        (E.editor GatherHeadersSubject Nothing ("Re: " <> getSubject pmail))
+      . set (asCompose . cFocus) AskFrom
+      . set asAppMode GatherHeaders
+
+sendMail :: AppState -> T.EventM Name (T.Next AppState)
+sendMail s = do
+    -- XXX if something has removed the tmpfile for whatever reason we go b00m :(
+    body <- liftIO $ readFile (view (asCompose . cTmpFile) s ^?! _Just)
+    let to =
+            Address
+                Nothing
+                (unlines $ E.getEditContents $ view (asCompose . cTo) s)
+    let from =
+            Address
+                Nothing
+                (unlines $ E.getEditContents $ view (asCompose . cFrom) s)
+    let m =
+            simpleMail'
+                to
+                from
+                (unlines $ E.getEditContents $ view (asCompose . cSubject) s)
+                body
+    liftIO $ renderSendMail m
+    continue $ set asCompose initialCompose s & set asAppMode BrowseMail
+
+initialCompose :: Compose
+initialCompose =
+    Compose
+        Nothing
+        AskFrom
+        (E.editor GatherHeadersFrom Nothing "")
+        (E.editor GatherHeadersTo Nothing "")
+        (E.editor GatherHeadersSubject Nothing "")

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -15,7 +15,7 @@ import UI.ComposeEditor.Main (composeEditor, drawComposeEditor)
 import UI.GatherHeaders.Main
        (drawInteractiveHeaders, interactiveGatherHeaders)
 import UI.Index.Main (drawMain, mainEvent)
-import UI.Keybindings (initialCompose)
+import UI.Actions (initialCompose)
 import UI.Mail.Main (drawMail, mailEvent)
 import Types
 

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -2,54 +2,17 @@
 
 module UI.ComposeEditor.Keybindings where
 
-import qualified Brick.Main             as M
-import qualified Brick.Types            as T
-import qualified Brick.Widgets.Edit     as E
-import Control.Lens.Fold ((^?!))
-import Control.Lens.Getter (view)
-import Control.Lens.Lens ((&))
-import Control.Lens.Prism (_Just)
-import Control.Lens.Setter (set)
-import           Control.Monad.IO.Class (liftIO)
-import           Data.Text              (unlines)
-import           Data.Text.Lazy.IO      (readFile)
-import qualified Graphics.Vty           as V
-import           Network.Mail.Mime      (Address (..), renderSendMail,
-                                         simpleMail')
-import           Prelude                hiding (readFile, unlines)
-import           UI.Keybindings         (cancelToMain, initialCompose)
+import qualified Brick.Widgets.Edit as E
+import Data.Text (Text)
+import qualified Graphics.Vty as V
+import Prelude hiding (readFile, unlines)
+import UI.Actions
 import Types
-       (AppState, Keybinding(..), Mode(..), Name(..),
-        asAppMode, asCompose, cFrom, cSubject, cTmpFile, cTo)
 
 
-composeEditorKeybindings :: [Keybinding]
+composeEditorKeybindings :: [Keybinding (E.Editor Text Name)]
 composeEditorKeybindings =
-    [ Keybinding "Toggle index view" (V.EvKey (V.KChar '\t') []) cancelToMain
-    , Keybinding "Send e-mail" (V.EvKey (V.KChar 'y') []) sendMail
-    , Keybinding "Cancel compose" (V.EvKey V.KEsc []) (M.continue . resetCompose)
+    [ Keybinding (V.EvKey (V.KChar '\t') []) backToIndex
+    , Keybinding (V.EvKey (V.KChar 'y') []) send
+    , Keybinding (V.EvKey V.KEsc []) reset
     ]
-
-sendMail :: AppState -> T.EventM Name (T.Next AppState)
-sendMail s = do
-    -- XXX if something has removed the tmpfile for whatever reason we go b00m :(
-    body <- liftIO $ readFile (view (asCompose . cTmpFile) s ^?! _Just)
-    let to =
-            Address
-                Nothing
-                (unlines $ E.getEditContents $ view (asCompose . cTo) s)
-    let from =
-            Address
-                Nothing
-                (unlines $ E.getEditContents $ view (asCompose . cFrom) s)
-    let m =
-            simpleMail'
-                to
-                from
-                (unlines $ E.getEditContents $ view (asCompose . cSubject) s)
-                body
-    liftIO $ renderSendMail m
-    M.continue $ set asCompose initialCompose s & set asAppMode BrowseMail
-
-resetCompose :: AppState -> AppState
-resetCompose s = set asCompose initialCompose s & set asAppMode BrowseMail

--- a/src/UI/GatherHeaders/Keybindings.hs
+++ b/src/UI/GatherHeaders/Keybindings.hs
@@ -1,9 +1,9 @@
 module UI.GatherHeaders.Keybindings where
 
 import qualified Graphics.Vty   as V
-import           UI.Keybindings (cancelToMain)
 import Types (Keybinding(..))
+import UI.Actions
 
-interactiveGatherHeadersKeybindings :: [Keybinding]
+interactiveGatherHeadersKeybindings :: [Keybinding a]
 interactiveGatherHeadersKeybindings =
-    [Keybinding "Return to list of mails" (V.EvKey V.KEsc []) cancelToMain]
+    [Keybinding (V.EvKey V.KEsc []) backToIndex]

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -1,136 +1,28 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module UI.Index.Keybindings where
 
-import Brick.Main (continue, halt)
-import qualified Brick.Types as T
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
-import Data.Vector (Vector)
-import Control.Lens (over, set, view)
-import Control.Monad.Except (runExceptT)
-import Control.Monad.IO.Class (liftIO)
-import Control.Monad ((>=>))
-import Data.Text.Zipper (currentLine, gotoEOL)
 import Data.Text (Text)
 import qualified Graphics.Vty as V
-import Storage.Notmuch (getMessages, addTag, removeTag, setNotmuchMailTags)
-import Storage.ParsedMail (parseMail, getTo, getFrom, getSubject)
+import UI.Actions
 import Types
-import Data.Monoid ((<>))
-import Error
 
 -- | Default Keybindings
-indexKeybindings :: [Keybinding]
+indexKeybindings :: [Keybinding (L.List Name NotmuchMail)]
 indexKeybindings =
-    [ Keybinding "Quits the application" (V.EvKey V.KEsc []) halt
-    , Keybinding
-          "Manipulate the notmuch database query"
-          (V.EvKey (V.KChar ':') [])
-          focusSearch
-    , Keybinding "display an e-mail" (V.EvKey V.KEnter []) displayMail
-    , Keybinding "mail index down" (V.EvKey V.KDown []) mailIndexDown
-    , Keybinding "mail index up" (V.EvKey V.KUp []) mailIndexUp
-    , Keybinding "Switch between editor and main" (V.EvKey (V.KChar '\t') []) toggleComposeEditorAndMain
-    , Keybinding "compose new mail" (V.EvKey (V.KChar 'm') []) composeMail
-    , Keybinding "reply to mail" (V.EvKey (V.KChar 'r') []) replyMail
-    , Keybinding "toggle unread" (V.EvKey (V.KChar 't') [])
-      (liftIO . updateReadState addTag >=> continue)
+    [ Keybinding (V.EvKey V.KEsc []) haltApp
+    , Keybinding (V.EvKey (V.KChar ':') []) focusSearch
+    , Keybinding (V.EvKey V.KEnter []) displayMail
+    , Keybinding (V.EvKey V.KDown []) mailIndexDown
+    , Keybinding (V.EvKey V.KUp []) mailIndexUp
+    , Keybinding (V.EvKey (V.KChar '\t') []) switchComposeEditor
+    , Keybinding (V.EvKey (V.KChar 'm') []) composeMail
+    , Keybinding (V.EvKey (V.KChar 'r') []) replyMail
+    , Keybinding (V.EvKey (V.KChar 't') []) setUnread
     ]
 
-indexsearchKeybindings :: [Keybinding]
+indexsearchKeybindings :: [Keybinding (E.Editor Text Name)]
 indexsearchKeybindings =
-    [ Keybinding "Cancel search" (V.EvKey V.KEsc []) cancelSearch
-    , Keybinding "Apply search" (V.EvKey V.KEnter []) applySearchTerms
+    [ Keybinding (V.EvKey V.KEsc []) backToIndex
+    , Keybinding (V.EvKey V.KEnter []) applySearchTerms
     ]
-
-focusSearch :: AppState -> T.EventM Name (T.Next AppState)
-focusSearch = continue
-                . set asAppMode SearchMail
-                . over (asMailIndex . miSearchEditor) (E.applyEdit gotoEOL)
-
-displayMail :: AppState -> T.EventM Name (T.Next AppState)
-displayMail s = do
-    s' <- liftIO $ updateStateWithParsedMail s >>= updateReadState removeTag
-    continue s'
-
-updateReadState :: (NotmuchMail -> Text -> NotmuchMail) -> AppState -> IO AppState
-updateReadState op s =
-    ($ s) <$> case L.listSelectedElement (view (asMailIndex . miListOfMails) s) of
-        Just (_,m) ->
-            let newTag = view (asConfig . confNotmuch . nmNewTag) s
-                dbpath = view (asConfig . confNotmuch . nmDatabase) s
-            in either setError updateMailInList
-               <$> runExceptT (setNotmuchMailTags dbpath (op m newTag))
-        Nothing -> pure $ setError (GenericError "No mail selected to update tags")
-
-updateMailInList :: NotmuchMail -> AppState -> AppState
-updateMailInList m s =
-    let l = L.listModify (const m) (view (asMailIndex . miListOfMails) s)
-    in set (asMailIndex . miListOfMails) l s
-
-updateStateWithParsedMail :: AppState -> IO AppState
-updateStateWithParsedMail s = ($ s) <$>
-    case L.listSelectedElement (view (asMailIndex . miListOfMails) s) of
-        Just (_,m) -> either
-            (\e -> setError e . set asAppMode BrowseMail)
-            (\pmail -> set (asMailView . mvMail) (Just pmail) . set asAppMode ViewMail)
-            <$> runExceptT (parseMail m (view (asConfig . confNotmuch . nmDatabase) s))
-        Nothing -> pure id
-
-mailIndexEvent :: AppState -> (L.List Name NotmuchMail -> L.List Name NotmuchMail) -> T.EventM n (T.Next AppState)
-mailIndexEvent s fx =
-    continue $
-    set
-        (asMailIndex . miListOfMails)
-        (fx $ view (asMailIndex . miListOfMails) s)
-        s
-
-mailIndexUp :: AppState -> T.EventM Name (T.Next AppState)
-mailIndexUp s = mailIndexEvent s L.listMoveUp
-
-mailIndexDown :: AppState -> T.EventM Name (T.Next AppState)
-mailIndexDown s = mailIndexEvent s L.listMoveDown
-
-composeMail :: AppState -> T.EventM Name (T.Next AppState)
-composeMail s = continue $ set asAppMode GatherHeaders s
-
-replyMail :: AppState -> T.EventM Name (T.Next AppState)
-replyMail s =
-  continue . ($ s)
-  =<< case L.listSelectedElement (view (asMailIndex . miListOfMails) s) of
-    Just (_, m) -> either handleErr handleMail
-                   <$> runExceptT (parseMail m (view (asConfig . confNotmuch . nmDatabase) s))
-    Nothing -> pure id
-  where
-    handleErr e = set asAppMode BrowseMail . setError e
-    handleMail pmail =
-      set (asCompose . cTo) (E.editor GatherHeadersTo Nothing $ getFrom pmail)
-      . set (asCompose . cFrom) (E.editor GatherHeadersFrom Nothing $ getTo pmail)
-      . set (asCompose . cSubject)
-        (E.editor GatherHeadersSubject Nothing ("Re: " <> getSubject pmail))
-      . set (asCompose . cFocus) AskFrom
-      . set asAppMode GatherHeaders
-
-toggleComposeEditorAndMain :: AppState -> T.EventM Name (T.Next AppState)
-toggleComposeEditorAndMain s =
-    case view (asCompose . cTmpFile) s of
-        Just _ -> continue $ set asAppMode ComposeEditor s
-        Nothing -> continue s
-
-cancelSearch  :: AppState -> T.EventM Name (T.Next AppState)
-cancelSearch s = continue $ set asAppMode BrowseMail s
-
-setError :: Error -> AppState -> AppState
-setError = set asError . Just
-
-applySearchTerms :: AppState -> T.EventM Name (T.Next AppState)
-applySearchTerms s =
-   runExceptT (getMessages searchterms (view (asConfig . confNotmuch) s))
-   >>= continue . ($ s) . either setError reloadListOfMails
-     where searchterms = currentLine $ view (asMailIndex . miSearchEditor . E.editContentsL) s
-
-reloadListOfMails :: Vector NotmuchMail -> AppState -> AppState
-reloadListOfMails vec =
-  set (asMailIndex . miListOfMails) (L.list ListOfMails vec 1)
-  . set asAppMode BrowseMail

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -3,9 +3,7 @@ module UI.Keybindings where
 
 import qualified Brick.Main as M
 import qualified Brick.Types as T
-import qualified Brick.Widgets.Edit as E
 import Control.Lens.Getter (view)
-import Control.Lens.Setter (set)
 import Data.List (find)
 import Graphics.Vty.Input.Events (Event)
 import Prelude hiding (readFile, unlines)
@@ -14,27 +12,15 @@ import Types
 
 -- | A generic event handler using Keybindings by default if available
 handleEvent
-    :: [Keybinding]  -- ^ Keybindings to lookup
+    :: [Keybinding a]  -- ^ Keybindings to lookup
     -> (AppState -> Event -> T.EventM Name (T.Next AppState))  -- ^ default handler if no keybinding matches
     -> AppState
     -> Event
     -> T.EventM Name (T.Next AppState)
 handleEvent kbs def s ev =
     case lookupKeybinding ev kbs of
-        Just kb -> view kbAction kb s
+        Just kb -> view (kbAction . aAction) kb s
         Nothing -> def s ev
 
-lookupKeybinding :: Event -> [Keybinding] -> Maybe Keybinding
+lookupKeybinding :: Event -> [Keybinding a] -> Maybe (Keybinding a)
 lookupKeybinding e = find (\x -> view kbEvent x == e)
-
-cancelToMain :: AppState -> T.EventM Name (T.Next AppState)
-cancelToMain s = M.continue $ set asAppMode BrowseMail s
-
-initialCompose :: Compose
-initialCompose =
-    Compose
-        Nothing
-        AskFrom
-        (E.editor GatherHeadersFrom Nothing "")
-        (E.editor GatherHeadersTo Nothing "")
-        (E.editor GatherHeadersSubject Nothing "")

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -1,30 +1,16 @@
 module UI.Mail.Keybindings where
 
-import qualified Brick.Main          as M
-import qualified Brick.Types         as T
-import Control.Lens.Setter (set)
-import Control.Lens.Getter (view)
-import qualified Graphics.Vty        as V
+import qualified Brick.Types as T
+import qualified Graphics.Vty as V
+import UI.Actions
 import Types
 
 {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
-displayMailKeybindings :: [Keybinding]
+displayMailKeybindings :: [Keybinding (T.Widget Name)]
 displayMailKeybindings =
-  [ Keybinding "Return to list of mails"
-    (V.EvKey V.KEsc []) (\s -> M.continue $ set asAppMode BrowseMail s)
-  , Keybinding "Scroll e-mail up" (V.EvKey V.KBS []) (\s -> scrollMailViewPage s T.Up)
-  , Keybinding "Scroll e-mail down" (V.EvKey (V.KChar ' ') []) (\s -> scrollMailViewPage s T.Down)
-  , Keybinding "toggle between filtered and all Headers" (V.EvKey (V.KChar 'h') []) (M.continue . toggleHeaders)
-  ]
-
-scrollMailViewPage :: AppState -> T.Direction -> T.EventM Name (T.Next AppState)
-scrollMailViewPage s d = do
-  let vp = M.viewportScroll ScrollingMailView
-  M.vScrollPage vp d
-  M.continue s
-
-toggleHeaders :: AppState -> AppState
-toggleHeaders s = case view (asMailView . mvHeadersState) s of
-  Filtered -> set (asMailView . mvHeadersState) ShowAll s
-  ShowAll -> set (asMailView . mvHeadersState) Filtered s
+    [ Keybinding (V.EvKey V.KBS []) scrollUp
+    , Keybinding (V.EvKey (V.KChar ' ') []) scrollDown
+    , Keybinding (V.EvKey (V.KChar 'h') []) toggleHeaders
+    , Keybinding (V.EvKey V.KEsc []) backToIndex
+    ]

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -20,7 +20,7 @@ import Data.CaseInsensitive (mk)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.Text as T
 import Graphics.Vty.Input.Events (Event)
-import UI.Index.Keybindings
+import UI.Actions
        (updateStateWithParsedMail, updateReadState)
 import Storage.Notmuch (removeTag)
 import UI.Index.Main (renderMailList)


### PR DESCRIPTION
Split up the Action in to it's own datatype from the binding itself.
The motivation is to compose multiple actions if there is need.

For example, to move the cursor up and down the index we can define one
action: moveIndexUp. Yet we can re-use the same action with an action to
update the current view with a parsed mail when we actually view
e-mails.

Issue: #45