### PR TITLE
Make the "mutt"-like keybindings the default

### DIFF
--- a/configs/config.hs
+++ b/configs/config.hs
@@ -8,36 +8,19 @@ import Data.List (union)
 
 myBrowseThreadsKbs :: [Keybinding 'BrowseThreads (Next AppState)]
 myBrowseThreadsKbs =
-  [ Keybinding (EvKey (KChar 'q') []) quit
-  , Keybinding (EvKey (KChar 'j') []) (listDown `chain` continue)
-  , Keybinding (EvKey (KChar 'k') []) (listUp `chain` continue)
-  , Keybinding (EvKey (KChar 'a') []) ((removeTags ["inbox"] `chain` addTags ["archive"] `chain` continue))
+  [ Keybinding (EvKey (KChar 'a') []) ((removeTags ["inbox"] `chain` addTags ["archive"] `chain` continue))
   ]
 
 myBrowseMailKeybindings :: [Keybinding 'BrowseMail (Next AppState)]
 myBrowseMailKeybindings =
-    [ Keybinding (EvKey (KChar 'q') []) (focus `chain'` (focus :: Action 'BrowseThreads AppState) `chain` continue)
-    , Keybinding (EvKey (KChar '/') []) (focus `chain` continue)
-    , Keybinding (EvKey KEnter []) (displayMail `chain` continue)
-    , Keybinding (EvKey KDown []) (listDown `chain` continue)
-    , Keybinding (EvKey (KChar 'j') []) (listDown `chain` continue)
-    , Keybinding (EvKey KUp []) (listUp `chain` continue)
-    , Keybinding (EvKey (KChar 'k') []) (listUp `chain` continue)
-    , Keybinding (EvKey (KChar 'a') []) ((removeTags ["inbox"] `chain` addTags ["archive"]) `chain` continue)
+    [ Keybinding (EvKey (KChar 'a') []) ((removeTags ["inbox"] `chain` addTags ["archive"]) `chain` continue)
     ]
 
 myMailKeybindings :: [Keybinding 'ViewMail (Next AppState)]
 myMailKeybindings =
-    [ Keybinding (EvKey (KChar 'q') []) (noop `chain'` (focus :: Action 'BrowseMail AppState) `chain` continue)
-    , Keybinding (EvKey (KChar 'a') []) ((removeTags ["inbox"] `chain` addTags ["archive"])
+    [ Keybinding (EvKey (KChar 'a') []) ((removeTags ["inbox"] `chain` addTags ["archive"])
                                          `chain'` (listDown :: Action 'BrowseMail AppState)
                                          `chain` displayMail `chain` continue)
-    ]
-
-myDisplayIndexKeybindings :: [Keybinding 'BrowseMail (Next AppState)]
-myDisplayIndexKeybindings =
-    [ Keybinding (EvKey (KChar 'j') []) (listDown `chain` displayMail `chain` continue)
-    , Keybinding (EvKey (KChar 'k') []) (listUp `chain` displayMail `chain` continue)
     ]
 
 main :: IO ()
@@ -46,4 +29,3 @@ main = purebred $ tweak defaultConfig where
     over (confIndexView . ivBrowseThreadsKeybindings) (`union` myBrowseThreadsKbs)
     . over (confIndexView . ivBrowseMailsKeybindings) (`union` myBrowseMailKeybindings)
     . over (confMailView . mvKeybindings) (`union` myMailKeybindings)
-    . over (confMailView . mvIndexKeybindings) (`union` myDisplayIndexKeybindings)

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -11,9 +11,12 @@ import Types
 browseMailKeybindings :: [Keybinding 'BrowseMail (Brick.Next AppState)]
 browseMailKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'BrowseThreads AppState) `chain'` (reloadList :: Action 'BrowseThreads AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (focus `chain'` (focus :: Action 'BrowseThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (displayMail `chain` continue)
     , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help AppState) `chain` continue)
@@ -24,12 +27,15 @@ browseMailKeybindings =
 browseThreadsKeybindings :: [Keybinding 'BrowseThreads (Brick.Next AppState)]
 browseThreadsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) quit
+    , Keybinding (V.EvKey (V.KChar 'q') []) quit
     , Keybinding (V.EvKey V.KEnter []) (displayThreadMails `chain'` (focus :: Action 'BrowseMail AppState) `chain'` selectNextUnread `chain` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` (focus :: Action 'SearchThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'm') []) (noop `chain'` (focus :: Action 'GatherHeadersFrom AppState) `chain`continue)
     , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'ManageThreadTags AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '\t') []) (switchComposeEditor `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     ]
 
 searchThreadsKeybindings :: [Keybinding 'SearchThreads (Brick.Next AppState)]

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -12,6 +12,7 @@ import Types
 displayMailKeybindings :: [Keybinding 'ViewMail (Brick.Next AppState)]
 displayMailKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'BrowseMail AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'BrowseMail AppState) `chain` continue)
     , Keybinding (V.EvKey V.KBS []) (scrollUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar ' ') []) (scrollDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'h') []) (toggleHeaders `chain` continue)
@@ -22,4 +23,6 @@ displayIndexKeybindings :: [Keybinding 'BrowseMail (Brick.Next AppState)]
 displayIndexKeybindings =
     [ Keybinding (V.EvKey V.KDown []) (listDown `chain` displayMail `chain` continue)
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` displayMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` displayMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` displayMail `chain` continue)
     ]


### PR DESCRIPTION
The chance that users know mutt keybindings are higher than our current
default. Therefore, use mutt like keybindings are the default until we
have a need to separate them with different configs.