### PR TITLE
Various refactoring and minor enhancements

### DIFF
--- a/configs/config.hs
+++ b/configs/config.hs
@@ -27,17 +27,17 @@ import System.Directory (getCurrentDirectory)
 import Data.Maybe (fromMaybe)
 import Data.List (union)
 
-myBrowseThreadsKbs :: [Keybinding 'Threads 'ListOfThreads (Next AppState)]
+myBrowseThreadsKbs :: [Keybinding 'Threads 'ListOfThreads]
 myBrowseThreadsKbs =
   [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
   ]
 
-myBrowseMailKeybindings :: [Keybinding 'Mails 'ListOfMails (Next AppState)]
+myBrowseMailKeybindings :: [Keybinding 'Mails 'ListOfMails]
 myBrowseMailKeybindings =
     [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
     ]
 
-myMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView (Next AppState)]
+myMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 myMailKeybindings =
     [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
     ]

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -324,7 +324,8 @@ asViews :: Lens' AppState ViewSettings
 asViews f (AppState a b c d e g) = fmap (\g' -> AppState a b c d e g') (f g)
 
 data Action (v :: ViewName) (ctx :: Name) a = Action
-    { _aDescription :: String
+    { _aDescription :: [T.Text]
+    -- ^ sequential list of things that the action does
     , _aAction :: AppState -> EventM Name a
     }
 
@@ -345,7 +346,7 @@ kbEvent = to (\(Keybinding b _) -> b)
 kbAction :: Getter (Keybinding v ctx a) (Action v ctx a)
 kbAction = to (\(Keybinding _ c) -> c)
 
-aDescription :: Getter (Action v ctx a) String
+aDescription :: Getter (Action v ctx a) [T.Text]
 aDescription = to (\(Action a _ ) -> a)
 
 type Body = T.Text

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -349,9 +349,6 @@ kbAction = to (\(Keybinding _ c) -> c)
 aDescription :: Getter (Action v ctx a) [T.Text]
 aDescription = to (\(Action a _ ) -> a)
 
-type Body = T.Text
-type Header = T.Text
-
 -- | an email from the notmuch database
 data NotmuchMail = NotmuchMail
     { _mailSubject :: T.Text

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -177,68 +177,68 @@ confDefaultView :: Lens' (Configuration a b) ViewName
 confDefaultView = lens _confDefaultView (\conf x -> conf { _confDefaultView = x })
 
 data ComposeViewSettings = ComposeViewSettings
-    { _cvFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom (Next AppState)]
-    , _cvToKeybindings :: [Keybinding 'ComposeView 'ComposeTo (Next AppState)]
-    , _cvSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject (Next AppState)]
+    { _cvFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
+    , _cvToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
+    , _cvSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
     , _cvSendMailCmd :: Mail.Mail -> IO ()
-    , _cvListOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ListOfAttachments (Next AppState)]
+    , _cvListOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ListOfAttachments]
     }
 
-cvFromKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeFrom (Next AppState)]
+cvFromKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeFrom]
 cvFromKeybindings = lens _cvFromKeybindings (\cv x -> cv { _cvFromKeybindings = x })
 
-cvToKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeTo (Next AppState)]
+cvToKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeTo]
 cvToKeybindings = lens _cvToKeybindings (\cv x -> cv { _cvToKeybindings = x })
 
-cvSubjectKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeSubject (Next AppState)]
+cvSubjectKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeSubject]
 cvSubjectKeybindings = lens _cvSubjectKeybindings (\cv x -> cv { _cvSubjectKeybindings = x })
 
 cvSendMailCmd :: Lens' ComposeViewSettings (Mail.Mail -> IO ())
 cvSendMailCmd = lens _cvSendMailCmd (\cv x -> cv { _cvSendMailCmd = x })
 
-cvListOfAttachmentsKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ListOfAttachments (Next AppState)]
+cvListOfAttachmentsKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ListOfAttachments]
 cvListOfAttachmentsKeybindings = lens _cvListOfAttachmentsKeybindings (\cv x -> cv { _cvListOfAttachmentsKeybindings = x })
 
 newtype HelpViewSettings = HelpViewSettings
