### PR TITLE
Incorporate attachments editor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: c
 
 # http://docs.haskellstack.org/en/stable/travis_ci/#container-infrastructure

--- a/configs/config.hs
+++ b/configs/config.hs
@@ -58,3 +58,4 @@ main = purebred $ tweak defaultConfig where
     . over (confIndexView . ivBrowseMailsKeybindings) (`union` myBrowseMailKeybindings)
     . over (confMailView . mvKeybindings) (`union` myMailKeybindings)
     . set (confComposeView . cvSendMailCmd) writeMailtoFile
+    . set (confFileBrowserView . bfHomePath) getCurrentDirectory

--- a/configs/config.hs
+++ b/configs/config.hs
@@ -58,4 +58,4 @@ main = purebred $ tweak defaultConfig where
     . over (confIndexView . ivBrowseMailsKeybindings) (`union` myBrowseMailKeybindings)
     . over (confMailView . mvKeybindings) (`union` myMailKeybindings)
     . set (confComposeView . cvSendMailCmd) writeMailtoFile
-    . set (confFileBrowserView . bfHomePath) getCurrentDirectory
+    . set (confFileBrowserView . fbHomePath) getCurrentDirectory

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -60,6 +60,7 @@ library
                      , UI.Utils
                      , UI.Views
                      , Purebred.Tags
+                     , Purebred.System.Directory
                      , UI.FileBrowser.Main
                      , UI.FileBrowser.Keybindings
                      , Config.Main

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -128,3 +128,5 @@ test-suite unittests
                      , notmuch
                      , time
                      , filepath
+                     , brick >= 0.34
+                     , vector

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -90,6 +90,7 @@ library
                      , purebred-email
                      , attoparsec
                      , containers
+                     , mime-types
 
 executable purebred
   hs-source-dirs:      app

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -60,6 +60,8 @@ library
                      , UI.Utils
                      , UI.Views
                      , Purebred.Tags
+                     , UI.FileBrowser.Main
+                     , UI.FileBrowser.Keybindings
                      , Config.Main
                      , Storage.Notmuch
                      , Storage.ParsedMail

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -112,6 +112,7 @@ test-suite unittests
   default-language:    Haskell2010
   build-depends:       base
                      , purebred
+                     , purebred-email
                      , tasty
                      , tasty-hunit
                      , tasty-quickcheck

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -15,6 +15,8 @@ import Network.Mail.Mime (renderSendMail)
 
 import Data.MIME (ContentType(..))
 
+import UI.FileBrowser.Keybindings
+       (fileBrowserKeybindings, manageSearchPathKeybindings)
 import UI.GatherHeaders.Keybindings
        (gatherFromKeybindings,
         gatherToKeybindings,
@@ -171,4 +173,8 @@ defaultConfig =
       { _hvKeybindings = helpKeybindings
       }
     , _confDefaultView = Threads
+    , _confFileBrowserView = FileBrowserSettings
+      { _fbKeybindings = fileBrowserKeybindings
+      , _fbSearchPathKeybindings = manageSearchPathKeybindings
+      }
     }

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -10,6 +10,7 @@ import Brick.Util (fg, on, bg)
 import qualified Brick.Widgets.Edit as E
 import qualified Graphics.Vty as V
 import System.Environment (lookupEnv)
+import System.Directory (getHomeDirectory)
 import Data.Maybe (fromMaybe)
 import Network.Mail.Mime (renderSendMail)
 
@@ -176,5 +177,6 @@ defaultConfig =
     , _confFileBrowserView = FileBrowserSettings
       { _fbKeybindings = fileBrowserKeybindings
       , _fbSearchPathKeybindings = manageSearchPathKeybindings
+      , _fbHomePath = getHomeDirectory
       }
     }

