### PR TITLE
Add two themes to choose from

### DIFF
--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -4,8 +4,9 @@ module Config.Main where
 
 import qualified Brick.AttrMap as A
 import qualified Brick.Widgets.List as L
+import Brick.Themes (Theme, newTheme)
 import Data.Monoid ((<>))
-import Brick.Util (fg, on)
+import Brick.Util (fg, on, bg)
 import qualified Brick.Widgets.Edit as E
 import qualified Graphics.Vty as V
 import System.Environment (lookupEnv)
@@ -32,29 +33,63 @@ import UI.ComposeEditor.Keybindings
 import Types
 import Storage.Notmuch (getDatabasePath)
 
-defaultColorMap :: A.AttrMap
-defaultColorMap =
-    A.attrMap
+solarizedDark :: Theme
+solarizedDark =
+    newTheme
         V.defAttr
-        [ (listAttr, V.brightBlue `on` V.black)
+        [ (listAttr, V.brightBlue `on` V.brightBlack)
         , (listSelectedAttr, V.white `on` V.yellow)
         , (listNewMailAttr, fg V.white `V.withStyle` V.bold)
         , (listNewMailSelectedAttr, V.white `on` V.yellow `V.withStyle` V.bold)
         , (mailTagsAttr, fg V.cyan)
         , (mailAuthorsAttr, fg V.white)
-        , (E.editFocusedAttr, V.white `on` V.black)
-        , (E.editAttr, V.brightBlue `on` V.black)
+        , (E.editFocusedAttr, V.white `on` V.brightBlack)
+        , (editorAttr, V.brightBlue `on` V.brightBlack)
+        , (editorLabelAttr, V.brightYellow `on` V.brightBlack)
         , (statusbarErrorAttr, fg V.red)
-        , (statusbarAttr, V.black `on` V.brightWhite)
+        , (statusbarAttr, V.brightYellow `on` V.black)
         , (headerKeyAttr, fg V.cyan)
         , (headerValueAttr, fg V.brightCyan)
         , (helpTitleAttr, fg V.cyan `V.withStyle` V.bold)]
+
+solarizedLight :: Theme
+solarizedLight =
+    newTheme
+        V.defAttr
+        [ (listAttr, V.brightCyan `on` V.brightWhite)
+        , (listSelectedAttr, V.white `on` V.yellow)
+        , (listNewMailAttr, fg V.brightGreen `V.withStyle` V.bold)
+        , (listNewMailSelectedAttr, V.white `on` V.yellow `V.withStyle` V.bold)
+        , (mailTagsAttr, fg V.magenta)
+        , (mailAuthorsAttr, fg V.brightCyan)
+        , (mailSelectedAuthorsAttr, fg V.brightWhite)
+        , (E.editFocusedAttr, V.brightBlack `on` V.brightWhite)
+        , (editorAttr, V.brightBlue `on` V.brightWhite)
+        , (editorLabelAttr, V.brightYellow `on` V.brightWhite)
+        , (statusbarErrorAttr, fg V.red)
+        , (statusbarAttr, V.brightYellow `on` V.white)
+        , (mailViewAttr, bg V.brightWhite)
+        , (headerKeyAttr, V.cyan `on` V.brightWhite)
+        , (headerValueAttr, V.brightCyan `on` V.brightWhite)
+        , (helpTitleAttr, fg V.cyan `V.withStyle` V.bold)]
+
+mailViewAttr :: A.AttrName
+mailViewAttr = "mailview"
 
 statusbarAttr :: A.AttrName
 statusbarAttr = "statusbar"
 
 statusbarErrorAttr :: A.AttrName
 statusbarErrorAttr = statusbarAttr <> "error"
+
+editorAttr :: A.AttrName
+editorAttr = E.editAttr
+
+editorFocusedAttr :: A.AttrName
+editorFocusedAttr = E.editFocusedAttr
+
+editorLabelAttr :: A.AttrName
+editorLabelAttr = editorAttr <> "label"
 
 listAttr :: A.AttrName
 listAttr = L.listAttr
@@ -77,6 +112,9 @@ mailTagsAttr = mailAttr <> "tags"
 mailAuthorsAttr :: A.AttrName
 mailAuthorsAttr = mailAttr <> "authors"
 
+mailSelectedAuthorsAttr :: A.AttrName
+mailSelectedAuthorsAttr = mailAuthorsAttr <> "selected"
+
 headerAttr :: A.AttrName
 headerAttr = "header"
 
@@ -98,7 +136,7 @@ helpKeybindingAttr = helpAttr <> "keybinding"
 defaultConfig :: UserConfiguration
 defaultConfig =
     Configuration
-    { _confColorMap = defaultColorMap
+    { _confTheme = solarizedDark
     , _confNotmuch = NotmuchSettings
       { _nmSearch = "tag:inbox"
       , _nmDatabase = getDatabasePath

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -12,7 +12,8 @@ module Purebred (
   renderMail',
   getDatabasePath,
   defaultConfig,
-  defaultColorMap,
+  solarizedDark,
+  solarizedLight,
   over,
   set,
   (&),
@@ -41,7 +42,7 @@ import UI.Index.Keybindings
 import UI.Mail.Keybindings
 import UI.Actions
 import Storage.Notmuch (getDatabasePath)
-import Config.Main (defaultConfig, defaultColorMap)
+import Config.Main (defaultConfig, solarizedDark, solarizedLight)
 import Types
 
 -- re-exports for configuration

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -8,8 +8,8 @@ module Types
   ) where
 
 import Data.Semigroup (Semigroup, (<>))
-import qualified Brick.AttrMap as Brick
 import qualified Brick.Focus as Brick
+import Brick.Themes (Theme)
 import Brick.Widgets.Core ((<=>), emptyWidget)
 import Brick.Types (EventM, Next, Widget)
 import qualified Brick.Widgets.Edit as E
@@ -139,7 +139,7 @@ nmNewTag :: Lens' (NotmuchSettings a) Tag
 nmNewTag f (NotmuchSettings a b c) = fmap (\c' -> NotmuchSettings a b c') (f c)
 
 data Configuration a b = Configuration
-    { _confColorMap :: Brick.AttrMap
+    { _confTheme :: Theme
     , _confNotmuch :: NotmuchSettings a
     , _confEditor :: b
     , _confMailView :: MailViewSettings
@@ -152,8 +152,8 @@ data Configuration a b = Configuration
 type UserConfiguration = Configuration (IO FilePath) (IO String)
 type InternalConfiguration = Configuration FilePath String
 
-confColorMap :: Getter (Configuration a b) Brick.AttrMap
-confColorMap = to (\(Configuration a _ _ _ _ _ _ _) -> a)
+confTheme :: Lens' (Configuration a b) Theme
+confTheme = lens _confTheme (\c x -> c { _confTheme = x })
 
 confEditor :: Lens (Configuration a b) (Configuration a b') b b'
 confEditor f (Configuration a b c d e g h i) = fmap (\c' -> Configuration a b c' d e g h i) (f c)

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -7,11 +7,12 @@ import qualified Brick.Main as M
 import Brick.Types (Widget)
 import Brick.Focus (focusRing)
 import Brick.Widgets.Core (vLimit)
+import Brick.Themes (themeToAttrMap)
 import qualified Brick.Types as T
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
 import qualified Graphics.Vty.Input.Events as Vty
-import Control.Lens.Getter (view)
+import Control.Lens (to, view)
 import Control.Monad.Except (runExceptT)
 import qualified Data.Vector as Vector
 import System.Exit (die)
@@ -109,5 +110,5 @@ theApp s =
     , M.appChooseCursor = M.showFirstCursor
     , M.appHandleEvent = appEvent
     , M.appStartEvent = return
-    , M.appAttrMap = const (view (asConfig . confColorMap) s)
+    , M.appAttrMap = const (view (asConfig . confTheme . to themeToAttrMap) s)
     }

--- a/src/UI/Draw/Main.hs
+++ b/src/UI/Draw/Main.hs
@@ -3,10 +3,11 @@
 module UI.Draw.Main where
 
 import Brick.Types (Padding(..), Widget)
-import Brick.Widgets.Core (fill, txt, vLimit, padRight, (<+>))
+import Brick.Widgets.Core (fill, txt, vLimit, padRight, (<+>), withAttr)
 import qualified Brick.Widgets.Edit as E
 import qualified Data.Text as T
 import Types
+import Config.Main (editorLabelAttr, editorAttr, editorFocusedAttr)
 
 fillLine :: Widget Name
 fillLine = vLimit 1 (fill ' ')
@@ -21,5 +22,6 @@ renderEditorWithLabel :: T.Text
                       -> Widget Name
 renderEditorWithLabel label hasFocus e =
   let inputW = E.renderEditor editorDrawContent hasFocus e
-      labelW = padRight (Pad 1) $ txt label
-  in labelW <+> vLimit 1 inputW
+      labelW = withAttr editorLabelAttr $ padRight (Pad 1) $ txt label
+      eAttr = if hasFocus then editorFocusedAttr else editorAttr
+  in labelW <+> withAttr eAttr (vLimit 1 inputW)

--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -27,7 +27,8 @@ import Storage.Notmuch (hasTag)
 import Types
 import Config.Main
        (listNewMailAttr, listNewMailSelectedAttr, mailTagsAttr,
-        listSelectedAttr, listAttr, mailAuthorsAttr)
+        listSelectedAttr, listAttr, mailAuthorsAttr,
+        mailSelectedAuthorsAttr)
 
 renderListOfThreads :: AppState -> Widget Name
 renderListOfThreads s = L.renderList (listDrawThread s) True $ view (asMailIndex . miListOfThreads) s
@@ -56,7 +57,7 @@ listDrawMail s sel a =
         isNewMail = hasTag (view nmNewTag settings) a
         widget = padLeft (Pad 1) (txt $ formatDate (view mailDate a)) <+>
                  padLeft (Pad 1) (renderTagsWidget (view mailTags a) (view nmNewTag settings)) <+>
-                 padLeft (Pad 1) (renderAuthors $ view mailFrom a) <+>
+                 padLeft (Pad 1) (renderAuthors sel $ view mailFrom a) <+>
                  padLeft (Pad 1) (txt (view mailSubject a)) <+> fillLine
     in withAttr (getListAttr isNewMail sel) widget
 
@@ -67,7 +68,7 @@ listDrawThread s sel a =
         widget = padLeft (Pad 1) (txt $ formatDate (view thDate a)) <+>
                  padLeft (Pad 1) (txt $ pack $ "(" <> show (view thReplies a) <> ")") <+>
                  padLeft (Pad 1) (renderTagsWidget (view thTags a) (view nmNewTag settings)) <+>
-                 padLeft (Pad 1) (renderAuthors $ T.unwords $ view thAuthors a) <+>
+                 padLeft (Pad 1) (renderAuthors sel $ T.unwords $ view thAuthors a) <+>
                  padLeft (Pad 1) (txt (view thSubject a)) <+> fillLine
     in withAttr (getListAttr isNewMail sel) widget
 
@@ -82,8 +83,13 @@ getListAttr False False = listAttr  -- not selected and not new
 formatDate :: UTCTime -> Text
 formatDate t = pack $ formatTime defaultTimeLocale "%d/%b" (utctDay t)
 
-renderAuthors :: Text -> Widget Name
-renderAuthors authors = withAttr mailAuthorsAttr $ hLimit 15 (txt authors)
+renderAuthors :: Bool -> Text -> Widget Name
+renderAuthors isSelected authors =
+    let attribute =
+            if isSelected
+                then mailSelectedAuthorsAttr
+                else mailAuthorsAttr
+    in withAttr attribute $ hLimit 15 (txt authors)
 
 renderTagsWidget :: [Tag] -> Tag -> Widget Name
 renderTagsWidget tgs ignored =

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -17,7 +17,7 @@ import qualified Data.Text as T
 import Data.MIME
 
 import Types
-import Config.Main (headerKeyAttr, headerValueAttr)
+import Config.Main (headerKeyAttr, headerValueAttr, mailViewAttr)
 
 -- | Instead of using the entire rendering area to show the email, we still show
 -- the index in context above the mail.
@@ -28,7 +28,7 @@ renderMailView :: AppState -> Widget Name
 renderMailView s = viewport ScrollingMailView Vertical (mailView s (view (asMailView . mvMail) s))
 
 mailView :: AppState -> Maybe MIMEMessage -> Widget Name
-mailView s (Just msg) = messageToMailView s msg
+mailView s (Just msg) = withAttr mailViewAttr $ messageToMailView s msg
 mailView _ Nothing = txt "Eeek: this is not supposed to happen"
 
 messageToMailView :: AppState -> MIMEMessage -> Widget Name

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -144,7 +144,7 @@ testManageTagsOnMails = withTmuxSession "manage tags on mails" $
     sendKeys "Enter" (Literal "Testmail")
 
     liftIO $ step "focus command to show mail tags"
-    sendKeys "`" (Regex (buildAnsiRegex [] ["37"] ["40"]))
+    sendKeys "`" (Regex (buildAnsiRegex [] ["37"] []))
 
     liftIO $ step "enter new tag"
     _ <- sendLiteralKeys "+inbox +foo +bar"
@@ -161,8 +161,8 @@ testManageTagsOnMails = withTmuxSession "manage tags on mails" $
 
     -- find newly tagged mail
     liftIO $ step "focus tag search"
-    sendKeys ":" (Regex (buildAnsiRegex [] ["37"] ["40"] <> "tag"))
-    sendKeys "C-u" (Regex (buildAnsiRegex [] ["37"] ["40"]))
+    sendKeys ":" (Regex (buildAnsiRegex [] ["37"] [] <> "tag"))
+    sendKeys "C-u" (Regex (buildAnsiRegex [] ["37"] []))
 
     liftIO $ step "enter tag to search `foo and bar`"
     _ <- sendLiteralKeys "tag:foo and tag:bar"
@@ -174,7 +174,7 @@ testManageTagsOnMails = withTmuxSession "manage tags on mails" $
     sendKeys "Enter" (Literal "Testmail")
 
     liftIO $ step "attempt to add a new tag"
-    sendKeys "`" (Regex (buildAnsiRegex [] ["37"] ["40"]))
+    sendKeys "`" (Regex (buildAnsiRegex [] ["37"] []))
 
     liftIO $ step "cancel tagging and expect old UI"
     -- instead of asserting the absence of the tagging editor, we assert the
@@ -201,7 +201,7 @@ testManageTagsOnThreads = withTmuxSession "manage tags on threads" $
     sendKeys "Enter" (Literal "ViewMail")
 
     liftIO $ step "open mail tag editor"
-    sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] ["40"]))
+    sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] []))
 
     liftIO $ step "add new tag"
     _ <- sendLiteralKeys "+archive"