-  { _hvKeybindings :: [Keybinding 'Help 'ScrollingHelpView (Next AppState)]
+  { _hvKeybindings :: [Keybinding 'Help 'ScrollingHelpView]
   }
 
-hvKeybindings :: Lens' HelpViewSettings [Keybinding 'Help 'ScrollingHelpView (Next AppState)]
+hvKeybindings :: Lens' HelpViewSettings [Keybinding 'Help 'ScrollingHelpView]
 hvKeybindings f (HelpViewSettings a) = fmap (\a' -> HelpViewSettings a') (f a)
 
 data IndexViewSettings = IndexViewSettings
-    { _ivBrowseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads (Next AppState)]
-    , _ivBrowseMailsKeybindings :: [Keybinding 'Mails 'ListOfMails (Next AppState)]
-    , _ivSearchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor (Next AppState)]
-    , _ivManageMailTagsKeybindings :: [Keybinding 'Mails 'ManageMailTagsEditor (Next AppState)]
-    , _ivManageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor (Next AppState)]
-    , _ivFromKeybindings :: [Keybinding 'Threads 'ComposeFrom (Next AppState)]
-    , _ivToKeybindings :: [Keybinding 'Threads 'ComposeTo (Next AppState)]
-    , _ivSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject (Next AppState)]
+    { _ivBrowseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]
+    , _ivBrowseMailsKeybindings :: [Keybinding 'Mails 'ListOfMails]
+    , _ivSearchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]
+    , _ivManageMailTagsKeybindings :: [Keybinding 'Mails 'ManageMailTagsEditor]
+    , _ivManageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor]
+    , _ivFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
+    , _ivToKeybindings :: [Keybinding 'Threads 'ComposeTo]
+    , _ivSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]
     }
 
-ivBrowseThreadsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ListOfThreads (Next AppState)]
+ivBrowseThreadsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ListOfThreads]
 ivBrowseThreadsKeybindings = lens _ivBrowseThreadsKeybindings (\s x -> s { _ivBrowseThreadsKeybindings = x })
 
-ivBrowseMailsKeybindings :: Lens' IndexViewSettings [Keybinding 'Mails 'ListOfMails (Next AppState)]
+ivBrowseMailsKeybindings :: Lens' IndexViewSettings [Keybinding 'Mails 'ListOfMails]
 ivBrowseMailsKeybindings = lens _ivBrowseMailsKeybindings (\s x -> s { _ivBrowseMailsKeybindings = x })
 
-ivSearchThreadsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'SearchThreadsEditor (Next AppState)]
+ivSearchThreadsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'SearchThreadsEditor]
 ivSearchThreadsKeybindings = lens _ivSearchThreadsKeybindings (\s x -> s { _ivSearchThreadsKeybindings = x })
 
-ivManageMailTagsKeybindings :: Lens' IndexViewSettings [Keybinding 'Mails 'ManageMailTagsEditor (Next AppState)]
+ivManageMailTagsKeybindings :: Lens' IndexViewSettings [Keybinding 'Mails 'ManageMailTagsEditor]
 ivManageMailTagsKeybindings = lens _ivManageMailTagsKeybindings (\s x -> s { _ivManageMailTagsKeybindings = x })
 
-ivManageThreadTagsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ManageThreadTagsEditor (Next AppState)]
+ivManageThreadTagsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ManageThreadTagsEditor]
 ivManageThreadTagsKeybindings = lens _ivManageThreadTagsKeybindings (\s x -> s { _ivManageThreadTagsKeybindings = x })
 
-ivFromKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ComposeFrom (Next AppState)]
+ivFromKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ComposeFrom]
 ivFromKeybindings = lens _ivFromKeybindings (\s x -> s { _ivFromKeybindings = x })
 
-ivToKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ComposeTo (Next AppState)]
+ivToKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ComposeTo]
 ivToKeybindings = lens _ivToKeybindings (\s x -> s { _ivToKeybindings = x })
 
-ivSubjectKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ComposeSubject (Next AppState)]
+ivSubjectKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ComposeSubject]
 ivSubjectKeybindings = lens _ivSubjectKeybindings (\s x -> s { _ivSubjectKeybindings = x })
 
 
@@ -246,8 +246,8 @@ data MailViewSettings = MailViewSettings
     { _mvIndexRows           :: Int
     , _mvPreferredContentType :: ContentType
     , _mvHeadersToShow       :: CI.CI B.ByteString -> Bool
-    , _mvKeybindings         :: [Keybinding 'ViewMail 'ScrollingMailView (Next AppState)]
-    , _mvManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor (Next AppState)]
+    , _mvKeybindings         :: [Keybinding 'ViewMail 'ScrollingMailView]
+    , _mvManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
     }
 
 mvIndexRows :: Lens' MailViewSettings Int
