### PR TITLE
Fix/allow reedit mailbody

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -43,13 +43,13 @@ import qualified Brick.Focus as Brick
 import qualified Brick.Types as T
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
-import Network.Mail.Mime (Address(..), plainPart, emptyMail)
+import Network.Mail.Mime (Part(..), Address(..), emptyMail, Encoding(..))
 import Network.Mail.Mime.Lens (lMailParts, lMailFrom, lMailTo, lMailHeaders)
 import Data.Proxy
 import Data.Semigroup ((<>))
-import Data.Text (unlines, Text, pack)
-import Data.Text.Lazy.IO (readFile)
+import Data.Text (unlines, unpack, pack, Text)
 import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Lazy as L
 import Data.Vector.Lens (vector)
 import Data.Maybe (fromMaybe)
 import Data.List (union)
@@ -63,7 +63,6 @@ import Control.Applicative ((<|>))
 import Control.Lens
        (_Just, at, toListOf, traversed, has, itoList, set, over, view,
         (&), Getting, Lens')
-import Control.Lens.Cons (cons)
 import Control.Monad ((>=>))
 import Control.Monad.Except (runExceptT)
 import Control.Exception (onException)
@@ -220,7 +219,7 @@ instance Focusable 'Help 'ScrollingHelpView where
   switchFocus _ _ = pure . over (asViews . vsFocusedView) (Brick.focusSetCurrent Help)
 
 instance Focusable 'ComposeView 'ListOfAttachments where
-  switchFocus _ _ s = pure $ s & over (asViews . vsViews . at (focusedViewName s) . _Just . vFocus) (Brick.focusSetCurrent ListOfAttachments)
+  switchFocus _ _ s = pure $ s & over (asViews . vsViews . at ComposeView . _Just . vFocus) (Brick.focusSetCurrent ListOfAttachments)
                     . over (asViews . vsViews . at Threads . _Just . vWidgets) (replaceEditor SearchThreadsEditor)
 
 -- TODO: helper function to replace whatever editor we're displaying at the
@@ -647,15 +646,35 @@ initialCompose =
 invokeEditor' :: AppState -> IO AppState
 invokeEditor' s = do
   let editor = view (asConfig . confEditor) s
-  tmpdir <- getTemporaryDirectory
-  tmpfile <- emptyTempFile tmpdir "purebred.tmp"
+  tmpfile <- attachmentFilename s
   status <- onException (system (editor <> " " <> tmpfile)) (pure $ setError editorError)
   case status of
     ExitFailure _ -> pure $ s & over (asViews . vsFocusedView) (Brick.focusSetCurrent Mails)
                               & setError editorError
     ExitSuccess -> do
-      body <- liftIO $ readFile tmpfile
-      pure $ s & over (asCompose . cAttachments . L.listElementsL) (cons $ plainPart body)
+      body <- liftIO $ makePlainPart tmpfile
+      pure $ s & over (asCompose . cAttachments) (upsertPart body)
+
+upsertPart :: Part -> L.List Name Part -> L.List Name Part
+upsertPart newPart list =
+  case L.listSelectedElement list of
+    Nothing -> L.listInsert 0 newPart list
+    Just (_, part) ->
+      if partFilename part == partFilename newPart then
+        L.listModify (const newPart) list
+      else
+        L.listInsert 0 newPart list
+
+attachmentFilename :: AppState -> IO String
+attachmentFilename s = let tempfile = getTemporaryDirectory >>= \tdir -> emptyTempFile tdir "purebred.tmp"
+                       in case L.listSelectedElement $ view (asCompose . cAttachments) s of
+                            Nothing -> tempfile
+                            Just (_, p) -> maybe tempfile (pure . unpack) $ partFilename p
+
+makePlainPart :: String -> IO Part
+makePlainPart filename = do
+  content <- L.readFile filename
+  pure $ Part "text/plain; charset=utf-8" Base64 (Just $ pack filename) [] content
 
 editorError :: Error
 editorError = GenericError ("Editor command exited with error code."

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -43,4 +43,5 @@ listOfAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'e') []) invokeEditor
     ] <> commonKeybindings

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -4,22 +4,26 @@
 module UI.ComposeEditor.Main (attachmentsEditor) where
 
 import Brick.Types (Padding(..), Widget)
-import Brick.Widgets.Core (padRight, txt, (<+>),)
+import Brick.Widgets.Core (padRight, txt, (<+>), withAttr)
 import qualified Brick.Widgets.List as L
 import Network.Mail.Mime (Part(..))
 import Control.Lens (view)
 import Data.Maybe (fromMaybe)
 