--- a/src/Network/Mail/Mime/Lens.hs
+++ b/src/Network/Mail/Mime/Lens.hs
@@ -17,7 +17,9 @@
 module Network.Mail.Mime.Lens where
 
 import Control.Lens (Lens')
-import Network.Mail.Mime (Mail(..), Alternatives, Address, Headers)
+import Data.ByteString.Lazy (ByteString)
+import Network.Mail.Mime
+       (Mail(..), Alternatives, Address, Headers, Part(..))
 
 
 lMailParts :: Lens' Mail [Alternatives]
@@ -31,3 +33,6 @@ lMailFrom f (Mail a b c d e g) = fmap (\a' -> Mail a' b c d e g) (f a)
 
 lMailHeaders :: Lens' Mail Headers
 lMailHeaders f (Mail a b c d e g) = fmap (\e' -> Mail a b c d e' g) (f e)
+
+lpartContent :: Lens' Part ByteString
+lpartContent f (Part a b c d e) = fmap (\e' -> Part a b c d e') (f e)

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -14,16 +14,14 @@ module Purebred (
   defaultConfig,
   solarizedDark,
   solarizedLight,
-  over,
-  set,
-  (&),
   (</>),
+  module Control.Lens,
   purebred) where
 
 import UI.App (theApp, initialState)
 
 import Control.Exception.Base (SomeException(..), IOException, catch)
-import Control.Monad (unless, void)
+import Control.Monad ((>=>), unless, void)
 import Options.Applicative hiding (str)
 import qualified Options.Applicative.Builder as Builder
 import Data.Semigroup ((<>))
@@ -50,10 +48,8 @@ import Graphics.Vty.Input.Events (Event(..), Key(..), Modifier(..))
 import Brick.Main (defaultMain)
 import Brick.Types (Next)
 import Brick.Widgets.List (List(..))
-import Control.Lens.Lens ((&))
-import Control.Lens.Setter (over, set)
-import Control.Lens.Getter (view)
 import Network.Mail.Mime (Mail, renderMail')
+import Control.Lens ((&), over, set)
 
 newtype AppConfig = AppConfig
     { databaseFilepath :: Maybe String
@@ -106,14 +102,10 @@ launch cfg = do
     void $ defaultMain (theApp s) s
 
 processConfig :: UserConfiguration -> IO InternalConfiguration
-processConfig cfg = do
-    fp <- view (confNotmuch . nmDatabase) cfg
-    ed <- view confEditor cfg
-    bfp <- view (confFileBrowserView . fbHomePath) cfg
-    pure $ cfg
-      & set (confNotmuch . nmDatabase) fp
-      & set confEditor ed
-      & set (confFileBrowserView . fbHomePath) bfp
+processConfig =
+  (confNotmuch . nmDatabase) id
+  >=> confEditor id
+  >=> (confFileBrowserView . fbHomePath) id
 
 -- | Recompile the config file if it has changed based on the modification timestamp
 -- Node: Mostly a XMonad.Main.hs rip-off.

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -109,9 +109,11 @@ processConfig :: UserConfiguration -> IO InternalConfiguration
 processConfig cfg = do
     fp <- view (confNotmuch . nmDatabase) cfg
     ed <- view confEditor cfg
+    bfp <- view (confFileBrowserView . fbHomePath) cfg
     pure $ cfg
       & set (confNotmuch . nmDatabase) fp
       & set confEditor ed
+      & set (confFileBrowserView . fbHomePath) bfp
 
 -- | Recompile the config file if it has changed based on the modification timestamp
 -- Node: Mostly a XMonad.Main.hs rip-off.

--- a/src/Purebred/System/Directory.hs
+++ b/src/Purebred/System/Directory.hs
@@ -1,0 +1,42 @@
+-- This file is part of purebred
+-- Copyright (C) 2018 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TupleSections #-}
+module Purebred.System.Directory where
+
+import Control.Exception.Base (IOException)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Except (MonadError, throwError)
+import Control.Exception (try)
+import System.Directory (listDirectory, doesDirectoryExist)
+import System.FilePath ((</>))
+import Data.List (sort)
+
+import Error
+import Types
+
+
+listDirectory' :: (MonadError Error m, MonadIO m) => FilePath -> m [FileSystemEntry]
+listDirectory' path = liftIO (try $ listDirectory path)
+                      >>= either (throwError . convertError) (traverse (filePathToEntry path) >>= pure . fmap sort)
+  where convertError :: IOException -> Error
+        convertError = GenericError . show
+
+filePathToEntry :: (MonadIO m) => FilePath -> FilePath -> m FileSystemEntry
+filePathToEntry base filename = do
+    exists <- liftIO $ doesDirectoryExist (base </> filename)
+    pure $ if exists then Directory filename else File filename

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- | Basic types for the UI used by this library
 module Types
@@ -171,7 +172,9 @@ data Configuration a b c = Configuration
 type UserConfiguration = Configuration (IO FilePath) (IO String) (IO FilePath)
 type InternalConfiguration = Configuration FilePath String FilePath
 
-confTheme :: Lens' (Configuration a b c) Theme
+type ConfigurationLens v = forall a b c. Lens' (Configuration a b c) v
+
+confTheme :: ConfigurationLens Theme
 confTheme = lens _confTheme (\c x -> c { _confTheme = x })
 
 confEditor :: Lens (Configuration a b c) (Configuration a b' c) b b'
@@ -180,19 +183,19 @@ confEditor f (Configuration a b c d e g h i j) = fmap (\c' -> Configuration a b 
 confNotmuch :: Lens (Configuration a b c) (Configuration a' b c) (NotmuchSettings a) (NotmuchSettings a')
 confNotmuch f (Configuration a b c d e g h i j) = fmap (\b' -> Configuration a b' c d e g h i j) (f b)
 
-confMailView :: Lens' (Configuration a b c) MailViewSettings
+confMailView :: ConfigurationLens MailViewSettings
 confMailView f (Configuration a b c d e g h i j) = fmap (\d' -> Configuration a b c d' e g h i j) (f d)
 
-confIndexView :: Lens' (Configuration a b c) IndexViewSettings
+confIndexView :: ConfigurationLens IndexViewSettings
 confIndexView f (Configuration a b c d e g h i j) = fmap (\e' -> Configuration a b c d e' g h i j) (f e)
 
-confComposeView :: Lens' (Configuration a b c) ComposeViewSettings
+confComposeView :: ConfigurationLens ComposeViewSettings
 confComposeView f (Configuration a b c d e g h i j) = fmap (\g' -> Configuration a b c d e g' h i j) (f g)
 
-confHelpView :: Lens' (Configuration a b c) HelpViewSettings
+confHelpView :: ConfigurationLens HelpViewSettings
 confHelpView f (Configuration a b c d e g h i j) = fmap (\h' -> Configuration a b c d e g h' i j) (f h)
 
-confDefaultView :: Lens' (Configuration a b c) ViewName
+confDefaultView :: ConfigurationLens ViewName
 confDefaultView = lens _confDefaultView (\conf x -> conf { _confDefaultView = x })
 
 confFileBrowserView :: Lens (Configuration a b c) (Configuration a b c') (FileBrowserSettings c) (FileBrowserSettings c')

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -141,19 +141,22 @@ nmNewTag :: Lens' (NotmuchSettings a) Tag
 nmNewTag f (NotmuchSettings a b c) = fmap (\c' -> NotmuchSettings a b c') (f c)
 
 
-data FileBrowserSettings = FileBrowserSettings
+data FileBrowserSettings a = FileBrowserSettings
   { _fbKeybindings :: [Keybinding 'FileBrowser 'ListOfFiles]
   , _fbSearchPathKeybindings :: [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
+  , _fbHomePath :: a
   }
 
-fbKeybindings :: Lens' FileBrowserSettings [Keybinding 'FileBrowser 'ListOfFiles]
+fbKeybindings :: Lens' (FileBrowserSettings a) [Keybinding 'FileBrowser 'ListOfFiles]
 fbKeybindings = lens _fbKeybindings (\cv x -> cv { _fbKeybindings = x })
 
-fbSearchPathKeybindings :: Lens' FileBrowserSettings [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
+fbSearchPathKeybindings :: Lens' (FileBrowserSettings a) [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
 fbSearchPathKeybindings = lens _fbSearchPathKeybindings (\cv x -> cv { _fbSearchPathKeybindings = x})
 
+fbHomePath :: Lens (FileBrowserSettings a) (FileBrowserSettings a') a a'
+fbHomePath = lens _fbHomePath (\s a -> s { _fbHomePath = a })
 
-data Configuration a b = Configuration
+data Configuration a b c = Configuration
     { _confTheme :: Theme
     , _confNotmuch :: NotmuchSettings a
     , _confEditor :: b
@@ -162,37 +165,37 @@ data Configuration a b = Configuration
     , _confComposeView :: ComposeViewSettings
     , _confHelpView :: HelpViewSettings
     , _confDefaultView :: ViewName
-    , _confFileBrowserView :: FileBrowserSettings
+    , _confFileBrowserView :: FileBrowserSettings c
     }
 
-type UserConfiguration = Configuration (IO FilePath) (IO String)
-type InternalConfiguration = Configuration FilePath String
+type UserConfiguration = Configuration (IO FilePath) (IO String) (IO FilePath)
+type InternalConfiguration = Configuration FilePath String FilePath
 
-confTheme :: Lens' (Configuration a b) Theme
+confTheme :: Lens' (Configuration a b c) Theme
 confTheme = lens _confTheme (\c x -> c { _confTheme = x })
 
-confEditor :: Lens (Configuration a b) (Configuration a b') b b'
+confEditor :: Lens (Configuration a b c) (Configuration a b' c) b b'
 confEditor f (Configuration a b c d e g h i j) = fmap (\c' -> Configuration a b c' d e g h i j) (f c)
 
-confNotmuch :: Lens (Configuration a c) (Configuration b c) (NotmuchSettings a) (NotmuchSettings b)
+confNotmuch :: Lens (Configuration a b c) (Configuration a' b c) (NotmuchSettings a) (NotmuchSettings a')
 confNotmuch f (Configuration a b c d e g h i j) = fmap (\b' -> Configuration a b' c d e g h i j) (f b)
 
-confMailView :: Lens' (Configuration a b) MailViewSettings
+confMailView :: Lens' (Configuration a b c) MailViewSettings
 confMailView f (Configuration a b c d e g h i j) = fmap (\d' -> Configuration a b c d' e g h i j) (f d)
 
-confIndexView :: Lens' (Configuration a b) IndexViewSettings
+confIndexView :: Lens' (Configuration a b c) IndexViewSettings
 confIndexView f (Configuration a b c d e g h i j) = fmap (\e' -> Configuration a b c d e' g h i j) (f e)
 
-confComposeView :: Lens' (Configuration a b) ComposeViewSettings
+confComposeView :: Lens' (Configuration a b c) ComposeViewSettings
 confComposeView f (Configuration a b c d e g h i j) = fmap (\g' -> Configuration a b c d e g' h i j) (f g)
 
-confHelpView :: Lens' (Configuration a b) HelpViewSettings
+confHelpView :: Lens' (Configuration a b c) HelpViewSettings
 confHelpView f (Configuration a b c d e g h i j) = fmap (\h' -> Configuration a b c d e g h' i j) (f h)
 
-confDefaultView :: Lens' (Configuration a b) ViewName
+confDefaultView :: Lens' (Configuration a b c) ViewName
 confDefaultView = lens _confDefaultView (\conf x -> conf { _confDefaultView = x })
 
-confFileBrowserView :: Lens' (Configuration a b) FileBrowserSettings
+confFileBrowserView :: Lens (Configuration a b c) (Configuration a b c') (FileBrowserSettings c) (FileBrowserSettings c')
 confFileBrowserView = lens _confFileBrowserView (\conf x -> conf { _confFileBrowserView = x })
 
 data ComposeViewSettings = ComposeViewSettings

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -108,7 +108,7 @@ data Compose = Compose
     , _cFrom :: E.Editor T.Text Name
     , _cTo :: E.Editor T.Text Name
     , _cSubject :: E.Editor T.Text Name
-    , _cAttachments :: L.List Name Mail.Part
+    , _cAttachments :: L.List Name MailPart
     }
 
 cMail :: Lens' Compose Mail.Mail
@@ -123,8 +123,21 @@ cTo = lens _cTo (\c x -> c { _cTo = x })
 cSubject :: Lens' Compose (E.Editor T.Text Name)
 cSubject = lens _cSubject (\c x -> c { _cSubject = x })
 
-cAttachments :: Lens' Compose (L.List Name Mail.Part)
+cAttachments :: Lens' Compose (L.List Name MailPart)
 cAttachments = lens _cAttachments (\c x -> c { _cAttachments = x })
+
+data AttachmentType
+    = Inline
+    | Attachment
+    deriving (Eq,Show)
+
+data MailPart =
+    MailPart AttachmentType
+             Mail.Part
+    deriving (Eq,Show)
+
+mailPart :: Lens' MailPart Mail.Part
+mailPart f (MailPart a b) = fmap (\b' -> MailPart a b') (f b)
 
 data NotmuchSettings a = NotmuchSettings
     { _nmSearch :: T.Text

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -324,7 +324,12 @@ vsFocusedView = lens _vsFocusedView (\settings x -> settings { _vsFocusedView = 
 data FileSystemEntry
     = Directory String
     | File String
-    deriving (Show)
+    deriving (Show,Ord,Eq)
+
+fsEntryName :: Getter FileSystemEntry String
+fsEntryName = let toName (Directory n) = n
+                  toName (File n) = n
+              in to toName
 
 data FileBrowser = CreateFileBrowser
   { _fbEntries :: L.List Name (Bool, FileSystemEntry)

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -76,6 +76,7 @@ handleViewEvent = f where
   f ViewMail _ = dispatch eventHandlerScrollingMailView
   f _ ScrollingHelpView = dispatch eventHandlerScrollingHelpView
   f _ ListOfFiles = dispatch eventHandlerComposeFileBrowser
+  f _ ManageFileBrowserSearchPath = dispatch eventHandlerManageFileBrowserSearchPath
   f _ _ = dispatch nullEventHandler
 
 
@@ -109,11 +110,12 @@ initialState conf = do
                           , (FileBrowser, filebrowserView)]
                     , _vsFocusedView = focusRing [Threads, Mails, ViewMail, Help, ComposeView, FileBrowser]
                     }
-                bf = CreateFileBrowser
+                path = view (confFileBrowserView . fbHomePath) conf
+                fb = CreateFileBrowser
                      (L.list ListOfFiles Vector.empty 1)
-                     (E.editor ManageFileBrowserSearchPath Nothing "")
+                     (E.editor ManageFileBrowserSearchPath Nothing path)
             in pure $
-               AppState conf mi mv initialCompose Nothing viewsettings bf
+               AppState conf mi mv initialCompose Nothing viewsettings fb
 
 theApp :: AppState -> M.App AppState e Name
 theApp s =

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -43,6 +43,6 @@ listOfAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'e') []) invokeEditor
+    , Keybinding (V.EvKey (V.KChar 'e') []) edit
     , Keybinding (V.EvKey (V.KChar 'a') []) (noop `chain'` (focus :: Action 'FileBrowser 'ListOfFiles AppState) `chain` continue)
     ] <> commonKeybindings

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -43,4 +43,5 @@ listOfAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'e') []) invokeEditor
     ] <> commonKeybindings

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -44,4 +44,5 @@ listOfAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'e') []) invokeEditor
+    , Keybinding (V.EvKey (V.KChar 'a') []) (noop `chain'` (focus :: Action 'FileBrowser 'ListOfFiles AppState) `chain` continue)
     ] <> commonKeybindings

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -44,5 +44,6 @@ listOfAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'e') []) edit
+    , Keybinding (V.EvKey (V.KChar 'D') []) (delete `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'a') []) (noop `chain'` (focus :: Action 'FileBrowser 'ListOfFiles AppState) `chain` continue)
     ] <> commonKeybindings

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -4,7 +4,7 @@
 module UI.ComposeEditor.Main (attachmentsEditor) where
 
 import Brick.Types (Padding(..), Widget)
