### PR TITLE
Abstract Action over pure AppState

### DIFF
--- a/configs/config.hs
+++ b/configs/config.hs
@@ -4,23 +4,27 @@ Example configuration, which uses more mutt-alike keybindings
 import Purebred
 import Data.List (union)
 
-myIndexKeybindings :: [Keybinding (List Name NotmuchMail)]
+myIndexKeybindings :: [Keybinding (List Name NotmuchMail) (Next AppState)]
 myIndexKeybindings =
-    [ Keybinding (EvKey (KChar 'q') []) haltApp
-    , Keybinding
-          (EvKey (KChar '/') [])
-          focusSearch
-    , Keybinding (EvKey KEnter []) displayMail
-    , Keybinding (EvKey KDown []) mailIndexDown
-    , Keybinding (EvKey (KChar 'j') []) mailIndexDown
-    , Keybinding (EvKey KUp []) mailIndexUp
-    , Keybinding (EvKey (KChar 'k') []) mailIndexUp
-    , Keybinding (EvKey (KChar '\t') []) switchComposeEditor
-    , Keybinding (EvKey (KChar 'm') []) composeMail]
+    [ Keybinding (EvKey (KChar 'q') []) quit
+    , Keybinding (EvKey (KChar '/') []) (focusSearch `chain` continue)
+    , Keybinding (EvKey KEnter []) (displayMail `chain` continue)
+    , Keybinding (EvKey KDown []) (mailIndexDown `chain` continue)
+    , Keybinding (EvKey (KChar 'j') []) (mailIndexDown `chain` continue)
+    , Keybinding (EvKey KUp []) (mailIndexUp `chain` continue)
+    , Keybinding (EvKey (KChar 'k') []) (mailIndexUp `chain` continue)
+    , Keybinding (EvKey (KChar '\t') []) (switchComposeEditor `chain` continue)
+    , Keybinding (EvKey (KChar 'm') []) (composeMail `chain` continue)]
 
-myMailKeybindings :: [Keybinding a]
+myMailKeybindings :: [Keybinding ctx (Next AppState)]
 myMailKeybindings =
