### PR TITLE
Improve "Item <m> of <n>" UI

### DIFF
--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -6,9 +6,7 @@ import Brick.Types (Widget)
 import Brick.Widgets.Core (str, withAttr, (<+>), strWrap)
 import qualified Brick.Widgets.List  as L
 import Control.Lens.Getter (view)
-import Data.Maybe (fromMaybe)
-import Data.Vector (length)
-import Prelude hiding (length)
+import Data.Semigroup ((<>))
 import UI.Draw.Main (fillLine)
 import Types
 import Config.Main (statusbarAttr, statusbarErrorAttr)
@@ -24,13 +22,14 @@ statusbar s =
 
 renderStatusbar :: Mode -> L.List Name e -> Widget Name
 renderStatusbar m l =
-  let mode = str $ show $ m
-      total = str $ show $ length $ view L.listElementsL l
-  in withAttr statusbarAttr $ str "Purebred: " <+>
-               str "Item " <+> currentIndexW l <+> str " of " <+> total <+> fillLine <+> mode
+  withAttr statusbarAttr $
+    str "Purebred: " <+> currentItemW l <+> fillLine <+> str (show m)
 
-currentIndexW :: L.List Name e -> Widget Name
-currentIndexW l = str $ show $ currentIndex l
-
-currentIndex :: L.List Name e -> Int
-currentIndex l = fromMaybe 0 $ view L.listSelectedL l
+currentItemW :: L.List Name e -> Widget Name
+currentItemW l = str $
+  maybe
+    "No items"
+    (\i -> "Item " <> show (i + 1) <> " of " <> total)
+    (view L.listSelectedL l)
+  where
+      total = show $ length $ view L.listElementsL l

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -210,7 +210,7 @@ testUserCanManipulateNMQuery =
 
           liftIO $ step "search for non existing tags yielding no results"
           _ <- sendLiteralKeys "does not match anything"
-          sendKeys "Enter" (Literal "Item 0 of 0")
+          sendKeys "Enter" (Literal "No items")
 
           liftIO $ step "search for mail correctly tagged"
           sendKeys ":" (Regex (buildAnsiRegex [] ["37"] ["40"] <> "does"))
@@ -220,7 +220,7 @@ testUserCanManipulateNMQuery =
           _ <- sendLiteralKeys "tag:replied"
 
           liftIO $ step "apply"
-          sendKeys "Enter" (Literal "Item 0 of 1")
+          sendKeys "Enter" (Literal "Item 1 of 1")
 
           liftIO $ step "open thread"
           sendKeys "Enter" (Literal "This is Purebred")


### PR DESCRIPTION
Currently we display "Item <index> of <n>" e.g. "Item 0 of 1".
Users probably want 1-based indexing, especially so that it can
align at the end of the list, i.e. "Item 7 of 7".  Also improve the
output when there are no items by saying "No items" instead of "Item
0 of 0".