-import Brick.Widgets.Core (padRight, txt, (<+>), withAttr)
+import Brick.Widgets.Core (padLeft, padRight, txt, (<+>), withAttr)
 import qualified Brick.Widgets.List as L
 import Network.Mail.Mime (Part(..))
 import Control.Lens (view)
@@ -20,10 +20,12 @@ attachmentsEditor s =
         attachmentsList = L.renderList renderPart hasFocus (view (asCompose . cAttachments) s)
     in attachmentsList
 
-renderPart :: Bool -> Part -> Widget Name
-renderPart selected p =
+renderPart :: Bool -> MailPart -> Widget Name
+renderPart selected (MailPart aType p) =
   let pType = partType p
       pFilename = fromMaybe "--" (partFilename p)
       listItemAttr = if selected then listSelectedAttr else listAttr
-      widget = padRight Max (txt pFilename) <+> txt pType
+      attachmentType Inline = txt "I"
+      attachmentType _ = txt "A"
+      widget = padRight (Pad 1) (padLeft (Pad 1) $ attachmentType aType) <+> padRight Max (txt pFilename) <+> txt pType
   in withAttr listItemAttr widget

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -4,22 +4,26 @@
 module UI.ComposeEditor.Main (attachmentsEditor) where
 
 import Brick.Types (Padding(..), Widget)