+import Config.Main (listSelectedAttr, listAttr)
 import UI.Utils (focusedViewWidget)
 import Types
 
 attachmentsEditor :: AppState -> Widget Name
 attachmentsEditor s =
     let hasFocus = ListOfAttachments == focusedViewWidget s ComposeFrom
-        attachmentsList = L.renderList (\_ i -> renderPart i) hasFocus (view (asCompose . cAttachments) s)
+        attachmentsList = L.renderList renderPart hasFocus (view (asCompose . cAttachments) s)
     in attachmentsList
 
-renderPart :: Part -> Widget Name
-renderPart p = let pType = partType p
-                   pFilename = fromMaybe "--" (partFilename p)
-               in padRight Max (txt pFilename) <+> txt pType
+renderPart :: Bool -> Part -> Widget Name
+renderPart selected p =
+  let pType = partType p
+      pFilename = fromMaybe "--" (partFilename p)
+      listItemAttr = if selected then listSelectedAttr else listAttr
+      widget = padRight Max (txt pFilename) <+> txt pType
+  in withAttr listItemAttr widget

--- a/src/UI/GatherHeaders/Main.hs
+++ b/src/UI/GatherHeaders/Main.hs
@@ -9,12 +9,13 @@ import Brick.Types (Widget)
 
 import Types
 import UI.Draw.Main (renderEditorWithLabel)
+import UI.Utils (focusedViewWidget)
 
 drawFrom :: AppState -> Widget Name
-drawFrom s = renderEditorWithLabel "From:" True (view (asCompose . cFrom) s)
+drawFrom s = renderEditorWithLabel "From:" (ComposeFrom == focusedViewWidget s ComposeFrom) (view (asCompose . cFrom) s)
 
 drawTo :: AppState -> Widget Name
-drawTo s = renderEditorWithLabel "To:" True (view (asCompose . cTo) s)
+drawTo s = renderEditorWithLabel "To:" (ComposeTo == focusedViewWidget s ComposeFrom) (view (asCompose . cTo) s)
 
 drawSubject :: AppState -> Widget Name
-drawSubject s = renderEditorWithLabel "Subject:" True (view (asCompose . cSubject) s)
+drawSubject s = renderEditorWithLabel "Subject:" (ComposeSubject == focusedViewWidget s ComposeFrom) (view (asCompose . cSubject) s)

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -24,7 +24,6 @@ browseMailKeybindings =
     , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'Mails 'ManageMailTagsEditor AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'm') []) (noop `chain'` (focus :: Action 'Mails 'ComposeFrom AppState) `chain` continue)
     ]
 
 browseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -411,7 +411,7 @@ testUserCanSwitchBackToIndex =
             sendKeys "Escape" (Literal "body")
 
             liftIO $ step "exit vim"
-            sendKeys ": x\r" (Regex ("From: " <> buildAnsiRegex [] ["37"] ["40"] <> "testuser@foo.test"))
+            sendKeys ": x\r" (Regex ("From: " <> buildAnsiRegex [] ["34"] ["40"] <> "testuser@foo.test"))
 
             liftIO $ step "switch back to index"
             sendKeys "Tab" (Literal "Testmail")
@@ -421,7 +421,7 @@ testUserCanSwitchBackToIndex =
 
             liftIO $ step "cycle to next input field"
             sendKeys "C-n" (Regex (buildAnsiRegex [] ["39"] ["49"] <> "To:\\s+"
-                                   <> buildAnsiRegex [] ["37"] ["40"] <> "user@to.test"))
+                                   <> buildAnsiRegex [] ["34"] ["40"] <> "user@to.test"))
             pure ()
 
 testSendMail :: Int -> TestTree

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -94,10 +94,6 @@ testCanJumpToFirstListItem = withTmuxSession "updates read state for mail and th
 testUpdatesReadState :: Int -> TestTree
 testUpdatesReadState = withTmuxSession "updates read state for mail and thread" $
   \step -> do
-    -- Make the regex less color code dependent. This can happen if different
-    -- environments support more than 16 colours (e.g. background values > 37),
-    -- while our CI environment only supports 16 colours.
-    setEnvVarInSession "TERM" "ansi"
     startApplication
 
     liftIO $ step "navigate to thread mails"
@@ -471,7 +467,7 @@ testSendMail =
           sendKeys "Escape" (Literal "body")
 
           liftIO $ step "exit vim"
