### PR TITLE
Display search editor when tagging is aborted

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -141,7 +141,9 @@ instance Resetable 'ManageMailTagsEditor where
   reset _ s = pure $ s & over (asMailIndex . miMailTagsEditor . E.editContentsL) clearZipper
 
 instance Resetable 'ManageThreadTagsEditor where
-  reset _ s = pure $ s & over (asMailIndex . miThreadTagsEditor . E.editContentsL) clearZipper
+  reset _ s = pure $ s
+              & over (asMailIndex . miThreadTagsEditor . E.editContentsL) clearZipper
+              . over (asViews . vsViews . at (focusedViewName s) . _Just . vWidgets) (replaceEditor SearchThreadsEditor)
 
 instance Resetable 'ComposeFrom where
   reset _ s = pure $ s & over (asCompose . cFrom . E.editContentsL) clearZipper

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -249,6 +249,15 @@ testManageTagsOnThreads = withTmuxSession "manage tags on threads" $
                               <> buildAnsiRegex [] ["37"] []
                               <> "\\sRóman Joost\\s<\\w+\\sRe: WIP Refactor"))
 
+    liftIO $ step "go back to list of threads"
+    sendKeys "Escape" (Literal "List of Threads")
+
+    liftIO $ step "open thread tag editor"
+    sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] ["40"]))
+
+    liftIO $ step "abort editing"
+    sendKeys "Escape" (Literal "Query")
+
     pure ()
 
 testHelp :: Int -> TestTree


### PR DESCRIPTION
Fixes https://github.com/purebred-mua/purebred/issues/189