-import Brick.Widgets.Core (padRight, txt, (<+>),)
+import Brick.Widgets.Core (padRight, txt, (<+>), withAttr)
 import qualified Brick.Widgets.List as L
 import Network.Mail.Mime (Part(..))
 import Control.Lens (view)
 import Data.Maybe (fromMaybe)
 
+import Config.Main (listSelectedAttr, listAttr)
 import UI.Utils (focusedViewWidget)
 import Types
 
 attachmentsEditor :: AppState -> Widget Name
 attachmentsEditor s =
     let hasFocus = ListOfAttachments == focusedViewWidget s ComposeFrom
-        attachmentsList = L.renderList (\_ i -> renderPart i) hasFocus (view (asCompose . cAttachments) s)
+        attachmentsList = L.renderList renderPart hasFocus (view (asCompose . cAttachments) s)
     in attachmentsList
 
-renderPart :: Part -> Widget Name
-renderPart p = let pType = partType p
-                   pFilename = fromMaybe "--" (partFilename p)
-               in padRight Max (txt pFilename) <+> txt pType
+renderPart :: Bool -> Part -> Widget Name
+renderPart selected p =
+  let pType = partType p
+      pFilename = fromMaybe "--" (partFilename p)
+      listItemAttr = if selected then listSelectedAttr else listAttr
+      widget = padRight Max (txt pFilename) <+> txt pType
+  in withAttr listItemAttr widget

