### PR TITLE
Use new function to match content type

### DIFF
--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -7,7 +7,7 @@ import Brick.Widgets.Core
   (padTop, txt, txtWrap, viewport, (<+>), (<=>), withAttr)
 
 import Control.Applicative ((<|>))
-import Control.Lens (filtered, firstOf, folded, to, toListOf, view)
+import Control.Lens (filtered, firstOf, folded, to, toListOf, view, preview)
 import qualified Data.ByteString as B
 import qualified Data.CaseInsensitive as CI
 import Data.Semigroup ((<>))
@@ -58,7 +58,10 @@ chooseEntity :: AppState -> MIMEMessage -> Maybe WireEntity
 chooseEntity s msg =
   let
     preferredContentType = view (asConfig . confMailView . mvPreferredContentType) s
-    match = ctEq preferredContentType . view (headers . contentType)
+    match x = matchContentType
+      (view (headers . contentType . ctType) x)
+      (preview (headers . contentType . ctSubtype) x)
+      preferredContentType
 
     -- select first entity with matching content-type;
     -- otherwise select first entity;

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,7 +43,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/purebred-mua/purebred-email.git
-    commit: 42afd3b36f1d8d2ae439bed31dee9f784c86c847
+    commit: a016b57faf9e6707690ba2482b6cd83312e162f4
   extra-dep: true
 
 # Dependency packages to be pulled from upstream that are not in the resolver


### PR DESCRIPTION
The ctEq function was deprecated and we want to use the new function to get rid
of the deprecation warning.