@@ -213,7 +213,7 @@ testManageTagsOnThreads = withTmuxSession "manage tags on threads" $
     sendKeys "Down" (Literal "Item 2 of 2")
 
     liftIO $ step "open mail tag editor"
-    sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] ["40"]))
+    sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] []))
 
     liftIO $ step "add new tag"
     _ <- sendLiteralKeys "+replied -inbox"
@@ -228,7 +228,7 @@ testManageTagsOnThreads = withTmuxSession "manage tags on threads" $
     sendKeys "Escape" (Literal "archive inbox replied")
 
     liftIO $ step "open thread tag editor"
-    sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] ["40"]))
+    sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] []))
 
     liftIO $ step "remove tag"
     -- "cheating" here a bit, since just invoking tmux with sending literally
@@ -361,18 +361,18 @@ testUserCanManipulateNMQuery =
         \step -> do
           startApplication
           liftIO $ step "focus command"
-          sendKeys ":" (Regex (buildAnsiRegex [] ["37"] ["40"] <> "tag"))
+          sendKeys ":" (Regex (buildAnsiRegex [] ["37"] [] <> "tag"))
 
           liftIO $ step "delete all input"
-          sendKeys "C-u" (Regex (buildAnsiRegex [] ["37"] ["40"]))
+          sendKeys "C-u" (Regex ("Query: " <> buildAnsiRegex [] ["37"] []))
 
           liftIO $ step "search for non existing tags yielding no results"
           _ <- sendLiteralKeys "does not match anything"
           sendKeys "Enter" (Literal "No items")
 
           liftIO $ step "search for mail correctly tagged"