--- a/src/UI/FileBrowser/Keybindings.hs
+++ b/src/UI/FileBrowser/Keybindings.hs
@@ -16,7 +16,7 @@ fileBrowserKeybindings =
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar ' ') []) (toggleListItem `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'u') [V.MCtrl]) (parentDirectory `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (enterDirectory `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (enterDirectory `chain` createAttachments `chain` continue)
     , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` (focus :: Action 'FileBrowser 'ManageFileBrowserSearchPath AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)

--- a/src/UI/FileBrowser/Keybindings.hs
+++ b/src/UI/FileBrowser/Keybindings.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds #-}
+module UI.FileBrowser.Keybindings where
+
+import qualified Graphics.Vty as V
+import UI.Actions
+import Types
+
+-- | Default Keybindings
+fileBrowserKeybindings :: [Keybinding 'FileBrowser 'ListOfFiles]
+fileBrowserKeybindings =
+    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
+    , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
+    -- Enter
+    ]
+
+manageSearchPathKeybindings :: [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
+manageSearchPathKeybindings = []

--- a/src/UI/FileBrowser/Keybindings.hs
+++ b/src/UI/FileBrowser/Keybindings.hs
@@ -14,8 +14,16 @@ fileBrowserKeybindings =
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
-    -- Enter
+    , Keybinding (V.EvKey (V.KChar ' ') []) (toggleListItem `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'u') [V.MCtrl]) (parentDirectory `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (enterDirectory `chain` continue)
+    , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` (focus :: Action 'FileBrowser 'ManageFileBrowserSearchPath AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     ]
 
 manageSearchPathKeybindings :: [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
-manageSearchPathKeybindings = []
+manageSearchPathKeybindings =
+  [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'FileBrowser 'ListOfFiles AppState) `chain` continue)
+  , Keybinding (V.EvKey V.KEnter []) (done `chain` continue)
+  ]

--- a/src/UI/FileBrowser/Main.hs
+++ b/src/UI/FileBrowser/Main.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE OverloadedStrings #-}
+module UI.FileBrowser.Main
+       (renderFileBrowser, renderFileBrowserSearchPathEditor) where
+
+import Brick.Types (Widget, Padding(..))
+import Brick.Widgets.Core
+       (str, txt, withAttr, (<+>), vLimit, padRight)
+import qualified Brick.Widgets.Edit as E
+
+import qualified Brick.Widgets.List as L
+import Control.Lens.Getter (view)
+import Config.Main (listSelectedAttr)
+import UI.Draw.Main (fillLine)
+import UI.Utils (focusedViewWidget)
+import Types
+
+renderFileBrowser :: AppState -> Widget Name
+renderFileBrowser s = L.renderList drawListItem (ListOfFiles == focusedViewWidget s ListOfThreads)
+                      $ view (asFileBrowser . fbEntries) s
+
+drawListItem :: Bool -> (Bool, FileSystemEntry) -> Widget Name
+drawListItem sel (toggled, x) = let toggled2Widget = if sel || toggled then withAttr listSelectedAttr else id
+                                in toggled2Widget $ str (show x) <+> fillLine
+
+renderFileBrowserSearchPathEditor :: AppState -> Widget Name
+renderFileBrowserSearchPathEditor s =
+  let hasFocus = ManageFileBrowserSearchPath == focusedViewWidget s ListOfThreads
+      editorDrawContent = str . unlines
+      inputW = E.renderEditor editorDrawContent hasFocus (view (asFileBrowser . fbSearchPath) s)
+      labelW = padRight (Pad 1) $ txt "Path:"
+  in labelW <+> vLimit 1 inputW

--- a/src/UI/FileBrowser/Main.hs
+++ b/src/UI/FileBrowser/Main.hs
@@ -4,12 +4,12 @@ module UI.FileBrowser.Main
 
 import Brick.Types (Widget, Padding(..))
 import Brick.Widgets.Core
-       (str, txt, withAttr, (<+>), vLimit, padRight)
+       (str, txt, withAttr, (<+>), vLimit, padRight, padLeft)
 import qualified Brick.Widgets.Edit as E
 
 import qualified Brick.Widgets.List as L
 import Control.Lens.Getter (view)
-import Config.Main (listSelectedAttr)
+import Config.Main (listSelectedAttr, listAttr)
 import UI.Draw.Main (fillLine)
 import UI.Utils (focusedViewWidget)
 import Types
@@ -19,8 +19,11 @@ renderFileBrowser s = L.renderList drawListItem (ListOfFiles == focusedViewWidge
                       $ view (asFileBrowser . fbEntries) s
 
 drawListItem :: Bool -> (Bool, FileSystemEntry) -> Widget Name
-drawListItem sel (toggled, x) = let toggled2Widget = if sel || toggled then withAttr listSelectedAttr else id
-                                in toggled2Widget $ str (show x) <+> fillLine
+drawListItem sel (toggled, x) = let attr = if sel then withAttr listSelectedAttr else withAttr listAttr
+                                    toggledWidget = if toggled then txt "☑" else txt "☐"
+                                in attr $ padLeft (Pad 1) $ toggledWidget
+                                   <+> padLeft (Pad 1) (renderFileSystemEntry x)
+                                   <+> fillLine
 
 renderFileBrowserSearchPathEditor :: AppState -> Widget Name
 renderFileBrowserSearchPathEditor s =
@@ -29,3 +32,7 @@ renderFileBrowserSearchPathEditor s =
       inputW = E.renderEditor editorDrawContent hasFocus (view (asFileBrowser . fbSearchPath) s)
       labelW = padRight (Pad 1) $ txt "Path:"
   in labelW <+> vLimit 1 inputW
+
+renderFileSystemEntry :: FileSystemEntry -> Widget Name
+renderFileSystemEntry (Directory name) = txt "📂" <+> padLeft (Pad 1) (str name)
+renderFileSystemEntry (File name) = txt "-" <+> padLeft (Pad 1) (str name)

--- a/src/UI/GatherHeaders/Main.hs
+++ b/src/UI/GatherHeaders/Main.hs
@@ -9,12 +9,13 @@ import Brick.Types (Widget)
 
 import Types
 import UI.Draw.Main (renderEditorWithLabel)
+import UI.Utils (focusedViewWidget)
 
 drawFrom :: AppState -> Widget Name
-drawFrom s = renderEditorWithLabel "From:" True (view (asCompose . cFrom) s)
+drawFrom s = renderEditorWithLabel "From:" (ComposeFrom == focusedViewWidget s ComposeFrom) (view (asCompose . cFrom) s)
 
 drawTo :: AppState -> Widget Name
-drawTo s = renderEditorWithLabel "To:" True (view (asCompose . cTo) s)
+drawTo s = renderEditorWithLabel "To:" (ComposeTo == focusedViewWidget s ComposeFrom) (view (asCompose . cTo) s)
 
 drawSubject :: AppState -> Widget Name
-drawSubject s = renderEditorWithLabel "Subject:" True (view (asCompose . cSubject) s)
+drawSubject s = renderEditorWithLabel "Subject:" (ComposeSubject == focusedViewWidget s ComposeFrom) (view (asCompose . cSubject) s)

--- a/src/UI/Help/Keybindings.hs
+++ b/src/UI/Help/Keybindings.hs
@@ -10,6 +10,8 @@ import Types
 helpKeybindings :: [Keybinding 'Help 'ScrollingHelpView]
 helpKeybindings =
     [ Keybinding (EvKey KEsc []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    , Keybinding (EvKey (KChar 'q') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)
     , Keybinding (EvKey (KChar ' ') []) (scrollPageDown `chain` continue)
+    , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)
     ]

--- a/src/UI/Help/Main.hs
+++ b/src/UI/Help/Main.hs
@@ -24,6 +24,9 @@ renderHelp s = let tweak = views (asConfig . confIndexView . ivBrowseMailsKeybin
                          <=> views (asConfig . confIndexView . ivManageThreadTagsKeybindings) (renderKbGroup ManageThreadTagsEditor) s
                          <=> views (asConfig . confMailView . mvKeybindings) (renderKbGroup ScrollingMailView) s
                          <=> views (asConfig . confHelpView . hvKeybindings) (renderKbGroup ScrollingHelpView) s
+                         <=> views (asConfig . confComposeView . cvListOfAttachmentsKeybindings) (renderKbGroup ListOfAttachments) s
+                         <=> views (asConfig . confFileBrowserView . fbKeybindings) (renderKbGroup ListOfFiles) s
+                         <=> views (asConfig . confFileBrowserView . fbSearchPathKeybindings) (renderKbGroup ManageFileBrowserSearchPath) s
              in viewport ScrollingHelpView T.Vertical tweak
 
 renderKbGroup :: Titleize a => a -> [Keybinding v ctx] -> Widget Name

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -24,7 +24,6 @@ browseMailKeybindings =
     , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'Mails 'ManageMailTagsEditor AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'm') []) (noop `chain'` (focus :: Action 'Mails 'ComposeFrom AppState) `chain` continue)
     ]
 
 browseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -110,3 +110,8 @@ eventHandlerComposeListOfAttachments :: EventHandler 'ComposeView 'ListOfAttachm
 eventHandlerComposeListOfAttachments = EventHandler
   (asConfig . confComposeView . cvListOfAttachmentsKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asCompose . cAttachments) L.handleListEvent)
+
+eventHandlerComposeFileBrowser :: EventHandler 'FileBrowser 'ListOfFiles
+eventHandlerComposeFileBrowser = EventHandler
+  (asConfig . confFileBrowserView . fbKeybindings)
+  (\s -> Brick.continue <=< Brick.handleEventLensed s (asFileBrowser . fbEntries) L.handleListEvent)

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -115,3 +115,8 @@ eventHandlerComposeFileBrowser :: EventHandler 'FileBrowser 'ListOfFiles
 eventHandlerComposeFileBrowser = EventHandler
   (asConfig . confFileBrowserView . fbKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asFileBrowser . fbEntries) L.handleListEvent)
