### PR TITLE
tests: Bump the notmuch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,30 +34,30 @@ addons:
 
 matrix:
   include:
-  - env: STACK_ARGS="--resolver lts-8" NOTMUCHVER=0.24.2
-    compiler: ": #stackage lts-8 (ghc-8.0.2) - notmuch: 0.24.2"
+  - env: STACK_ARGS="--resolver lts-8" NOTMUCHVER=0.26.2
+    compiler: ": #stackage lts-8 (ghc-8.0.2) - notmuch: 0.26.2"
 
-  - env: STACK_ARGS="--resolver lts-8" NOTMUCHVER=0.25
-    compiler: ": #stackage lts-8 (ghc-8.0.2) - notmuch: 0.25"
+  - env: STACK_ARGS="--resolver lts-8" NOTMUCHVER=0.27
+    compiler: ": #stackage lts-8 (ghc-8.0.2) - notmuch: 0.27"
 
-  - env: STACK_ARGS="--resolver lts-9" NOTMUCHVER=0.24.2
-    compiler: ": #stackage lts-9 (ghc-8.0.2) - notmuch: 0.24.2"
+  - env: STACK_ARGS="--resolver lts-9" NOTMUCHVER=0.26.2
+    compiler: ": #stackage lts-9 (ghc-8.0.2) - notmuch: 0.26.2"
 
-  - env: STACK_ARGS="--resolver lts-9" NOTMUCHVER=0.25
-    compiler: ": #stackage lts-9 (ghc-8.0.2) - notmuch: 0.25"
+  - env: STACK_ARGS="--resolver lts-9" NOTMUCHVER=0.27
+    compiler: ": #stackage lts-9 (ghc-8.0.2) - notmuch: 0.27"
 
-  - env: STACK_ARGS="--resolver lts-10" NOTMUCHVER=0.24.2
-    compiler: ": #stackage lts-10 (ghc-8.2.2) - notmuch: 0.24.2"
+  - env: STACK_ARGS="--resolver lts-10" NOTMUCHVER=0.26.2
+    compiler: ": #stackage lts-10 (ghc-8.2.2) - notmuch: 0.26.2"
 
-  - env: STACK_ARGS="--resolver lts-10" NOTMUCHVER=0.25
-    compiler: ": #stackage lts-10 (ghc-8.2.2) - notmuch: 0.25"
+  - env: STACK_ARGS="--resolver lts-10" NOTMUCHVER=0.27
+    compiler: ": #stackage lts-10 (ghc-8.2.2) - notmuch: 0.27"
 
-  - env: STACK_ARGS="--resolver nightly" NOTMUCHVER=0.24.2
-    compiler: ": #stackage nightly - notmuch: 0.24.2"
+  - env: STACK_ARGS="--resolver nightly" NOTMUCHVER=0.26.2
+    compiler: ": #stackage nightly - notmuch: 0.26.2"
 
-  - env: STACK_ARGS="--resolver nightly" NOTMUCHVER=0.25
-    compiler: ": #stackage nightly - notmuch: 0.25"
+  - env: STACK_ARGS="--resolver nightly" NOTMUCHVER=0.27
+    compiler: ": #stackage nightly - notmuch: 0.27"
 
   allow_failures:
-  - env: STACK_ARGS="--resolver nightly" NOTMUCHVER=0.24.2
-  - env: STACK_ARGS="--resolver nightly" NOTMUCHVER=0.25
+  - env: STACK_ARGS="--resolver nightly" NOTMUCHVER=0.26.2
+  - env: STACK_ARGS="--resolver nightly" NOTMUCHVER=0.27


### PR DESCRIPTION
Bump all notmuch versions from 0.24 to 0.26 - 0.27 to test against. Most
distributions ship newer versions and at this point in development there is in
point supporting older notmuch versions.