### PR TITLE
implement charset decoding

### DIFF
--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -21,7 +21,7 @@ import Types (NotmuchMail, decodeLenient)
 
 parseMail
   :: (MonadError Error m, MonadIO m)
-  => NotmuchMail -> FilePath -> m (Message MIME)
+  => NotmuchMail -> FilePath -> m MIMEMessage
 parseMail m dbpath = do
   filePath <- mailFilepath m dbpath
   liftIO (try (B.readFile filePath))
@@ -29,16 +29,16 @@ parseMail m dbpath = do
     >>= either (throwError . FileParseError filePath) pure
         . parse (message mime)
 
-getHeader :: CI.CI B.ByteString -> Message a -> T.Text
+getHeader :: CI.CI B.ByteString -> Message s a -> T.Text
 getHeader k =
   maybe "header not found" decodeLenient
-  . firstOf (messageHeaders . header k)
+  . firstOf (headers . header k)
 
-getFrom :: Message MIME -> T.Text
+getFrom :: Message s a -> T.Text
 getFrom = getHeader "from"
 
-getSubject :: Message MIME -> T.Text
+getSubject :: Message s a -> T.Text
 getSubject = getHeader "subject"
 
-getTo :: Message MIME -> T.Text
+getTo :: Message s a -> T.Text
 getTo = getHeader "to"

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -92,11 +92,11 @@ miThreadTagsEditor = lens _miThreadTagsEditor (\m v -> m { _miThreadTagsEditor =
 data HeadersState = ShowAll | Filtered
 
 data MailView = MailView
-    { _mvMail :: Maybe (Message MIME)
+    { _mvMail :: Maybe MIMEMessage
     , _mvHeadersState :: HeadersState
     }
 
-mvMail :: Lens' MailView (Maybe (Message MIME))
+mvMail :: Lens' MailView (Maybe MIMEMessage)
 mvMail = lens _mvMail (\mv pm -> mv { _mvMail = pm })
 
 mvHeadersState :: Lens' MailView HeadersState

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,7 +43,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/purebred-mua/purebred-email.git
-    commit: a1e16b68701baa9ec8e805ef1376fb30487f2089
+    commit: 3b9039dac7e1e525db8bb6b489d9b7ad7a4bcd10
   extra-dep: true
 
 # Dependency packages to be pulled from upstream that are not in the resolver

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -296,7 +296,7 @@ testUserViewsMailSuccessfully = withTmuxSession "user can view mail" $
     sendKeys "Space Space Space" (Literal "But I must explain")
 
     liftIO $ step "go to previous mail with reset scroll state"
-    sendKeys "k" (Regex "Subject\\s.*WIP Refactor")
+    sendKeys "k" (Regex "Subject:\\s.*WIP Refactor")
 
     pure ()
 


### PR DESCRIPTION
Update to commit of purebred-email that introduces charset decoding
and modify purebred to perform charset decoding when displaying a
message.

Drive-by generalisation of getHeader, getFrom, getSubject and getTo
which work for all instantiations of 'Message s a'.