+
+eventHandlerManageFileBrowserSearchPath :: EventHandler 'FileBrowser 'ManageFileBrowserSearchPath
+eventHandlerManageFileBrowserSearchPath = EventHandler
+  (asConfig . confFileBrowserView . fbSearchPathKeybindings)
+  (\s -> Brick.continue <=< Brick.handleEventLensed s (asFileBrowser . fbSearchPath) E.handleEditorEvent)

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -38,6 +38,7 @@ statusbar s =
                 ListOfMails -> renderStatusbar (view (asMailIndex . miListOfMails) s) s
                 ScrollingMailView -> renderStatusbar (view (asMailView . mvMail) s) s
                 ListOfAttachments -> renderStatusbar (view (asCompose . cAttachments) s) s
+                ListOfFiles -> renderStatusbar (view (asFileBrowser . fbEntries) s) s
                 ComposeTo -> renderStatusbar (view (asCompose . cTo) s) s
                 ComposeFrom -> renderStatusbar (view (asCompose . cFrom) s) s
                 ComposeSubject -> renderStatusbar (view (asCompose . cSubject) s) s
@@ -50,6 +51,9 @@ instance WithContext (L.List Name NotmuchThread) where
   renderContext _ = currentItemW
 
 instance WithContext (L.List Name NotmuchMail) where
