### PR TITLE
Clear errors with the next key handler

### DIFF
--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 module UI.Keybindings where
 
@@ -9,23 +8,11 @@ import qualified Brick.Main as Brick
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
 import Graphics.Vty (Event (..))
-import Control.Lens.Getter (view)
+import Control.Lens ((&), view, set)
 import Data.List (find)
 import Prelude hiding (readFile, unlines)
 import Data.Proxy
 import Types
-
--- | A generic event handler using Keybindings by default if available
-handleEvent
-    :: [Keybinding ctx (Brick.Next AppState)]  -- ^ Keybindings to lookup
-    -> (AppState -> Event -> Brick.EventM Name (Brick.Next AppState))  -- ^ default handler if no keybinding matches
-    -> AppState
-    -> Event
-    -> Brick.EventM Name (Brick.Next AppState)
-handleEvent kbs def s ev =
-    case lookupKeybinding ev kbs of
-        Just kb -> view (kbAction . aAction) kb s
-        Nothing -> def s ev
 
 lookupKeybinding :: Event -> [Keybinding ctx a] -> Maybe (Keybinding ctx a)
 lookupKeybinding e = find (\x -> view kbEvent x == e)
@@ -92,5 +79,5 @@ instance EventHandler 'GatherHeadersSubject where
 dispatch :: EventHandler m => Proxy m -> AppState -> Event -> Brick.EventM Name (Brick.Next AppState)
 dispatch m s e = let kbs = view (keybindingsL m) s
                  in case lookupKeybinding e kbs of
-                      Just kb -> view (kbAction . aAction) kb s
+                      Just kb -> s & view (kbAction . aAction) kb . set asError Nothing
                       Nothing -> fallbackHandler m s e

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -142,7 +142,12 @@ testErrorHandling = withTmuxSession "error handling" $
 
     liftIO $ step "shows error message"
     sendKeys "Enter" (Literal "FileReadError")
-      >>= assertSubstrInOutput "openFile: does not exist"
+      >>= assertRegex "openFile:.*does not exist"
+
+    liftIO $ step "error is cleared with next registered keybinding"
+    sendKeys "Up" (Literal "Purebred: Item 1 of 1")
+
+    pure ()
 
 testSetsMailToRead ::
   TestTree


### PR DESCRIPTION
This sets the error to nothing with the next key press event. This has
the potential of errors being missed if the key presses from the user
happen to quickly, but anything more elaborate is not of priority now.

Fixes https://github.com/purebred-mua/purebred/issues/73