@@ -259,10 +259,10 @@ mvPreferredContentType = lens _mvPreferredContentType (\mv x -> mv { _mvPreferre
 mvHeadersToShow :: Getter MailViewSettings (CI.CI B.ByteString -> Bool)
 mvHeadersToShow = lens _mvHeadersToShow (\mv x -> mv { _mvHeadersToShow = x })
 
-mvKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'ScrollingMailView (Next AppState)]
+mvKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'ScrollingMailView]
 mvKeybindings = lens _mvKeybindings (\mv x -> mv { _mvKeybindings = x })
 
-mvManageMailTagsKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'ManageMailTagsEditor (Next AppState)]
+mvManageMailTagsKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'ManageMailTagsEditor]
 mvManageMailTagsKeybindings = lens _mvManageMailTagsKeybindings (\mv x -> mv { _mvManageMailTagsKeybindings = x })
 
 data ViewName
@@ -332,18 +332,18 @@ data Action (v :: ViewName) (ctx :: Name) a = Action
 aAction :: Getter (Action v ctx a) (AppState -> EventM Name a)
 aAction = to (\(Action _ b) -> b)
 
-data Keybinding (v :: ViewName) (ctx :: Name) a = Keybinding
+data Keybinding (v :: ViewName) (ctx :: Name) = Keybinding
     { _kbEvent :: Vty.Event
-    , _kbAction :: Action v ctx a
+    , _kbAction :: Action v ctx (Next AppState)
     }
-instance Eq (Keybinding v ctx a) where
+instance Eq (Keybinding v ctx) where
   (==) (Keybinding a _) (Keybinding b _) = a == b
   (/=) (Keybinding a _) (Keybinding b _) = a /= b
 
-kbEvent :: Getter (Keybinding v ctx a) Vty.Event
+kbEvent :: Getter (Keybinding v ctx) Vty.Event
 kbEvent = to (\(Keybinding b _) -> b)
 
-kbAction :: Getter (Keybinding v ctx a) (Action v ctx a)
+kbAction :: Getter (Keybinding v ctx) (Action v ctx (Next AppState))
 kbAction = to (\(Keybinding _ c) -> c)
 
 aDescription :: Getter (Action v ctx a) [T.Text]

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -431,7 +431,7 @@ listJumpToEnd = Action
 
 listJumpToStart :: Action v m AppState
 listJumpToStart = Action
-  { _aDescription = "move selection to last element"
+  { _aDescription = "move selection to first element"
     , _aAction = \s -> case focusedViewWidget s ListOfThreads of
         ListOfThreads -> pure $ over (asMailIndex . miListOfThreads) (L.listMoveTo 0) s
         ScrollingMailView -> pure $ over (asMailIndex . miListOfMails) (L.listMoveTo 0) s

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -24,6 +24,8 @@ module UI.Actions (
   , replyMail
   , scrollUp
   , scrollDown
+  , scrollPageUp
+  , scrollPageDown
   , toggleHeaders
   , initialCompose
   , continue
@@ -36,9 +38,7 @@ module UI.Actions (
   , focusNextWidget
   ) where
 
-import qualified Brick.Main as Brick
-       (suspendAndResume, continue, halt, vScrollToBeginning, vScrollPage,
-        viewportScroll, ViewportScroll)
+import qualified Brick
 import qualified Brick.Focus as Brick
 import qualified Brick.Types as T
 import qualified Brick.Widgets.Edit as E
@@ -360,15 +360,27 @@ focus = Action ("switch mode to " <> show (name (Proxy :: Proxy a))) (switchFocu
 noop :: Action v ctx AppState
 noop = Action "" pure
 
-scrollUp :: forall ctx v. (HasViewName v, Scrollable ctx) => Action v ctx AppState
+scrollUp :: forall ctx v. (Scrollable ctx) => Action v ctx AppState
 scrollUp = Action
-  { _aDescription = "scrolling up"
+  { _aDescription = "scroll up"
+  , _aAction = (<$ Brick.vScrollBy (makeViewportScroller (Proxy :: Proxy ctx)) (-1))
+  }
+
+scrollDown :: forall ctx v. (Scrollable ctx) => Action v ctx AppState
+scrollDown = Action
+  { _aDescription = "scroll down"
+  , _aAction = \s -> s <$ Brick.vScrollBy (makeViewportScroller (Proxy :: Proxy ctx)) 1
+  }
+
+scrollPageUp :: forall ctx v. (Scrollable ctx) => Action v ctx AppState
+scrollPageUp = Action
+  { _aDescription = "page up"
   , _aAction = \s -> Brick.vScrollPage (makeViewportScroller (Proxy :: Proxy ctx)) T.Up >> pure s
   }
 
-scrollDown :: forall ctx v. (HasViewName v, Scrollable ctx) => Action v ctx AppState
-scrollDown = Action
-  { _aDescription = "scrolling down"
+scrollPageDown :: forall ctx v. (Scrollable ctx) => Action v ctx AppState
+scrollPageDown = Action
+  { _aDescription = "page down"
   , _aAction = \s -> Brick.vScrollPage (makeViewportScroller (Proxy :: Proxy ctx)) T.Down >> pure s
   }
 

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -65,7 +65,7 @@ handleViewEvent = f where
   f Threads ManageThreadTagsEditor = dispatch eventHandlerManageThreadTagsEditor
   f Threads SearchThreadsEditor = dispatch eventHandlerSearchThreadsEditor
   f ViewMail ManageMailTagsEditor = dispatch eventHandlerViewMailManageMailTagsEditor
-  f ViewMail ScrollingMailView = dispatch eventHandlerScrollingMailView
+  f ViewMail _ = dispatch eventHandlerScrollingMailView
   f _ ScrollingHelpView = dispatch eventHandlerScrollingHelpView
   f _ _ = dispatch nullEventHandler
 

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -3,37 +3,35 @@
 module UI.ComposeEditor.Keybindings where
 
 import Data.Semigroup ((<>))
-import qualified Brick.Types as Brick
 import qualified Graphics.Vty as V
-import Prelude hiding (readFile, unlines)
 import UI.Actions
 import Types
 
 
-commonKeybindings :: [Keybinding 'ComposeView ctx (Brick.Next AppState)]
+commonKeybindings :: [Keybinding 'ComposeView ctx]
 commonKeybindings =
     [ Keybinding (V.EvKey (V.KChar 'n') [V.MCtrl]) (focusNextWidget `chain` continue)
     ]
 
-composeSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject (Brick.Next AppState)]
+composeSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
 composeSubjectKeybindings =
     [ Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` continue)
     ] <> commonKeybindings
 
-composeFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom (Brick.Next AppState)]
+composeFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
 composeFromKeybindings =
     [ Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEsc []) (abort `chain` continue)
     ] <> commonKeybindings
 
-composeToKeybindings :: [Keybinding 'ComposeView 'ComposeTo (Brick.Next AppState)]
+composeToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
 composeToKeybindings =
     [ Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEsc []) (abort `chain` continue)
     ] <> commonKeybindings
 
-listOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ListOfAttachments (Brick.Next AppState)]
+listOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ListOfAttachments]
 listOfAttachmentsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)

--- a/src/UI/GatherHeaders/Keybindings.hs
+++ b/src/UI/GatherHeaders/Keybindings.hs
@@ -1,24 +1,23 @@
 {-# LANGUAGE DataKinds #-}
 module UI.GatherHeaders.Keybindings where
 
-import qualified Brick.Types as T
 import qualified Graphics.Vty as V
 import Types
 import UI.Actions
 
-gatherFromKeybindings :: [Keybinding 'Threads 'ComposeFrom (T.Next AppState)]
+gatherFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
 gatherFromKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'Threads 'ComposeTo AppState) `chain` continue)
     ]
 
-gatherToKeybindings :: [Keybinding 'Threads 'ComposeTo (T.Next AppState)]
+gatherToKeybindings :: [Keybinding 'Threads 'ComposeTo]
 gatherToKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'Threads 'ComposeSubject AppState) `chain` continue)
     ]
 
-gatherSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject (T.Next AppState)]
+gatherSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]
 gatherSubjectKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` invokeEditor)

--- a/src/UI/Help/Keybindings.hs
+++ b/src/UI/Help/Keybindings.hs
@@ -2,13 +2,12 @@
 
 module UI.Help.Keybindings where
 
-import qualified Brick.Types as Brick
 import Graphics.Vty (Event (..), Key (..))
 import UI.Actions
 import Types
 
 -- | Default Keybindings
-helpKeybindings :: [Keybinding 'Help 'ScrollingHelpView (Brick.Next AppState)]
+helpKeybindings :: [Keybinding 'Help 'ScrollingHelpView]
 helpKeybindings =
     [ Keybinding (EvKey KEsc []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)

--- a/src/UI/Help/Keybindings.hs
+++ b/src/UI/Help/Keybindings.hs
@@ -11,6 +11,6 @@ import Types
 helpKeybindings :: [Keybinding 'Help 'ScrollingHelpView (Brick.Next AppState)]
 helpKeybindings =
     [ Keybinding (EvKey KEsc []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (EvKey KBS []) (scrollUp `chain` continue)
-    , Keybinding (EvKey (KChar ' ') []) (scrollDown `chain` continue)
+    , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)
+    , Keybinding (EvKey (KChar ' ') []) (scrollPageDown `chain` continue)
     ]

--- a/src/UI/Help/Main.hs
+++ b/src/UI/Help/Main.hs
@@ -26,14 +26,14 @@ renderHelp s = let tweak = views (asConfig . confIndexView . ivBrowseMailsKeybin
                          <=> views (asConfig . confHelpView . hvKeybindings) (renderKbGroup ScrollingHelpView) s
              in viewport ScrollingHelpView T.Vertical tweak
 
-renderKbGroup :: Titleize a => a -> [Keybinding v ctx s] -> Widget Name
+renderKbGroup :: Titleize a => a -> [Keybinding v ctx] -> Widget Name
 renderKbGroup name kbs =
   withAttr helpTitleAttr (padBottom (Pad 1) $ txt (titleize name))
   <=> padBottom (Pad 1) (vBox (renderKeybinding <$> uniqKBs))
   where
     uniqKBs = nubBy ((==) `on` view kbEvent) kbs
 
-renderKeybinding :: Keybinding v ctx a-> Widget Name
+renderKeybinding :: Keybinding v ctx -> Widget Name
 renderKeybinding kb = let keys = view kbEvent kb
                           actions = view (kbAction . aDescription) kb
                       in withAttr helpKeybindingAttr (hLimit 30 (padRight Max $ txt $ ppKbEvent keys))

--- a/src/UI/Help/Main.hs
+++ b/src/UI/Help/Main.hs
@@ -4,7 +4,7 @@ module UI.Help.Main (renderHelp) where
 import Brick.Types (Padding(..), Widget)
 import qualified Brick.Types as T
 import Brick.Widgets.Core
-       (viewport, hLimit, padLeft, padBottom, padRight, str, txt, (<=>),
+       (viewport, hLimit, padLeft, padBottom, padRight, txt, (<=>),
         (<+>), emptyWidget, withAttr)
 import Graphics.Vty.Input.Events (Event(..), Key(..), Modifier(..))
 import Control.Lens (view, views)
@@ -33,7 +33,7 @@ renderKeybinding :: Keybinding v ctx a-> Widget Name
 renderKeybinding kb = let keys = view kbEvent kb
                           actions = view (kbAction . aDescription) kb
                       in withAttr helpKeybindingAttr (hLimit 30 (padRight Max $ txt $ ppKbEvent keys))
-                         <+> padLeft (Pad 3) (str actions)
+                         <+> padLeft (Pad 3) (txt (intercalate " > " actions))
 
 ppKbEvent :: Event -> Text
 ppKbEvent (EvKey k modifiers) = intercalate " + " $ (ppMod <$> modifiers) <> [ppKey k]

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -2,13 +2,12 @@
 
 module UI.Index.Keybindings where
 
-import qualified Brick.Types as Brick
 import qualified Graphics.Vty as V
 import UI.Actions
 import Types
 
 -- | Default Keybindings
-browseMailKeybindings :: [Keybinding 'Mails 'ListOfMails (Brick.Next AppState)]
+browseMailKeybindings :: [Keybinding 'Mails 'ListOfMails]
 browseMailKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
@@ -28,7 +27,7 @@ browseMailKeybindings =
     , Keybinding (V.EvKey (V.KChar 'm') []) (noop `chain'` (focus :: Action 'Mails 'ComposeFrom AppState) `chain` continue)
     ]
 
-browseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads (Brick.Next AppState)]
+browseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]
 browseThreadsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) quit
     , Keybinding (V.EvKey (V.KChar 'q') []) quit
@@ -46,19 +45,19 @@ browseThreadsKeybindings =
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     ]
 
-searchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor (Brick.Next AppState)]
+searchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]
 searchThreadsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     ]
 
-manageMailTagsKeybindings :: [Keybinding 'Mails 'ManageMailTagsEditor (Brick.Next AppState)]
+manageMailTagsKeybindings :: [Keybinding 'Mails 'ManageMailTagsEditor]
 manageMailTagsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
     ]
 
-manageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor (Brick.Next AppState)]
+manageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor]
 manageThreadTagsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -14,12 +14,12 @@ import Data.List (find)
 import Prelude hiding (readFile, unlines)
 import Types
 
-lookupKeybinding :: Event -> [Keybinding v ctx a] -> Maybe (Keybinding v ctx a)
+lookupKeybinding :: Event -> [Keybinding v ctx] -> Maybe (Keybinding v ctx)
 lookupKeybinding e = find (\x -> view kbEvent x == e)
 
 data EventHandler v m = EventHandler
   (forall f. Functor f
-    => ([Keybinding v m (Brick.Next AppState)] -> f [Keybinding v m (Brick.Next AppState)])
+    => ([Keybinding v m] -> f [Keybinding v m])
     -> AppState -> f AppState) -- lens to keybindings
   (AppState -> Event -> Brick.EventM Name (Brick.Next AppState)) -- fallback handler
 

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -13,8 +13,8 @@ displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView (Brick.Next A
 displayMailKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KBS []) (scrollUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar ' ') []) (scrollDown `chain` continue)
