### PR TITLE
use purebred-email for parsing mail

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -61,7 +61,6 @@ library
                      , unix
                      , mtl
                      , exceptions
-                     , profunctors >= 5
                      , purebred-email
 
 executable purebred

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -62,6 +62,8 @@ library
                      , unix
                      , mtl
                      , exceptions
+                     , profunctors >= 5
+                     , purebred-email
 
 executable purebred
   hs-source-dirs:      app

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -48,7 +48,6 @@ library
                      , vector
                      , notmuch
                      , text
-                     , mime
                      , process
                      , mime-mail
                      , network

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -21,6 +21,9 @@ import UI.Index.Keybindings
         manageMailTagsKeybindings)
 import UI.Mail.Keybindings (displayMailKeybindings, displayIndexKeybindings)
 import UI.Help.Keybindings (helpKeybindings)
+
+import Data.MIME (ContentType(..))
+
 import Types
 import Storage.Notmuch (getDatabasePath)
 
@@ -95,7 +98,7 @@ defaultConfig =
     , _confEditor = fromMaybe "vi" <$> lookupEnv "EDITOR"
     , _confMailView = MailViewSettings
       { _mvIndexRows = 10
-      , _mvPreferedContentType = "text/plain"
+      , _mvPreferedContentType = ContentType "text" "plain" []
       , _mvHeadersToShow = (`elem` ["subject", "to", "from"])
       , _mvKeybindings = displayMailKeybindings
       , _mvIndexKeybindings = displayIndexKeybindings

--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -9,39 +9,53 @@ import Codec.MIME.Parse (parseMIMEMessage)
 import Codec.MIME.Type
        (MIMEParam(..), MIMEValue(..), mime_val_headers)
 import Control.Exception (try)
+import Control.Lens (firstOf)
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as L
+import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Storage.Notmuch (mailFilepath)
 
+import Data.MIME
+
 import Error
-import Types (ParsedMail(..), NotmuchMail)
+import Types (ParsedMail(..), NotmuchMail, decodeLenient)
 
 parseMail
   :: (MonadError Error m, MonadIO m)
   => NotmuchMail -> FilePath -> m ParsedMail
 parseMail m dbpath = do
   filePath <- mailFilepath m dbpath
+  {-
   liftIO (try (T.readFile filePath))
     >>= either
       (throwError . FileReadError filePath)
       (pure . MIMEMail . parseMIMEMessage)
+      -}
+  liftIO (try (L.readFile filePath))
+    >>= either (throwError . FileReadError filePath) pure
+    >>= either (throwError . FileParseError filePath) (pure . PurebredEmail)
+        . parse (message mime)
+
+getHeader :: CI.CI B.ByteString -> Message a -> T.Text
+getHeader k =
+  maybe "header not found" decodeLenient
+  . firstOf (messageHeaders . header k)
 
 getFrom :: ParsedMail -> T.Text
 getFrom (MIMEMail v) = findHeader v "from"
-getFrom _ = throwNotImplemented
+getFrom (PurebredEmail msg) = getHeader "from" msg
 
 getSubject :: ParsedMail -> T.Text
 getSubject (MIMEMail v) = findHeader v "subject"
-getSubject _ = throwNotImplemented
+getSubject (PurebredEmail msg) = getHeader "subject" msg
 
 getTo :: ParsedMail -> T.Text
 getTo (MIMEMail v) = findHeader v "to"
-getTo _ = throwNotImplemented
-
-throwNotImplemented :: a
-throwNotImplemented = error "Not implemented. ParsedMail.hs needs a proper mail parser"
+getTo (PurebredEmail msg) = getHeader "to" msg
 
 findHeader :: MIMEValue -> T.Text -> T.Text
 findHeader m name = T.strip . paramValue . head $ filter (\x -> paramName x == name) $ mime_val_headers m

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -4,7 +4,6 @@
 -- | Basic types for the UI used by this library
 module Types where
 
-import Codec.MIME.Type (MIMEValue)
 import qualified Brick.AttrMap             as Brick
 import Brick.Types (EventM, Next)
 import qualified Brick.Widgets.Edit        as E
@@ -86,11 +85,11 @@ miThreadTagsEditor = lens _miThreadTagsEditor (\m v -> m { _miThreadTagsEditor =
 data HeadersState = ShowAll | Filtered
 
 data MailView = MailView
-    { _mvMail :: Maybe ParsedMail
+    { _mvMail :: Maybe (Message MIME)
     , _mvHeadersState :: HeadersState
     }
 
-mvMail :: Lens' MailView (Maybe ParsedMail)
+mvMail :: Lens' MailView (Maybe (Message MIME))
 mvMail = lens _mvMail (\mv pm -> mv { _mvMail = pm })
 
 mvHeadersState :: Lens' MailView HeadersState
@@ -292,13 +291,6 @@ aDescription = to (\(Action a _ ) -> a)
 
 type Body = T.Text
 type Header = T.Text
-
--- | a parsed email representing either a MIME or RFC2822 e-mail. Note: RFC2822
--- is currently not implemented, but we're using the same type for the case we
--- add support for it
-data ParsedMail
-    = MIMEMail MIMEValue
-    | PurebredEmail (Message MIME)
 
 -- | an email from the notmuch database
 data NotmuchMail = NotmuchMail

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -18,6 +18,8 @@ import qualified Graphics.Vty.Input.Events as Vty
 import Data.Time (UTCTime)
 import qualified Data.CaseInsensitive as CI
 
+import Data.MIME
+
 import Error
 
 {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
@@ -296,7 +298,7 @@ type Header = T.Text
 -- add support for it
 data ParsedMail
     = MIMEMail MIMEValue
-    | RFC2822 [Header] Body
+    | PurebredEmail (Message MIME)
 
 -- | an email from the notmuch database
 data NotmuchMail = NotmuchMail

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -215,8 +215,8 @@ ivManageThreadTagsKeybindings f (IndexViewSettings a b c d e) = fmap (\e' -> Ind
 
 data MailViewSettings = MailViewSettings
     { _mvIndexRows           :: Int
-    , _mvPreferedContentType :: T.Text
-    , _mvHeadersToShow       :: CI.CI T.Text -> Bool
+    , _mvPreferedContentType :: ContentType
+    , _mvHeadersToShow       :: CI.CI B.ByteString -> Bool
     , _mvKeybindings         :: [Keybinding 'ViewMail (Next AppState)]
     , _mvIndexKeybindings    :: [Keybinding 'BrowseMail (Next AppState)]
     }
@@ -224,10 +224,10 @@ data MailViewSettings = MailViewSettings
 mvIndexRows :: Lens' MailViewSettings Int
 mvIndexRows f (MailViewSettings a b c d e) = fmap (\a' -> MailViewSettings a' b c d e) (f a)
 
-mvPreferredContentType :: Lens' MailViewSettings T.Text
+mvPreferredContentType :: Lens' MailViewSettings ContentType
 mvPreferredContentType f (MailViewSettings a b c d e) = fmap (\b' -> MailViewSettings a b' c d e) (f b)
 
-mvHeadersToShow :: Getter MailViewSettings (CI.CI T.Text -> Bool)
+mvHeadersToShow :: Getter MailViewSettings (CI.CI B.ByteString -> Bool)
 mvHeadersToShow = to (\(MailViewSettings _ _ h _ _) -> h)
 
 mvKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail (Next AppState)]

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -12,7 +12,6 @@ import Control.Lens (filtered, firstOf, folded, toListOf, view)
 import qualified Data.ByteString as B
 import qualified Data.CaseInsensitive as CI
 import Data.Maybe (fromMaybe)
-import Data.Profunctor (lmap)
 
 import Data.MIME
 
@@ -43,10 +42,7 @@ messageToMailView s msg =
   let
     wantHeader :: CI.CI B.ByteString -> Bool
     wantHeader = case view (asMailView . mvHeadersState) s of
-      Filtered ->
-        -- FIXME the config is currently (CI T.Text -> Bool)
-        lmap (CI.map decodeLenient) $
-        view (asConfig . confMailView . mvHeadersToShow) s
+      Filtered -> view (asConfig . confMailView . mvHeadersToShow) s
       ShowAll -> const True
 
     filteredHeaders =
@@ -67,9 +63,9 @@ messageToMailView s msg =
     foldr (<=>) (padTop (Pad 1) body) headerWidgets
 
 chooseEntity :: AppState -> Message MIME -> Entity
-chooseEntity _ msg =
+chooseEntity s msg =
   let
-    preferredContentType = defaultContentType -- FIXME
+    preferredContentType = view (asConfig . confMailView . mvPreferredContentType) s
     match :: Entity -> Bool
     match (h, _) = view contentType h `ctEq` preferredContentType
 

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -7,13 +7,20 @@ import Brick.Widgets.Core
        (padLeft, padTop, txt, txtWrap, vLimit, viewport, (<+>), (<=>),
         withAttr)
 
+import Control.Applicative ((<|>))
+import Control.Lens (filtered, firstOf, folded, toListOf, view)
+import qualified Data.ByteString as B
+import qualified Data.CaseInsensitive as CI
+import Data.Maybe (fromMaybe)
+import Data.Profunctor (lmap)
+import qualified Data.Text as T
+
 import Codec.MIME.Type
        (MIMEContent(..), MIMEParam(..), MIMEValue(..), Type(..),
         showMIMEType)
-import qualified Data.CaseInsensitive as CI
-import Control.Lens.Getter (view)
-import Data.CaseInsensitive (mk)
-import qualified Data.Text as T
+
+import Data.MIME
+
 import UI.Index.Main (renderMailList, renderEditor)
 import UI.Status.Main (statusbar)
 import Types
@@ -35,7 +42,7 @@ drawMail s =
 -- | TODO: See #19
 mailView :: AppState -> Maybe ParsedMail -> Widget Name
 mailView s (Just (MIMEMail m)) =
-    let filtered_headers = filter (headerFilter s . mk . paramName) $ mime_val_headers m
+    let filtered_headers = filter (headerFilter s . CI.mk . paramName) $ mime_val_headers m
         widgets =
             (\h ->
                   withAttr headerKeyAttr $
@@ -46,8 +53,52 @@ mailView s (Just (MIMEMail m)) =
             filtered_headers
         body = padTop (Pad 1) $ mimeContentToView s m
     in foldr (<=>) (padTop (Pad 1) body) widgets
-mailView _ (Just (RFC2822 _ _)) = txt "Not supported yet"
+mailView s (Just (PurebredEmail msg)) = messageToMailView s msg
 mailView _ Nothing = txt "Eeek: this is not supposed to happen"
+
+messageToMailView :: AppState -> Message MIME -> Widget Name
+messageToMailView s msg =
+  let
+    wantHeader :: CI.CI B.ByteString -> Bool
+    wantHeader = case view (asMailView . mvHeadersState) s of
+      Filtered ->
+        -- FIXME the config is currently (CI T.Text -> Bool)
+        lmap (CI.map decodeLenient) $
+        view (asConfig . confMailView . mvHeadersToShow) s
+      ShowAll -> const True
+
+    filteredHeaders =
+      toListOf (messageHeaders . folded . filtered (wantHeader . fst)) msg
+
+    headerToWidget :: (CI.CI B.ByteString, B.ByteString) -> Widget Name
+    headerToWidget (k, v) =
+      withAttr headerKeyAttr $
+      txt (decodeLenient (CI.original k)) <+>
+      padLeft
+          (Pad 1)
+          (withAttr headerValueAttr (txtWrap (decodeLenient v)))
+
+    headerWidgets = headerToWidget <$> filteredHeaders
+    body = padTop (Pad 1) (entityToView ent)
+    ent = chooseEntity s msg
+  in
+    foldr (<=>) (padTop (Pad 1) body) headerWidgets
+
+chooseEntity :: AppState -> Message MIME -> Entity
+chooseEntity _ msg =
+  let
+    preferredContentType = defaultContentType -- FIXME
+    match :: Entity -> Bool
+    match (h, _) = view contentType h `ctEq` preferredContentType
+
+    -- select first entity with matching content-type;
+    -- otherwise select first entity;
+    ent = firstOf (entities . filtered match) msg <|> firstOf entities msg
+  in
+    fromMaybe mempty ent
+
+entityToView :: Entity -> Widget Name
+entityToView (_, b) = txtWrap $ decodeLenient b
 
 mimeContentToView :: AppState -> MIMEValue -> Widget Name
 mimeContentToView _ (MIMEValue _ _ (Single m) _ _) = txtWrap m

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,10 @@ packages:
     git: https://github.com/purebred-mua/hs-notmuch.git
     commit: 75150384a5815d2ebabfe7bb45151e2be39cc90e
   extra-dep: true
+- location:
+    git: https://github.com/purebred-mua/purebred-email.git
+    commit: 4db0a4889b9fe733edf4bf6d1aabf4e6b3159e25
+  extra-dep: true
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -142,7 +142,7 @@ testErrorHandling = withTmuxSession "error handling" $
 
     liftIO $ step "shows error message"
     sendKeys "Enter" (Literal "FileReadError")
-      >>= assertRegex "openFile:.*does not exist"
+      >>= assertRegex "open(Binary)?File:.*does not exist"
 
     liftIO $ step "error is cleared with next registered keybinding"
     sendKeys "Up" (Literal "Purebred: Item 1 of 1")
@@ -178,11 +178,11 @@ testCanToggleHeaders = withTmuxSession "user can toggle Headers" $
     sendKeys "Enter" (Literal "This is a test mail")
 
     liftIO $ step "toggle to show all headers"
-    sendKeys "h" (Literal "return-path")
+    sendKeys "h" (Regex "[Rr]eturn-[Pp]ath")
 
     liftIO $ step "toggle filtered headers"
     out <- sendKeys "h" (Literal "This is a test mail")
-    assertRegex "Purebred.*\n.*from" out
+    assertRegex "Purebred.*\n.*[Ff]rom" out
 
 testUserViewsMailSuccessfully ::
   TestTree


### PR DESCRIPTION
This patchset switches mail parsing to purebred-email.
Please try it out and see where the glaring problems are.

One known gap: content-transfer-encoding is not automatically performed.
Neither do we do it in purebred itself.  So bodies using quoted-printable or
base64 will be displayed as-is.  I will try to address this in the coming days.

If you notice any other epic fails please let me know :)