-          sendKeys ":" (Regex (buildAnsiRegex [] ["37"] ["40"] <> "does"))
-          sendKeys "C-u" (Regex (buildAnsiRegex [] ["37"] ["40"]))
+          sendKeys ":" (Regex ("Query: " <> buildAnsiRegex [] ["37"] [] <> "does"))
+          sendKeys "C-u" (Regex (buildAnsiRegex [] ["37"] []))
 
           liftIO $ step "enter new tag"
           _ <- sendLiteralKeys "tag:replied"
@@ -411,7 +411,7 @@ testUserCanSwitchBackToIndex =
             sendKeys "Escape" (Literal "body")
 
             liftIO $ step "exit vim"
-            sendKeys ": x\r" (Regex ("From: " <> buildAnsiRegex [] ["37"] ["40"] <> "testuser@foo.test"))
+            sendKeys ": x\r" (Regex ("From: " <> buildAnsiRegex [] ["37"] [] <> "testuser@foo.test"))
 
             liftIO $ step "switch back to index"
             sendKeys "Tab" (Literal "Testmail")
@@ -420,8 +420,8 @@ testUserCanSwitchBackToIndex =
             sendKeys "Tab" (Literal "test subject")
 
             liftIO $ step "cycle to next input field"
-            sendKeys "C-n" (Regex (buildAnsiRegex [] ["39"] ["49"] <> "To:\\s+"
-                                   <> buildAnsiRegex [] ["37"] ["40"] <> "user@to.test"))
+            sendKeys "C-n" (Regex (buildAnsiRegex [] ["33"] [] <> "To:\\s+"
+                                   <> buildAnsiRegex [] ["37"] [] <> "user@to.test"))
             pure ()
 
 testSendMail :: Int -> TestTree
@@ -458,7 +458,7 @@ testSendMail =
           sendKeys ": x\r" (Literal "text/plain")
 
           liftIO $ step "send mail and go back to threads"
-          sendKeys "y" (Regex (buildAnsiRegex [] ["39"] ["49"] <> "Query"))
+          sendKeys "y" (Regex ("Query:\\s" <> buildAnsiRegex [] ["34"] [] <> "tag:inbox"))
 
           let fpath = testdir </> "sentMail"
           contents <- liftIO $ B.readFile fpath


### PR DESCRIPTION
This now adds two themes users can select from: solarizedDark (default) and
solarizedLight. This does not provide the ability to overwrite them with custom
attributes. I decided against it for now, since our executable is already quite
big (24MiB).

Related to https://github.com/purebred-mua/purebred/issues/33