+    , Keybinding (V.EvKey V.KBS []) (scrollPageUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar ' ') []) (scrollPageDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'h') []) (toggleHeaders `chain` continue)
     , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'ViewMail 'ManageMailTagsEditor AppState) `chain` continue)
 

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -2,14 +2,11 @@
 
 module UI.Mail.Keybindings where
 
-import qualified Brick.Types as Brick
 import qualified Graphics.Vty as V
 import UI.Actions
 import Types
 
-{-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
-
-displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView (Brick.Next AppState)]
+displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 displayMailKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
@@ -25,7 +22,7 @@ displayMailKeybindings =
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
     ]
 
-mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor (Brick.Next AppState)]
+mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
 mailViewManageMailTagsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -18,6 +18,6 @@ actionTests =
 
 testModeDescription :: TestTree
 testModeDescription = testCase "mode present in the switch action"
-                      $ view aDescription a @?= "switch mode to ManageMailTagsEditor"
+                      $ view aDescription a @?= ["switch mode to ManageMailTagsEditor"]
   where
     a = focus :: Action 'Mails 'ManageMailTagsEditor AppState


### PR DESCRIPTION
Changes:

```
82bdfcf (Fraser Tweedale, 14 minutes ago)
   remove unneeded Keybinding type parameter

   One of the Keybinding type parameters was always set to `Brick.Next
   AppState`.  At this stage there is no need to have it, so remove it.

73aa0b0 (Fraser Tweedale, 32 minutes ago)
   remove unused type synonyms

06a798f (Fraser Tweedale, 75 minutes ago)
   help: don't show overridden key binding

   nub each keybinding list on the event to make sure that we don't show
   overridden key bindings in the help view.

185e54b (Fraser Tweedale, 2 hours ago)
   tidy up composite action descriptions

   The "noop" action and the currrent means of describing composite actions -
   writing "... and then ..." - led to some pretty ugly descriptions.  Tidy it
   up by preserving descriptions as a (possibly empty) list of strings, and
   combining them in the obvious way.  Make the output a bit more compact: the
   combining text is now " > " instead of "and then".

   Also change the type from String to Text for efficiency.

4bf8c69 (Fraser Tweedale, 2 hours ago)
   add single-line scrolling actions

   Add single-line scrolling actions and rename the existing scroll actions to
   scrollPageUp and scrollPageDown.

8e730b7 (Fraser Tweedale, 2 hours ago)
   fix listJumpToStart action description

4b8db97 (Fraser Tweedale, 2 hours ago)
   fix mail view event dispatch

   If viewing a mail from thread list, backing out to mail list, then
   selecting a mail, we end up in ViewMail/ListOfMails rather than
   ViewMail/ScrollingMailView.  The former is not mapped to an event handler.

   I'm not entirely sure why we end up in that mode, so for now just dispatch
   to ScollingMailView keybindings whenever ViewMail is the active view.
```