-    [ Keybinding (EvKey (KChar 'q') []) backToIndex
+    [ Keybinding (EvKey (KChar 'q') []) (backToIndex `chain` continue)
+    ]
+
+myDisplayIndexKeybindings :: [Keybinding (List Name NotmuchMail) (Next AppState)]
+myDisplayIndexKeybindings =
+    [ Keybinding (EvKey (KChar 'j') []) (mailIndexDown `chain` displayMail `chain` continue)
+    , Keybinding (EvKey (KChar 'k') []) (mailIndexUp `chain` displayMail `chain` continue)
     ]
 
 main :: IO ()
@@ -28,3 +32,4 @@ main = purebred $ tweak defaultConfig where
   tweak =
     over (confIndexView . ivKeybindings) (`union` myIndexKeybindings)
     . over (confMailView . mvKeybindings) (`union` myMailKeybindings)
+    . over (confMailView . mvIndexKeybindings) (`union` myDisplayIndexKeybindings)

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -13,7 +13,7 @@ import Data.Maybe (fromMaybe)
 import UI.ComposeEditor.Keybindings (composeEditorKeybindings)
 import UI.Index.Keybindings
        (indexKeybindings, indexsearchKeybindings)
-import UI.Mail.Keybindings (displayMailKeybindings)
+import UI.Mail.Keybindings (displayMailKeybindings, displayIndexKeybindings)
 import Types
   ( ComposeViewSettings(..)
   , UserConfiguration, Configuration(..), IndexViewSettings(..)
@@ -85,7 +85,7 @@ defaultConfig =
       , _mvPreferedContentType = "text/plain"
       , _mvHeadersToShow = (`elem` ["subject", "to", "from"])
       , _mvKeybindings = displayMailKeybindings
-      , _mvIndexKeybindings = []
+      , _mvIndexKeybindings = displayIndexKeybindings
       }
     , _confIndexView = IndexViewSettings
       { _ivKeybindings = indexKeybindings

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -7,15 +7,14 @@ module Purebred (
   Key(..),
   Modifier(..),
   List(..),
+  Next,
   getDatabasePath,
   defaultConfig,
   defaultColorMap,
   over,
   set,
   (&),
-  purebred,
-  halt,
-  continue) where
+  purebred) where
 
 import UI.App (theApp, initialState)
 
@@ -44,7 +43,8 @@ import Types
 
 -- re-exports for configuration
 import Graphics.Vty.Input.Events (Event(..), Key(..), Modifier(..))
-import Brick.Main (halt, continue, defaultMain)
+import Brick.Main (defaultMain)
+import Brick.Types (Next)
 import Brick.Widgets.List (List(..))
 import Control.Lens.Lens ((&))
 import Control.Lens.Setter (over, set)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -145,29 +145,29 @@ confComposeView = to (\(Configuration _ _ _ _ _ h) -> h)
 
 
 newtype ComposeViewSettings = ComposeViewSettings
-    { _cvKeybindings :: [Keybinding (E.Editor T.Text Name)]
+    { _cvKeybindings :: [Keybinding (E.Editor T.Text Name) (Next AppState)]
     }
 
-cvKeybindings :: Lens' ComposeViewSettings [Keybinding (E.Editor T.Text Name)]
+cvKeybindings :: Lens' ComposeViewSettings [Keybinding (E.Editor T.Text Name) (Next AppState)]
 cvKeybindings f (ComposeViewSettings a) = fmap (\a' -> ComposeViewSettings a') (f a)
 
 data IndexViewSettings = IndexViewSettings
-    { _ivKeybindings       :: [Keybinding (L.List Name NotmuchMail)]
-    , _ivSearchKeybindings :: [Keybinding (E.Editor T.Text Name)]
+    { _ivKeybindings       :: [Keybinding (L.List Name NotmuchMail) (Next AppState)]
+    , _ivSearchKeybindings :: [Keybinding (E.Editor T.Text Name) (Next AppState)]
     }
 
-ivKeybindings :: Lens' IndexViewSettings [Keybinding (L.List Name NotmuchMail)]
+ivKeybindings :: Lens' IndexViewSettings [Keybinding (L.List Name NotmuchMail) (Next AppState)]
 ivKeybindings f (IndexViewSettings a b) = fmap (\a' -> IndexViewSettings a' b) (f a)
 
-ivSearchKeybindings :: Lens' IndexViewSettings [Keybinding (E.Editor T.Text Name)]
+ivSearchKeybindings :: Lens' IndexViewSettings [Keybinding (E.Editor T.Text Name) (Next AppState)]
 ivSearchKeybindings f (IndexViewSettings a b) = fmap (\b' -> IndexViewSettings a b') (f b)
 
 data MailViewSettings = MailViewSettings
     { _mvIndexRows           :: Int
     , _mvPreferedContentType :: T.Text
     , _mvHeadersToShow       :: CI.CI T.Text -> Bool
-    , _mvKeybindings         :: [Keybinding (Widget Name)]
-    , _mvIndexKeybindings    :: [Keybinding (L.List Name NotmuchMail)]
+    , _mvKeybindings         :: [Keybinding (Widget Name) (Next AppState)]
+    , _mvIndexKeybindings    :: [Keybinding (L.List Name NotmuchMail) (Next AppState)]
     }
 
 mvIndexRows :: Lens' MailViewSettings Int
@@ -179,10 +179,10 @@ mvPreferredContentType f (MailViewSettings a b c d e) = fmap (\b' -> MailViewSet
 mvHeadersToShow :: Getter MailViewSettings (CI.CI T.Text -> Bool)
 mvHeadersToShow = to (\(MailViewSettings _ _ h _ _) -> h)
 
-mvKeybindings :: Lens' MailViewSettings [Keybinding (Widget Name)]
+mvKeybindings :: Lens' MailViewSettings [Keybinding (Widget Name) (Next AppState)]
 mvKeybindings f (MailViewSettings a b c d e) = fmap (\d' -> MailViewSettings a b c d' e) (f d)
 
-mvIndexKeybindings :: Lens' MailViewSettings [Keybinding (L.List Name NotmuchMail)]
+mvIndexKeybindings :: Lens' MailViewSettings [Keybinding (L.List Name NotmuchMail) (Next AppState)]
 mvIndexKeybindings f (MailViewSettings a b c d e) = fmap (\e' -> MailViewSettings a b c d e') (f e)
 
 -- | Overall application state
@@ -213,29 +213,29 @@ asAppMode f (AppState a b c d e g) = fmap (\e' -> AppState a b c d e' g) (f e)
 asError :: Lens' AppState (Maybe Error)
 asError f (AppState a b c d e g) = fmap (\g' -> AppState a b c d e g') (f g)
 
-data Action n = Action
+data Action ctx a = Action
     { _aDescription :: String
-    , _aAction :: AppState -> EventM Name (Next AppState)
+    , _aAction :: AppState -> EventM Name a
     }
 
-aAction :: Getter (Action a) (AppState -> EventM Name (Next AppState))
+aAction :: Getter (Action ctx a) (AppState -> EventM Name a)
 aAction = to (\(Action _ b) -> b)
 
-data Keybinding a = Keybinding
+data Keybinding ctx a = Keybinding
     { _kbEvent :: Vty.Event
-    , _kbAction :: Action a
+    , _kbAction :: Action ctx a
     }
-instance Eq (Keybinding a) where
+instance Eq (Keybinding ctx a) where
   (==) (Keybinding a _) (Keybinding b _) = a == b
   (/=) (Keybinding a _) (Keybinding b _) = a /= b
 
-kbEvent :: Getter (Keybinding a) Vty.Event
+kbEvent :: Getter (Keybinding ctx a) Vty.Event
 kbEvent = to (\(Keybinding b _) -> b)
 
-kbAction :: Getter (Keybinding a) (Action a)
+kbAction :: Getter (Keybinding ctx a) (Action ctx a)
 kbAction = to (\(Keybinding _ c) -> c)
 
-aDescription :: Getter (Action a) String
+aDescription :: Getter (Action ctx a) String
 aDescription = to (\(Action a _ ) -> a)
 
 type Body = T.Text

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module UI.Actions
-       (backToIndex, haltApp, focusSearch, displayMail, setUnread,
+       (backToIndex, quit, focusSearch, displayMail, setUnread,
         applySearchTerms, mailIndexUp, mailIndexDown, switchComposeEditor,
         composeMail, replyMail, scrollUp, scrollDown, toggleHeaders, send,
-        reset, updateStateWithParsedMail, updateReadState, initialCompose)
+        reset, initialCompose, continue, chain)
        where
 
-import Brick.Main (continue, halt, vScrollPage)
+import qualified Brick.Main as B (continue, halt, vScrollPage)
 import qualified Brick.Types as T
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
@@ -28,108 +28,106 @@ import Storage.ParsedMail (parseMail, getTo, getFrom, getSubject)
 import Types
 import Error
 
-backToIndex :: Action a
+quit :: Action ctx (T.Next AppState)
+quit = Action "quit the application" B.halt
+
+continue :: Action ctx (T.Next AppState)
+continue = Action "" B.continue
+
+chain :: Action ctx AppState -> Action ctx a -> Action ctx a
+chain (Action d1 f1) (Action d2 f2) =
+  Action (if null d2 then d1 else d1 <> " and then " <> d2) (f1 >=> f2)
+
+backToIndex :: Action ctx AppState
 backToIndex =
     Action
     { _aDescription = "back to the index"
-    , _aAction = continue . set asAppMode BrowseMail
+    , _aAction = pure . set asAppMode BrowseMail
     }
 
-haltApp :: Action a
-haltApp =
-    Action
-    { _aDescription = "quit the application"
-    , _aAction = halt
-    }
-
-composeMail :: Action (L.List Name NotmuchMail)
+composeMail :: Action (L.List Name NotmuchMail) AppState
 composeMail =
     Action
     { _aDescription = "compose a new mail"
-    , _aAction = continue . set asAppMode GatherHeaders
+    , _aAction = pure . set asAppMode GatherHeaders
     }
 
-focusSearch :: Action (L.List Name NotmuchMail)
+focusSearch :: Action (L.List Name NotmuchMail) AppState
 focusSearch =
     Action
     { _aDescription = "Manipulate the notmuch database query"
-    , _aAction = (continue
-                   . set asAppMode SearchMail
-                   . over (asMailIndex . miSearchEditor) (E.applyEdit gotoEOL))
+    , _aAction = (pure
+                  . set asAppMode SearchMail
+                  . over (asMailIndex . miSearchEditor) (E.applyEdit gotoEOL))
     }
 
-displayMail :: Action (L.List Name NotmuchMail)
+displayMail :: Action (L.List Name NotmuchMail) AppState
 displayMail =
     Action
     { _aDescription = "display an e-mail"
-    , _aAction = \s ->
-                      do s' <-
-                             liftIO $
-                             updateStateWithParsedMail s >>=
-                             updateReadState removeTag
-                         continue s'
+    , _aAction = \s -> liftIO $ updateStateWithParsedMail s >>= updateReadState removeTag
     }
 
-setUnread :: Action (L.List Name NotmuchMail)
+setUnread :: Action (L.List Name NotmuchMail) AppState
 setUnread =
     Action
     { _aDescription = "toggle unread"
-    , _aAction = (liftIO . updateReadState addTag >=> continue)
+    , _aAction = (liftIO . updateReadState addTag)
     }
 
-applySearchTerms :: Action (E.Editor Text Name)
+applySearchTerms :: Action (E.Editor Text Name) AppState
 applySearchTerms =
     Action
     { _aDescription = "apply search"
     , _aAction = applySearch
     }
 
-mailIndexUp :: Action (L.List Name NotmuchMail)
+mailIndexUp :: Action (L.List Name NotmuchMail) AppState
 mailIndexUp =
     Action
     { _aDescription = "mail index up one e-mail"
     , _aAction = mailIndexEvent L.listMoveUp
     }
 
-mailIndexDown :: Action (L.List Name NotmuchMail)
+mailIndexDown :: Action (L.List Name NotmuchMail) AppState
 mailIndexDown =
     Action
     { _aDescription = "mail index down one e-mail"
     , _aAction = mailIndexEvent L.listMoveDown
     }
 
-switchComposeEditor :: Action (L.List Name NotmuchMail)
+switchComposeEditor :: Action (L.List Name NotmuchMail) AppState
 switchComposeEditor =
     Action
     { _aDescription = "switch to compose editor"
     , _aAction = \s -> case view (asCompose . cTmpFile) s of
-                          Just _ -> continue $ set asAppMode ComposeEditor s
-                          Nothing -> continue s
+                          Just _ -> pure $ set asAppMode ComposeEditor s
+                          Nothing -> pure s
     }
 
-replyMail :: Action (L.List Name NotmuchMail)
+replyMail :: Action (L.List Name NotmuchMail) AppState
 replyMail =
     Action
     { _aDescription = "reply to an e-mail"
     , _aAction = replyToMail
     }
 
-scrollUp :: Scrollable a => Action (T.Widget a)
+scrollUp :: Scrollable ctx => Action (T.Widget ctx) AppState
 scrollUp = Action
   { _aDescription = "scrolling up"
-  , _aAction = (\s -> vScrollPage (makeViewportScroller s) T.Up >> continue s)
+  , _aAction = (\s -> B.vScrollPage (makeViewportScroller s) T.Up >> pure s)
   }
-
-scrollDown :: Scrollable a => Action (T.Widget a)
+  
+scrollDown :: Scrollable ctx => Action (T.Widget ctx) AppState
 scrollDown = Action
   { _aDescription = "scrolling down"
-  , _aAction = (\s -> vScrollPage (makeViewportScroller s) T.Down >> continue s)
+  , _aAction = (\s -> B.vScrollPage (makeViewportScroller s) T.Down >> pure s)
   }
 
-toggleHeaders :: Action (T.Widget Name)
+toggleHeaders :: Action (T.Widget Name) AppState
 toggleHeaders = Action
   { _aDescription = "toggle mail headers"
-  , _aAction = (continue . go)
+  , _aAction = pure . go
   }
   where
     go :: AppState -> AppState
@@ -137,22 +135,22 @@ toggleHeaders = Action
       Filtered -> set (asMailView . mvHeadersState) ShowAll s
       ShowAll -> set (asMailView . mvHeadersState) Filtered s
 
-send :: Action (E.Editor Text Name)
+send :: Action (E.Editor Text Name) AppState
 send = Action
   { _aDescription = "send mail"
   , _aAction = sendMail
   }
 
-reset :: Action (E.Editor Text Name)
+reset :: Action (E.Editor Text Name) AppState
 reset = Action
   { _aDescription = "cancel compose"
-  , _aAction = continue . set asCompose initialCompose . set asAppMode BrowseMail
+  , _aAction = pure . set asCompose initialCompose . set asAppMode BrowseMail
   }
 
-applySearch :: AppState -> T.EventM Name (T.Next AppState)
+applySearch :: AppState -> T.EventM Name AppState
 applySearch s =
    runExceptT (getMessages searchterms (view (asConfig . confNotmuch) s))
-   >>= continue . ($ s) . either setError reloadListOfMails
+   >>= pure . ($ s) . either setError reloadListOfMails
      where searchterms = currentLine $ view (asMailIndex . miSearchEditor . E.editContentsL) s
 
 updateStateWithParsedMail :: AppState -> IO AppState
@@ -190,17 +188,17 @@ reloadListOfMails vec =
 mailIndexEvent
     :: (L.List Name NotmuchMail -> L.List Name NotmuchMail)
     -> AppState
-    -> T.EventM n (T.Next AppState)
+    -> T.EventM n AppState
 mailIndexEvent fx s =
-    continue $
+    pure $
     set
         (asMailIndex . miListOfMails)
         (fx $ view (asMailIndex . miListOfMails) s)
         s
 
-replyToMail :: AppState -> T.EventM Name (T.Next AppState)
+replyToMail :: AppState -> T.EventM Name AppState
 replyToMail s =
-  continue . ($ s)
+  pure . ($ s)
   =<< case L.listSelectedElement (view (asMailIndex . miListOfMails) s) of
     Just (_, m) -> either handleErr handleMail
                    <$> runExceptT (parseMail m (view (asConfig . confNotmuch . nmDatabase) s))
@@ -215,7 +213,7 @@ replyToMail s =
       . set (asCompose . cFocus) AskFrom
       . set asAppMode GatherHeaders
 
-sendMail :: AppState -> T.EventM Name (T.Next AppState)
+sendMail :: AppState -> T.EventM Name AppState
 sendMail s = do
     -- XXX if something has removed the tmpfile for whatever reason we go b00m :(
     body <- liftIO $ readFile (view (asCompose . cTmpFile) s ^?! _Just)
@@ -234,7 +232,7 @@ sendMail s = do
                 (unlines $ E.getEditContents $ view (asCompose . cSubject) s)
                 body
     liftIO $ renderSendMail m
-    continue $ set asCompose initialCompose s & set asAppMode BrowseMail
+    pure $ set asCompose initialCompose s & set asAppMode BrowseMail
 
 initialCompose :: Compose
 initialCompose =

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -3,6 +3,7 @@
 module UI.ComposeEditor.Keybindings where
 
 import qualified Brick.Widgets.Edit as E
+import qualified Brick.Types as T
 import Data.Text (Text)
 import qualified Graphics.Vty as V
 import Prelude hiding (readFile, unlines)
@@ -10,9 +11,9 @@ import UI.Actions
 import Types
 
 
-composeEditorKeybindings :: [Keybinding (E.Editor Text Name)]
+composeEditorKeybindings :: [Keybinding (E.Editor Text Name) (T.Next AppState)]
 composeEditorKeybindings =
-    [ Keybinding (V.EvKey (V.KChar '\t') []) backToIndex
-    , Keybinding (V.EvKey (V.KChar 'y') []) send
-    , Keybinding (V.EvKey V.KEsc []) reset
+    [ Keybinding (V.EvKey (V.KChar '\t') []) (backToIndex `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'y') []) (send `chain` continue)
+    , Keybinding (V.EvKey V.KEsc []) (reset `chain` continue)
     ]

--- a/src/UI/GatherHeaders/Keybindings.hs
+++ b/src/UI/GatherHeaders/Keybindings.hs
@@ -1,9 +1,10 @@
 module UI.GatherHeaders.Keybindings where
 
-import qualified Graphics.Vty   as V
-import Types (Keybinding(..))
+import qualified Brick.Types as T
+import qualified Graphics.Vty as V
+import Types (Keybinding(..), AppState)
 import UI.Actions
 
-interactiveGatherHeadersKeybindings :: [Keybinding a]
+interactiveGatherHeadersKeybindings :: [Keybinding ctx (T.Next AppState)]
 interactiveGatherHeadersKeybindings =
-    [Keybinding (V.EvKey V.KEsc []) backToIndex]
+    [Keybinding (V.EvKey V.KEsc []) (backToIndex `chain` continue)]

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -1,5 +1,6 @@
 module UI.Index.Keybindings where
 
+import Brick.Types (Next)
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
 import Data.Text (Text)
@@ -8,21 +9,21 @@ import UI.Actions
 import Types
 
 -- | Default Keybindings
-indexKeybindings :: [Keybinding (L.List Name NotmuchMail)]
+indexKeybindings :: [Keybinding (L.List Name NotmuchMail) (Next AppState)]
 indexKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) haltApp
-    , Keybinding (V.EvKey (V.KChar ':') []) focusSearch
-    , Keybinding (V.EvKey V.KEnter []) displayMail
-    , Keybinding (V.EvKey V.KDown []) mailIndexDown
-    , Keybinding (V.EvKey V.KUp []) mailIndexUp
-    , Keybinding (V.EvKey (V.KChar '\t') []) switchComposeEditor
-    , Keybinding (V.EvKey (V.KChar 'm') []) composeMail
-    , Keybinding (V.EvKey (V.KChar 'r') []) replyMail
-    , Keybinding (V.EvKey (V.KChar 't') []) setUnread
+    [ Keybinding (V.EvKey V.KEsc []) quit
+    , Keybinding (V.EvKey (V.KChar ':') []) (focusSearch `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (displayMail `chain` continue)
+    , Keybinding (V.EvKey V.KDown []) (mailIndexDown `chain` continue)
+    , Keybinding (V.EvKey V.KUp []) (mailIndexUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (switchComposeEditor `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'm') []) (composeMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     ]
 
-indexsearchKeybindings :: [Keybinding (E.Editor Text Name)]
+indexsearchKeybindings :: [Keybinding (E.Editor Text Name) (Next AppState)]
 indexsearchKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) backToIndex
-    , Keybinding (V.EvKey V.KEnter []) applySearchTerms
+    [ Keybinding (V.EvKey V.KEsc []) (backToIndex `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (applySearchTerms `chain` continue)
     ]

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module UI.Keybindings where
 
-import qualified Brick.Main as M
 import qualified Brick.Types as T
 import Control.Lens.Getter (view)
 import Data.List (find)
@@ -12,7 +11,7 @@ import Types
 
 -- | A generic event handler using Keybindings by default if available
 handleEvent
-    :: [Keybinding a]  -- ^ Keybindings to lookup
+    :: [Keybinding ctx (T.Next AppState)]  -- ^ Keybindings to lookup
     -> (AppState -> Event -> T.EventM Name (T.Next AppState))  -- ^ default handler if no keybinding matches
     -> AppState
     -> Event
@@ -22,5 +21,5 @@ handleEvent kbs def s ev =
         Just kb -> view (kbAction . aAction) kb s
         Nothing -> def s ev
 
-lookupKeybinding :: Event -> [Keybinding a] -> Maybe (Keybinding a)
+lookupKeybinding :: Event -> [Keybinding ctx a] -> Maybe (Keybinding ctx a)
 lookupKeybinding e = find (\x -> view kbEvent x == e)

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -1,5 +1,6 @@
 module UI.Mail.Keybindings where
 
+import Brick.Widgets.List (List)
 import qualified Brick.Types as T
 import qualified Graphics.Vty as V
 import UI.Actions
@@ -7,10 +8,16 @@ import Types
 
 {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
-displayMailKeybindings :: [Keybinding (T.Widget Name)]
+displayMailKeybindings :: [Keybinding (T.Widget Name) (T.Next AppState)]
 displayMailKeybindings =
-    [ Keybinding (V.EvKey V.KBS []) scrollUp
-    , Keybinding (V.EvKey (V.KChar ' ') []) scrollDown
-    , Keybinding (V.EvKey (V.KChar 'h') []) toggleHeaders
-    , Keybinding (V.EvKey V.KEsc []) backToIndex
+    [ Keybinding (V.EvKey V.KBS []) (scrollUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar ' ') []) (scrollDown `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'h') []) (toggleHeaders `chain` continue)
+    , Keybinding (V.EvKey V.KEsc []) (backToIndex `chain` continue)
     ]
+
+displayIndexKeybindings :: [Keybinding (List Name NotmuchMail) (T.Next AppState)]
+displayIndexKeybindings = [
+  Keybinding (V.EvKey V.KDown []) (mailIndexDown `chain` displayMail `chain` continue)
+  , Keybinding (V.EvKey V.KUp []) (mailIndexUp `chain` displayMail `chain` continue)
+  ]


### PR DESCRIPTION
In order to chain actions together to a) reduce duplication and b) allow
to compose multiple actions this re-factoring adds an additional
abstraction over the AppState.

Issue: #45