### PR TITLE
read mail files as strict bytestring

### DIFF
--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -10,7 +10,6 @@ import Control.Lens (firstOf)
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as L
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as T
 
@@ -25,7 +24,7 @@ parseMail
   => NotmuchMail -> FilePath -> m (Message MIME)
 parseMail m dbpath = do
   filePath <- mailFilepath m dbpath
-  liftIO (try (L.readFile filePath))
+  liftIO (try (B.readFile filePath))
     >>= either (throwError . FileReadError filePath) pure
     >>= either (throwError . FileParseError filePath) pure
         . parse (message mime)


### PR DESCRIPTION
When parsing using attoparsec, if it is assumed that an input will
parse successfully, and most of the input will be parsed, and the
input is many multiples of the default chunk size for lazy
bytestrings, then strict bytestrings give better performance than
lazy bytestrings.  This is because feeding many chunks to an
attoparsec parser will result in several resizings of the
contiguously allocated buffer.  In contrast, if the input is
provided as a single strict bytestring, there initial (and sole)
buffer reuses the same memory. For MIME messages, most of the parsed
data are bytestrings that also point into the same memory.  Buffer
resizes are avoided and there is minimal copying.

Therefore read emails as strict bytestrings.