-          sendKeys ": x\r" (Regex ("text/plain; charset=utf-8\\s" <> buildAnsiRegex [] ["94"] ["40"] <> "\\s+"))
+          sendKeys ": x\r" (Regex ("text/plain; charset=utf-8\\s" <> buildAnsiRegex [] ["34"] ["40"] <> "\\s+"))
 
           liftIO $ step "send mail and go back to threads"
           sendKeys "y" (Regex (buildAnsiRegex [] ["39"] ["49"] <> "Query"))
@@ -524,6 +520,7 @@ setUp i desc = do
     sessionName = intercalate "-" (sessionNamePrefix : show i : descWords)
     descWords = words $ filter (\c -> isAscii c && (isAlphaNum c || c == ' ')) desc
   setUpTmuxSession sessionName
+  prepareEnvironment sessionName
   (testdir, maildir) <- setUpTempMaildir
   setUpPurebredConfig testdir
   pure $ Env testdir maildir sessionName
@@ -686,6 +683,18 @@ startApplication = do
   liftIO $ callProcess "tmux" $
     communicateSessionArgs sessionName ("purebred --database " <> testmdir <> "\r") False
   void $ waitForString "Purebred: Item" defaultCountdown
+
+
+-- | Prepare the environment
+-- Here we're setting up the environment to run in a more predictable fasion.
+--
+-- a) Make the regex less color code dependent by setting the TERM to 'ansi'.
+-- This can happen if different environments support more than 16 colours (e.g.
+-- background values > 37), while our CI environment only supports 16 colours.
+prepareEnvironment :: String -> IO ()
+prepareEnvironment sessionName =
+  liftIO $ callProcess "tmux" $
+    communicateSessionArgs sessionName "export TERM=ansi\r" False
 
 -- | Sets a shell environment variable
 -- Note: The tmux program provides a command to set environment variables for

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -461,6 +461,18 @@ testSendMail =
           liftIO $ step "exit vim"
           sendKeys ": x\r" (Literal "text/plain")
 
+          liftIO $ step "user can re-edit body"
+          sendKeys "e" (Literal "This is a test body")
+
+          liftIO $ step "Writes more text"
+          sendKeys "i. More text" (Literal "text")
+
+          liftIO $ step "exit insert mode in vim"
+          sendKeys "Escape" (Literal "body")
+
+          liftIO $ step "exit vim"
+          sendKeys ": x\r" (Regex ("text/plain; charset=utf-8\\s" <> buildAnsiRegex [] ["94"] ["40"] <> "\\s+"))
+
           liftIO $ step "send mail and go back to threads"
           sendKeys "y" (Regex (buildAnsiRegex [] ["39"] ["49"] <> "Query"))
 


### PR DESCRIPTION
```
commit 9e3f0a82360b25d36e444cc9250a9b6d9b9ddae6 (HEAD -> fix/allow_reedit_mailbody, origin/fix/allow_reedit_mailbody)
Author: Roman Joost <roman@bromeco.de>
Date:   Thu Jun 21 15:53:35 2018 +1000

    Focus ComposeView editors conditionally

commit 5df30b2b008aae0478d31088025db0fd949212ca
Author: Roman Joost <roman@bromeco.de>
Date:   Thu Jun 21 16:35:36 2018 +1000

    Always "dumb" down the terminal
    
    More tests were failing because of the difference between high-color terminal
    escape sequences. I think a less colorful terminal is almost always what we
    want which makes the tests between us and the CI more reliable.

commit b346da885a3ea8b718af36a46a15627fb1c37764
Author: Roman Joost <roman@bromeco.de>
Date:   Thu Jun 21 16:03:23 2018 +1000

    Remove to compose mails from mail list
    
    Removed keybinding from the list of mails, since it will just get the
    user stuck. Typically users will always land on the view which shows the
    mail first. So to compose a mail from the list of mails, you'd have to
    press two keys to intentionally start composing. I don't think it's
    worth it.
    
    In order to support this, we'd need to add quite a bit of new code for
    additional keybindings and drawing. Since we're currently not really
    sure if we want to really keep the way we're composing mails, rather
    just support the mail composition from the thread view.

commit 211cd9a47d7943eb90955760e61310857b8c0714
Author: Roman Joost <roman@bromeco.de>
Date:   Wed Jun 20 20:30:11 2018 +1000

    Allow to re-edit the mail body
    
    Once the initial editor was closed, it was not possible to edit the mail body
    again. This patch adds a new keybinding 'e' to edit the mail body and updates
    the list of attachments (currently restricted to one).

```