### PR TITLE
Refactor: Use an empty mail in the compose editor

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -63,6 +63,7 @@ library
                      , Storage.Notmuch
                      , Storage.ParsedMail
                      , Purebred
+                     , Network.Mail.Mime.Lens
   build-depends:       base >= 4.9 && < 5
                      , lens
                      , brick >= 0.20

--- a/src/Network/Mail/Mime/Lens.hs
+++ b/src/Network/Mail/Mime/Lens.hs
@@ -1,0 +1,33 @@
+-- This file is part of purebred
+-- Copyright (C) 2018 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--
+module Network.Mail.Mime.Lens where
+
+import Control.Lens (Lens')
+import Network.Mail.Mime (Mail(..), Alternatives, Address, Headers)
+
+
+lMailParts :: Lens' Mail [Alternatives]
+lMailParts f (Mail a b c d e f') = fmap (\f'' -> Mail a b c d e f'') (f f')
+
+lMailTo :: Lens' Mail [Address]
+lMailTo f (Mail a b c d e g) = fmap (\b' -> Mail a b' c d e g) (f b)
+
+lMailFrom :: Lens' Mail Address
+lMailFrom f (Mail a b c d e g) = fmap (\a' -> Mail a' b c d e g) (f a)
+
+lMailHeaders :: Lens' Mail Headers
+lMailHeaders f (Mail a b c d e g) = fmap (\e' -> Mail a b c d e' g) (f e)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -57,6 +57,7 @@ data Name =
     | ScrollingHelpView
     | ManageMailTagsEditor
     | ManageThreadTagsEditor
+    | ListOfAttachments
     deriving (Eq,Show,Ord)
 
 {- | main application interface
@@ -102,15 +103,16 @@ mvHeadersState :: Lens' MailView HeadersState
 mvHeadersState = lens _mvHeadersState (\mv hs -> mv { _mvHeadersState = hs })
 
 data Compose = Compose
-    { _cTmpFile :: Maybe String
-    , _cFrom    :: E.Editor T.Text Name
-    , _cTo      :: E.Editor T.Text Name
+    { _cMail :: Mail.Mail
+    , _cFrom :: E.Editor T.Text Name
+    , _cTo :: E.Editor T.Text Name
     , _cSubject :: E.Editor T.Text Name
     , _cFocusFields :: Brick.FocusRing Name
+    , _cAttachments :: L.List Name Mail.Part
     }
 
-cTmpFile :: Lens' Compose (Maybe String)
-cTmpFile = lens _cTmpFile (\c x -> c { _cTmpFile = x })
+cMail :: Lens' Compose Mail.Mail
+cMail = lens _cMail (\c x -> c { _cMail = x })
 
 cFrom :: Lens' Compose (E.Editor T.Text Name)
 cFrom = lens _cFrom (\c x -> c { _cFrom = x })
@@ -133,6 +135,9 @@ cFocusedEditorL
 cFocusedEditorL ComposeTo = asCompose . cTo
 cFocusedEditorL ComposeFrom = asCompose . cFrom
 cFocusedEditorL _ = asCompose . cSubject
+
+cAttachments :: Lens' Compose (L.List Name Mail.Part)
+cAttachments = lens _cAttachments (\c x -> c { _cAttachments = x })
 
 data NotmuchSettings a = NotmuchSettings
     { _nmSearch :: T.Text

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -16,4 +16,6 @@ composeEditorKeybindings =
     , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'BrowseThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` (focus :: Action 'BrowseThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'BrowseThreads AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     ]

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -61,7 +61,9 @@ instance EventHandler 'ComposeEditor where
   keybindingsL _ = asConfig . confComposeView . cvKeybindings
   fallbackHandler _ s e = Brick.continue
                           =<< maybe (pure s)
-                          (\n -> Brick.handleEventLensed s (cFocusedEditorL n) E.handleEditorEvent e)
+                          (\n -> case n of
+                              ListOfAttachments -> Brick.handleEventLensed s (asCompose . cAttachments) L.handleListEvent e
+                              _ -> Brick.handleEventLensed s (cFocusedEditorL n) E.handleEditorEvent e)
                           (Brick.focusGetCurrent (view (asCompose . cFocusFields) s))
 
 instance EventHandler 'Help where

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -401,7 +401,7 @@ testSendMail =
           sendKeys "Escape" (Literal "body")
 
           liftIO $ step "exit vim"
-          sendKeys ": x\r" (Literal "Attachments")
+          sendKeys ": x\r" (Literal "text/plain")
 
           liftIO $ step "send mail"
           sendKeys "y" (Literal "Purebred")


### PR DESCRIPTION
Instead of starting out with a temporary file, start with an empty mail
which we "fill" with the necessary data to send it.