### PR TITLE
selectNextUnread: if no current item return offset 0

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -396,11 +396,18 @@ reloadList = Action "reload list of threads" applySearch
 selectNextUnread :: Action 'BrowseMail AppState
 selectNextUnread =
   Action { _aDescription = "select next unread"
-         , _aAction = (\s -> let vec = (view (asMailIndex . miListOfMails . L.listElementsL) s)
-                                 cur = (view (asMailIndex . miListOfMails . L.listSelectedL) s) <|> Just 0
-                                 fx m = Notmuch.hasTag (view (asConfig . confNotmuch . nmNewTag) s) m
-                                 seekIndex i = fromMaybe i . findIndexWithOffset (i + 1) fx
-                             in pure $ over (asMailIndex . miListOfMails) (L.listMoveTo (seekIndex (fromMaybe 0 cur) vec)) s)
+         , _aAction = \s ->
+           let
+             vec = view (asMailIndex . miListOfMails . L.listElementsL) s
+             cur = view (asMailIndex . miListOfMails . L.listSelectedL) s <|> Just 0
+             fx = Notmuch.hasTag (view (asConfig . confNotmuch . nmNewTag) s)
+             seekIndex i = fromMaybe i . findIndexWithOffset (i + 1) fx
+           in
+             pure $
+               over
+                 (asMailIndex . miListOfMails)
+                 (L.listMoveTo (seekIndex (fromMaybe 0 cur) vec))
+                 s
          }
 
 -- Function definitions for actions


### PR DESCRIPTION
```
a772d2e (Fraser Tweedale, 17 minutes ago)
   selectNextUnread: if no current item return offset 0

   Only apply `findIndexWithOffset` if there is a current selection. Otherwise
   the first item should be selected.

   Fixes: https://github.com/purebred-mua/purebred/issues/126

55eb569 (Fraser Tweedale, 21 minutes ago)
   reformat selectNextUnread action

   Long lines are long.  Reformat.
```