### PR TITLE
switch tag parsing to attoparsec, and unrelated cleanups

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -110,7 +110,7 @@ test-suite unittests
                      , brick
                      , tasty-hunit
                      , tasty-quickcheck
-                     , quickcheck-text
+                     , quickcheck-instances
                      , tasty
                      , directory
                      , process
@@ -121,7 +121,6 @@ test-suite unittests
                      , temporary
                      , text
                      , resourcet
-                     , time
                      , regex-posix
                      , mtl
                      , lens

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -73,7 +73,6 @@ library
                      , text
                      , process
                      , mime-mail
-                     , network
                      , directory
                      , bytestring
                      , time
@@ -81,7 +80,6 @@ library
                      , optparse-applicative >= 0.13
                      , xdg-basedir
                      , filepath
-                     , unix
                      , mtl
                      , exceptions
                      , purebred-email
@@ -107,20 +105,16 @@ test-suite unittests
   default-language:    Haskell2010
   build-depends:       base
                      , purebred
-                     , brick
+                     , tasty
                      , tasty-hunit
                      , tasty-quickcheck
                      , quickcheck-instances
-                     , tasty
                      , directory
                      , process
-                     , unbounded-delays
                      , bytestring
-                     , network
                      , ini
                      , temporary
                      , text
-                     , resourcet
                      , regex-posix
                      , mtl
                      , lens

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -85,7 +85,7 @@ library
                      , mtl
                      , exceptions
                      , purebred-email
-                     , parsec
+                     , attoparsec
 
 executable purebred
   hs-source-dirs:      app
@@ -125,3 +125,4 @@ test-suite unittests
                      , regex-posix
                      , mtl
                      , lens
+                     , notmuch

--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -14,8 +14,6 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Vector as Vec
 import System.Process (readProcess)
 import qualified Data.Text as T
