### PR TITLE
Meaningful description for mode switch

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -77,6 +77,7 @@ test-suite unittests
   ghc-options:         -Wall
   main-is:             Main.hs
   other-modules:       TestMail
+                     , TestActions
                      , TestUserAcceptance
   default-language:    Haskell2010
   build-depends:       base

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -180,8 +180,8 @@ done = Action "apply" (complete (Proxy :: Proxy a))
 abort :: forall a. Resetable a => Action a AppState
 abort = Action "cancel" (reset (Proxy :: Proxy a))
 
-focus :: forall a. Focusable a => Action a AppState
-focus = Action "switch focus" (switchFocus (Proxy :: Proxy a))
+focus :: forall a. (HasMode a, Focusable a) => Action a AppState
+focus = Action ("switch mode to " <> show (mode (Proxy :: Proxy a))) (switchFocus (Proxy :: Proxy a))
 
 -- | A no-op action which just returns the current AppState
 -- This action can be used at the start of an Action chain where an immediate

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import TestMail (mailTests)
 import TestUserAcceptance (systemTests)
+import TestActions (actionTests)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 
 tests ::
@@ -12,7 +13,7 @@ tests = testGroup "tests" [unittests, systemTests]
 --
 unittests :: TestTree
 unittests =
-    testGroup "unit tests" [mailTests]
+    testGroup "unit tests" [mailTests, actionTests]
 
 main ::
   IO ()

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+module TestActions where
+
+import Types
+import UI.Actions
+
+import Control.Lens (view)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+actionTests ::
+  TestTree
+actionTests =
+    testGroup
+        "action tests"
+        [testModeDescription]
+
+testModeDescription :: TestTree
+testModeDescription = testCase "mode present in the switch action"
+                      $ view aDescription a @?= "switch mode to ManageTags"
+  where
+    a = focus :: Action 'ManageTags AppState


### PR DESCRIPTION
This fixes the description for focus which mode the keybindings are
switching to. Instead of:

  'switch focus'

it now says:

  'switch mode to ManageTags'

issue: #96