### PR TITLE
Fix ResetTags op leaving message without tags

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -119,3 +119,4 @@ test-suite unittests
                      , mtl
                      , lens
                      , notmuch
+                     , time

--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -43,7 +43,7 @@ applyTags
     -> m (a, NotmuchMail)
 applyTags ops db mail = do
     let
-      mail' = foldr (over _2 . applyTagOp) mail ops
+      mail' = over _2 (tagItem ops) mail
       nmtags = view (_2 . mailTags) mail'
     if haveTagsChanged mail mail'
         then do
@@ -51,13 +51,16 @@ applyTags ops db mail = do
             pure mail'
         else pure mail'
 
+tagItem :: ManageTags a => [TagOp] -> a -> a
+tagItem ops mail = foldl (flip applyTagOp) mail ops
+
 haveTagsChanged :: (a, NotmuchMail) -> (a, NotmuchMail) -> Bool
 haveTagsChanged m1 m2 = sort (nub (view (_2 . mailTags) m1)) /= sort (nub (view (_2 . mailTags) m2))
 
 applyTagOp :: (ManageTags a) => TagOp -> a -> a
 applyTagOp (AddTag t) = addTags [t]
 applyTagOp (RemoveTag t) = removeTags [t]
-applyTagOp ResetTags = set tags []
+applyTagOp ResetTags = setTags []
 
 class ManageTags a  where
     tags :: Lens' a [Tag]

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -562,18 +562,6 @@ emptyTempFile targetDir template = bracket
   (\(_, handle) -> hClose handle)
   (\(filePath, _) -> pure filePath)
 
--- | Utility function to set tags on the notmuch thread.
--- Note, that the tags are not persisted since notmuch does not support writing
--- tags to the thread itself. It is currently only used to avoid reloaded the
--- thread from the database after tags have been written to each mail in the
--- thread.
---
-tagThread
-  :: [TagOp]
-  -> NotmuchThread
-  -> NotmuchThread
-tagThread ops thread = foldr Notmuch.applyTagOp thread ops
-
 manageThreadTags
     :: MonadIO m
     => AppState
@@ -581,7 +569,7 @@ manageThreadTags
     -> (t, NotmuchThread)
     -> m (AppState -> AppState)
 manageThreadTags s ops t =
-  let update ops' _ = over (asMailIndex . miListOfThreads) (L.listModify (tagThread ops'))
+  let update ops' _ = over (asMailIndex . miListOfThreads) (L.listModify (Notmuch.tagItem ops'))
   in getMailsForThread t s
      >>= \ms -> applyTagOps ops ms s
      >>= either (pure . setError) (pure . update ops)

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -71,7 +71,7 @@ testManageTagsOnMails = withTmuxSession "manage tags on mails" $
     _ <- sendLiteralKeys "+inbox +foo +bar"
 
     liftIO $ step "apply"
-    sendKeys "Enter" (Literal "bar foo")
+    sendKeys "Enter" (Literal "foo bar")
 
     liftIO $ step "go back to list of threads"
     sendKeys "Escape" (Literal "Testmail")


### PR DESCRIPTION
The tag operations applied to the data type where applied from right to
left, which has left ResetTag as the last operation.

This patch applies the tag operations from left to right, the same way
we parse them.

Fixes https://github.com/purebred-mua/purebred/issues/151