+  renderContext _ = currentItemW
+
+instance WithContext (L.List Name (Bool, FileSystemEntry)) where
   renderContext _ = currentItemW
 
 instance WithContext (L.List Name Part) where

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -5,12 +5,11 @@ module UI.Status.Main where
 
 import Brick.Types (Widget, Padding(..))
 import Brick.Widgets.Core
-       (txt, str, withAttr, (<+>), strWrap, vLimit, fill, padRight)
+       (txt, str, withAttr, (<+>), strWrap, padRight)
 import qualified Brick.Widgets.List  as L
 import qualified Brick.Widgets.Edit  as E
 import Control.Lens (view)
 import Data.MIME (MIMEMessage)
-import Network.Mail.Mime (Part)
 import Data.Semigroup ((<>))
 import Data.Text (Text)
 import Data.Text.Zipper (cursorPosition)
@@ -56,8 +55,8 @@ instance WithContext (L.List Name NotmuchMail) where
 instance WithContext (L.List Name (Bool, FileSystemEntry)) where
   renderContext _ = currentItemW
 
-instance WithContext (L.List Name Part) where
-  renderContext _ _ = txt "-- Attachments " <+> vLimit 1 (fill '-')
+instance WithContext (L.List Name MailPart) where
+  renderContext _ = currentItemW
 
 instance WithContext (E.Editor Text Name) where
   renderContext _ = str . show . cursorPosition . view E.editContentsL

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 -- This file is part of purebred
 -- Copyright (C) 2017 Fraser Tweedale and Róman Joost
 --
