### PR TITLE
Fixes copy/paste error adding tags

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -284,7 +284,7 @@ addTags :: [Text] -> Action ctx AppState
 addTags ts =
     Action
     { _aDescription = "add given tags"
-    , _aAction = (\s -> liftIO . selectedMailHelper s $ \m -> applyMailTags m ts Notmuch.removeTags s)
+    , _aAction = (\s -> liftIO . selectedMailHelper s $ \m -> applyMailTags m ts Notmuch.addTags s)
     }
 
 removeTags :: [Text] -> Action ctx AppState


### PR DESCRIPTION
This function is used in the config and is untested (no auto test). I've
realised this happening while using. I'd wish I'd have a better option
at this point to actually test it, but unless we solve issue #41 than
fixing this.