-import Data.Text.Encoding (decodeUtf8)
-import Types
 import Control.Lens (_2, view, over, set, firstOf, folded, Lens')
 
 import qualified Notmuch
@@ -23,6 +21,7 @@ import Notmuch.Search
 import Notmuch.Util (bracketT)
 
 import Error
+import Types
 
 
 -- | apply tag operations on all given mails and write the resulting tags to the
@@ -145,8 +144,8 @@ messageToMail
 messageToMail m = do
     tgs <- Notmuch.tags m
     NotmuchMail
-      <$> (decodeUtf8 . fromMaybe "" <$> Notmuch.messageHeader "Subject" m)
-      <*> (decodeUtf8 . fromMaybe "" <$> Notmuch.messageHeader "From" m)
+      <$> (decodeLenient . fromMaybe "" <$> Notmuch.messageHeader "Subject" m)
+      <*> (decodeLenient . fromMaybe "" <$> Notmuch.messageHeader "From" m)
       <*> Notmuch.messageDate m
       <*> pure tgs
       <*> Notmuch.messageId m
@@ -209,7 +208,7 @@ threadToThread m = do
     tgs <- Notmuch.tags m
     auth <- Notmuch.threadAuthors m
     NotmuchThread
-      <$> (decodeUtf8 <$> Notmuch.threadSubject m)
+      <$> (decodeLenient <$> Notmuch.threadSubject m)
       <*> pure (view Notmuch.matchedAuthors auth)
       <*> Notmuch.threadNewestDate m
       <*> pure tgs

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -2,7 +2,10 @@
 {-# LANGUAGE KindSignatures #-}
 
 -- | Basic types for the UI used by this library
-module Types where
+module Types
+  ( module Types
+  , Tag
+  ) where
 
 import qualified Brick.AttrMap as Brick
 import qualified Brick.Focus as Brick
@@ -18,6 +21,7 @@ import qualified Graphics.Vty.Input.Events as Vty
 import Data.Time (UTCTime)
 import qualified Data.CaseInsensitive as CI
 
+import Notmuch (Tag)
 import Data.MIME
 
 import Error
@@ -132,7 +136,7 @@ cFocusedEditorL _ = asCompose . cSubject
 data NotmuchSettings a = NotmuchSettings
     { _nmSearch :: T.Text
     , _nmDatabase :: a
-    , _nmNewTag :: T.Text
+    , _nmNewTag :: Tag
     }
 
 nmSearch :: Lens' (NotmuchSettings a) T.Text
@@ -141,7 +145,7 @@ nmSearch f (NotmuchSettings a b c) = fmap (\a' -> NotmuchSettings a' b c) (f a)
 nmDatabase :: Lens (NotmuchSettings a) (NotmuchSettings b) a b
 nmDatabase f (NotmuchSettings a b c) = fmap (\b' -> NotmuchSettings a b' c) (f b)
 
-nmNewTag :: Getter (NotmuchSettings a) T.Text
+nmNewTag :: Getter (NotmuchSettings a) Tag
 nmNewTag = to (\(NotmuchSettings _ _ c) -> c)
 
 data Configuration a b = Configuration
@@ -311,7 +315,7 @@ data NotmuchMail = NotmuchMail
     { _mailSubject :: T.Text
     , _mailFrom :: T.Text
     , _mailDate :: UTCTime
-    , _mailTags :: [T.Text]
+    , _mailTags :: [Tag]
     , _mailId :: B.ByteString
     } deriving (Show, Eq)
 
@@ -324,7 +328,7 @@ mailFrom = lens _mailFrom (\m f -> m { _mailFrom = f })
 mailDate :: Lens' NotmuchMail UTCTime
 mailDate = lens _mailDate (\m d -> m { _mailDate = d })
 
-mailTags :: Lens' NotmuchMail [T.Text]
+mailTags :: Lens' NotmuchMail [Tag]
 mailTags = lens _mailTags (\m t -> m { _mailTags = t })
 
 mailId :: Lens' NotmuchMail B.ByteString
@@ -334,7 +338,7 @@ data NotmuchThread = NotmuchThread
     { _thSubject :: T.Text
     , _thAuthors :: [T.Text]
     , _thDate :: UTCTime
-    , _thTags :: [T.Text]
+    , _thTags :: [Tag]
     , _thReplies :: Int
     , _thId :: B.ByteString
     } deriving (Show, Eq)
@@ -348,7 +352,7 @@ thAuthors = lens _thAuthors (\m f -> m { _thAuthors = f })
 thDate :: Lens' NotmuchThread UTCTime
 thDate = lens _thDate (\m d -> m { _thDate = d })
 
-thTags :: Lens' NotmuchThread [T.Text]
+thTags :: Lens' NotmuchThread [Tag]
 thTags = lens _thTags (\m t -> m { _thTags = t })
 
 thReplies :: Lens' NotmuchThread Int
@@ -362,6 +366,5 @@ decodeLenient :: B.ByteString -> T.Text
 decodeLenient = T.decodeUtf8With T.lenientDecode
 
 -- | Tag operations
-type Tag = T.Text
 data TagOp = RemoveTag Tag | AddTag Tag | ResetTags
   deriving (Show, Eq)

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,7 @@ packages:
 - '.'
 - location:
     git: https://github.com/purebred-mua/hs-notmuch.git
-    commit: ec2b6a4b1b3aa841369843792a50f7b4473e6c7c
+    commit: 441380c287df0d8fc08196148350c931f4b25a20
   extra-dep: true
 - location:
     git: https://github.com/purebred-mua/purebred-email.git

--- a/test/TestMail.hs
+++ b/test/TestMail.hs
@@ -4,16 +4,14 @@
 module TestMail where
 
 import qualified Data.ByteString as B
-import Data.Text (pack)
+import qualified Data.Text.Encoding as T
+
 import Types (NotmuchMail(..), Tag)
 import Storage.Notmuch (addTags, removeTags)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck
-       (testProperty, Arbitrary, arbitrary, choose, Gen)
-import Test.QuickCheck.Utf8 (utf8BS)
-import Data.Text.Arbitrary ()
-import Data.Time.Calendar (Day(..))
-import Data.Time.Clock (secondsToDiffTime, UTCTime(..), DiffTime)
+       (testProperty, Arbitrary, arbitrary, choose)
+import Test.QuickCheck.Instances ()
 
 import Notmuch (mkTag, tagMaxLen)
 
@@ -44,20 +42,9 @@ instance Arbitrary Tag where
 
 instance Arbitrary NotmuchMail where
     arbitrary =
-        NotmuchMail <$>
-        (pack <$> arbitrary) <*>
-        (pack <$> arbitrary) <*>
-        arbitrary <*>
-        arbitrary <*>
-        utf8BS
-
-instance Arbitrary UTCTime where
-  arbitrary = UTCTime <$> arbitrary <*> genDiffTime
-
-instance Arbitrary Day where
-  arbitrary = ModifiedJulianDay <$> arbitrary
-
-genDiffTime :: Gen DiffTime
-genDiffTime = do
-  i <- choose (0, 200000)
-  pure $ secondsToDiffTime i
+      NotmuchMail
+        <$> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> (T.encodeUtf8 <$> arbitrary)


### PR DESCRIPTION
```
3695c4b (Fraser Tweedale, 2 minutes ago)
   avoid non-total function decodeUtf8

   Data.Text.Encoding.decodeUtf8 is a non-total function which throws an
   exception on invalid input.  Change to 'decodeLenient' which replaces
   invalid code points with a placeholder character.

57b7f33 (Fraser Tweedale, 4 minutes ago)
   remove unused dependencies

44d2f99 (Fraser Tweedale, 14 minutes ago)
   use quickcheck-instances instead of quickcheck-text

   The more popular quickcheck-instances package provides orphan Arbitrary
   instances not only for 'text' but many other common library.  Switch to it,
   and remove 'time'-related orphan instances.

74ed5be (Fraser Tweedale, 36 minutes ago)
   switch tag parsing back to attoparsec

   We want to avoid depending on two different parser libraries. So switch
   back to attoparsec for parsing tags.

   This refactor also changes Purebred to use the Notmuch.Tag type internally.
    User input is parsed into a Notmuch.Tag during parsing. Anything that will
   not be accepted by libnotmuch is rejected at that point, so there is now
   one less error that can occur later on when trying to write tags.

   attoparsec's error handling is not as nice as parsec so add a couple of
   helper parsers for getting nicer errors out of it.  The error message did
   change a little, so update the test accordingly.

   An orphan Arbitrary instance is added for Notmuch.Tag.  The Tag is of a
   random length (between 1 and the max length), and consists of random
   printable ASCII characters excluding SPACE.  Bump the hs-notmuch dependency
   to a commit where 'tagMaxLen' is exported (we need it for the Arbitrary
   instance).
```