### PR TITLE
Jump to start or end of the list

### DIFF
--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -17,6 +17,8 @@ browseMailKeybindings =
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help AppState) `chain` continue)
@@ -36,6 +38,8 @@ browseThreadsKeybindings =
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     ]
 
 searchThreadsKeybindings :: [Keybinding 'SearchThreads (Brick.Next AppState)]

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -76,7 +76,21 @@ systemTests =
       , testManageTagsOnThreads
       , testConfig
       , testUpdatesReadState
+      , testCanJumpToFirstListItem
       ]
+
+testCanJumpToFirstListItem :: Int -> TestTree
+testCanJumpToFirstListItem = withTmuxSession "updates read state for mail and thread" $
+  \step -> do
+    startApplication
+
+    liftIO $ step "Jump to last mail"
+    sendKeys "G" (Literal "3 of 3")
+
+    liftIO $ step "Jump to first mail"
+    sendKeys "1" (Literal "1 of 3")
+
+    pure ()
 
 testUpdatesReadState :: Int -> TestTree
 testUpdatesReadState = withTmuxSession "updates read state for mail and thread" $
@@ -84,8 +98,7 @@ testUpdatesReadState = withTmuxSession "updates read state for mail and thread" 
     startApplication
 
     liftIO $ step "navigate to thread mails"
-    sendKeys "Down" (Literal "2 of 3")
-    sendKeys "Down" (Literal "3 of 3")
+    sendKeys "G" (Literal "3 of 3")
 
     liftIO $ step "view unread mail in thread"
     sendKeys "Enter" (Literal "WIP Refactor")


### PR DESCRIPTION
This patch adds two actions to jump to the beginning or end of a list. Currently
used for the list of threads and mails. This is useful if you have many items in
the inbox and you want to start reading from either end.