@@ -17,16 +18,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module UI.Utils
        (safeUpdate, focusedViewWidget, focusedViewWidgets,
-        focusedViewName, focusedView, titleize, Titleize)
+        focusedViewName, focusedView, titleize, Titleize, toggledItems)
        where
 import qualified Data.Vector as Vector
 import Data.Foldable (toList)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text, pack)
-import Control.Lens (view, at, _Just)
+import Control.Lens (folded, filtered, toListOf, Lens', view, at, _Just)
 import Brick.Focus (focusGetCurrent)
+import qualified Brick.Widgets.List as L
 
 import UI.Views (indexView)
+
+
 import Types
 
 safeUpdate :: Foldable t => Vector.Vector a -> t (Int, a) -> Vector.Vector a
@@ -51,6 +55,9 @@ focusedViewName s =
 focusedView :: AppState -> View
 focusedView s = let focused = view (asViews . vsViews . at (focusedViewName s)) s
                 in fromMaybe indexView focused
+
+toggledItems :: AppState -> Lens' AppState (L.List Name (Bool, a)) -> [(Bool, a)]
+toggledItems s l = toListOf (l . L.listElementsL . folded . filtered fst) s
 
 class Titleize a where
   titleize :: a -> Text

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -81,6 +81,9 @@ instance Titleize Name where
   titleize ComposeTo = "Editor to Compose a new Mail"
   titleize ComposeFrom = "Editor to Compose a new Mail"
   titleize ComposeSubject = "Editor to Compose a new Mail"
+  titleize ListOfFiles = "Directory Listing"
+  titleize ListOfAttachments = "Attachments"
+  titleize ManageFileBrowserSearchPath = "Filepath for Directory Listing"
   titleize m = pack $ show m
 
 instance Titleize ViewName where

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -1,5 +1,5 @@
 module UI.Views
-       (indexView, listOfMailsView, mailView, composeView, helpView) where
+       (indexView, listOfMailsView, mailView, composeView, helpView, filebrowserView) where
 
 import Brick.Focus (focusRing)
 import Types
@@ -43,4 +43,11 @@ helpView =
     View
     { _vFocus = focusRing [ScrollingHelpView]
     , _vWidgets = [ScrollingHelpView]
+    }
+
+filebrowserView :: View
+filebrowserView =
+    View
+    { _vFocus = focusRing [ListOfFiles, ManageFileBrowserSearchPath]
+    , _vWidgets = [ListOfFiles, StatusBar, ManageFileBrowserSearchPath]
     }

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -2,22 +2,40 @@
 {-# LANGUAGE OverloadedStrings #-}
 module TestActions where
 
-import Types
-import UI.Actions
+import qualified Brick.Widgets.List as L
 
-import Control.Lens (view)
+import Control.Lens
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
+import qualified Data.Vector as Vector
+
+import Types
+import UI.Actions
+import UI.Utils (selectedFiles)
+
 
 actionTests ::
   TestTree
 actionTests =
     testGroup
         "action tests"
-        [testModeDescription]
+        [ testModeDescription
+        , testNoDupes
+        ]
 
 testModeDescription :: TestTree
 testModeDescription = testCase "mode present in the switch action"
                       $ view aDescription a @?= ["switch mode to ManageMailTagsEditor"]
   where
     a = focus :: Action 'Mails 'ManageMailTagsEditor AppState
+
+testNoDupes :: TestTree
+testNoDupes =
+    let vec =
+            Vector.fromList
+                [ (True, File "file 1")
+                , (True, File "file 2")
+                , (False, File "file 3")]
+        l = set L.listSelectedL (Just 1) $ L.list ListOfFiles vec 1
+    in testCase "no duplicates when multiple items are selected" $
+       selectedFiles l @?= ["file 1", "file 2"]

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -466,6 +466,18 @@ testSendMail =
           liftIO $ step "exit vim"
           sendKeys ": x\r" (Literal "text/plain")
 
+          liftIO $ step "user can re-edit body"
+          sendKeys "e" (Literal "This is a test body")
+
+          liftIO $ step "Writes more text"
+          sendKeys "i. More text" (Literal "text")
+
+          liftIO $ step "exit insert mode in vim"
+          sendKeys "Escape" (Literal "body")
+
+          liftIO $ step "exit vim"
+          sendKeys ": x\r" (Regex ("text/plain; charset=utf-8\\s" <> buildAnsiRegex [] ["34"] ["40"] <> "\\s+"))
+
           liftIO $ step "send mail and go back to threads"
           sendKeys "y" (Regex ("Query:\\s" <> buildAnsiRegex [] ["34"] [] <> "tag:inbox"))
 


### PR DESCRIPTION
This is it. This adds the file browser with the ability to add attachments, re-edit the mail body, as well as delete the attachments again.

There is still massive room for improvement (e.g. toggling hidden directories or filtering for files), but I thought the current state is a good starting point.