### PR TITLE
avoid runs of multiple (<+>) and (<=>)

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -8,11 +8,9 @@ module Types
   , Tag
   ) where
 
-import Data.Semigroup (Semigroup, (<>))
 import qualified Brick.Focus as Brick
 import Brick.Themes (Theme)
-import Brick.Widgets.Core ((<=>), emptyWidget)
-import Brick.Types (EventM, Next, Widget)
+import Brick.Types (EventM, Next)
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
 import Control.Lens
@@ -50,15 +48,6 @@ data Name =
     | StatusBar
     deriving (Eq,Show,Ord)
 
--- | Drawing types
-newtype VBox = VBox { unVBox :: Widget Name }
-
-instance Semigroup VBox where
-  VBox a <> VBox b = VBox (a <=> b)
-
-instance Monoid VBox where
-  mappend = (<>)
-  mempty = VBox emptyWidget
 
 {- | main application interface
 

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
+
 -- | The main application module
 module UI.App where
 
 import qualified Brick.Main as M
 import Brick.Types (Widget)
 import Brick.Focus (focusRing)
-import Brick.Widgets.Core (vLimit)
+import Brick.Widgets.Core (vBox, vLimit)
 import Brick.Themes (themeToAttrMap)
 import qualified Brick.Types as T
 import qualified Brick.Widgets.Edit as E
@@ -39,7 +39,7 @@ import UI.ComposeEditor.Main (attachmentsEditor)
 import Types
 
 drawUI :: AppState -> [Widget Name]
-drawUI s = [unVBox $ foldMap (VBox . renderWidget s (focusedViewName s)) (focusedViewWidgets s)]
+drawUI s = [vBox (renderWidget s (focusedViewName s) <$> focusedViewWidgets s)]
 
 renderWidget :: AppState -> ViewName -> Name -> Widget Name
 renderWidget s _ ListOfThreads = renderListOfThreads s

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -3,8 +3,8 @@
 
 module UI.ComposeEditor.Main (attachmentsEditor) where
 
-import Brick.Types (Padding(..), Widget)
-import Brick.Widgets.Core (padLeft, padRight, txt, (<+>), withAttr)
+import Brick.Types (Padding(Max), Widget)
+import Brick.Widgets.Core (hBox, padLeftRight, padRight, txt, withAttr)
 import qualified Brick.Widgets.List as L
 import Control.Lens (view, preview)
 import Data.Maybe (fromMaybe)
@@ -28,6 +28,10 @@ renderPart selected m =
   let pType = showContentType $ view (headers . contentType) m
       pFilename = fromMaybe "--" (preview (headers . contentDisposition . filename) m)
       listItemAttr = if selected then listSelectedAttr else listAttr
-      attachmentType = if isAttachment m then txt "A" else txt "I"
-      widget = padRight (Pad 1) (padLeft (Pad 1) attachmentType) <+> padRight Max (txt pFilename) <+> txt pType
+      attachmentType = txt (if isAttachment m then "A" else "I")
+      widget = hBox
+        [ padLeftRight 1 attachmentType
+        , padRight Max (txt pFilename)
+        , txt pType
+        ]
   in withAttr listItemAttr widget

--- a/src/UI/FileBrowser/Main.hs
+++ b/src/UI/FileBrowser/Main.hs
@@ -2,9 +2,8 @@
 module UI.FileBrowser.Main
        (renderFileBrowser, renderFileBrowserSearchPathEditor) where
 
-import Brick.Types (Widget, Padding(..))
-import Brick.Widgets.Core
-       (str, txt, withAttr, (<+>), vLimit, padRight, padLeft)
+import Brick.Types (Widget)
+import Brick.Widgets.Core (hBox, str, txt, withAttr, (<+>), vLimit)
 import qualified Brick.Widgets.Edit as E
 
 import qualified Brick.Widgets.List as L
@@ -19,20 +18,24 @@ renderFileBrowser s = L.renderList drawListItem (ListOfFiles == focusedViewWidge
                       $ view (asFileBrowser . fbEntries) s
 
 drawListItem :: Bool -> (Bool, FileSystemEntry) -> Widget Name
-drawListItem sel (toggled, x) = let attr = if sel then withAttr listSelectedAttr else withAttr listAttr
-                                    toggledWidget = if toggled then txt "☑" else txt "☐"
-                                in attr $ padLeft (Pad 1) $ toggledWidget
-                                   <+> padLeft (Pad 1) (renderFileSystemEntry x)
-                                   <+> fillLine
+drawListItem sel (toggled, x) =
+  let attr = withAttr $ if sel then listSelectedAttr else listAttr
+      toggledWidget = txt $ if toggled then " ☑ " else " ☐ "
+  in
+    attr $ hBox
+      [ toggledWidget
+      , renderFileSystemEntry x
+      , fillLine
+      ]
 
 renderFileBrowserSearchPathEditor :: AppState -> Widget Name
 renderFileBrowserSearchPathEditor s =
   let hasFocus = ManageFileBrowserSearchPath == focusedViewWidget s ListOfThreads
       editorDrawContent = str . unlines
       inputW = E.renderEditor editorDrawContent hasFocus (view (asFileBrowser . fbSearchPath) s)
-      labelW = padRight (Pad 1) $ txt "Path:"
+      labelW = txt "Path: "
   in labelW <+> vLimit 1 inputW
 
 renderFileSystemEntry :: FileSystemEntry -> Widget Name
-renderFileSystemEntry (Directory name) = txt "📂" <+> padLeft (Pad 1) (str name)
-renderFileSystemEntry (File name) = txt "-" <+> padLeft (Pad 1) (str name)
+renderFileSystemEntry (Directory name) = txt "📂 " <+> str name
+renderFileSystemEntry (File name) = txt "- " <+> str name

--- a/src/UI/Help/Main.hs
+++ b/src/UI/Help/Main.hs
@@ -17,17 +17,18 @@ import Types
 import UI.Utils (titleize, Titleize)
 
 renderHelp :: AppState -> Widget Name
-renderHelp s = let tweak = views (asConfig . confIndexView . ivBrowseMailsKeybindings) (renderKbGroup ListOfMails) s
-                         <=> views (asConfig . confIndexView . ivBrowseThreadsKeybindings) (renderKbGroup ListOfThreads) s
-                         <=> views (asConfig . confIndexView . ivSearchThreadsKeybindings) (renderKbGroup SearchThreadsEditor) s
-                         <=> views (asConfig . confIndexView . ivManageMailTagsKeybindings) (renderKbGroup ManageMailTagsEditor) s
-                         <=> views (asConfig . confIndexView . ivManageThreadTagsKeybindings) (renderKbGroup ManageThreadTagsEditor) s
-                         <=> views (asConfig . confMailView . mvKeybindings) (renderKbGroup ScrollingMailView) s
-                         <=> views (asConfig . confHelpView . hvKeybindings) (renderKbGroup ScrollingHelpView) s
-                         <=> views (asConfig . confComposeView . cvListOfAttachmentsKeybindings) (renderKbGroup ListOfAttachments) s
-                         <=> views (asConfig . confFileBrowserView . fbKeybindings) (renderKbGroup ListOfFiles) s
-                         <=> views (asConfig . confFileBrowserView . fbSearchPathKeybindings) (renderKbGroup ManageFileBrowserSearchPath) s
-             in viewport ScrollingHelpView T.Vertical tweak
+renderHelp s = viewport ScrollingHelpView T.Vertical $ vBox
+  [ views (asConfig . confIndexView . ivBrowseMailsKeybindings) (renderKbGroup ListOfMails) s
+  , views (asConfig . confIndexView . ivBrowseThreadsKeybindings) (renderKbGroup ListOfThreads) s
+  , views (asConfig . confIndexView . ivSearchThreadsKeybindings) (renderKbGroup SearchThreadsEditor) s
+  , views (asConfig . confIndexView . ivManageMailTagsKeybindings) (renderKbGroup ManageMailTagsEditor) s
+  , views (asConfig . confIndexView . ivManageThreadTagsKeybindings) (renderKbGroup ManageThreadTagsEditor) s
+  , views (asConfig . confMailView . mvKeybindings) (renderKbGroup ScrollingMailView) s
+  , views (asConfig . confHelpView . hvKeybindings) (renderKbGroup ScrollingHelpView) s
+  , views (asConfig . confComposeView . cvListOfAttachmentsKeybindings) (renderKbGroup ListOfAttachments) s
+  , views (asConfig . confFileBrowserView . fbKeybindings) (renderKbGroup ListOfFiles) s
+  , views (asConfig . confFileBrowserView . fbSearchPathKeybindings) (renderKbGroup ManageFileBrowserSearchPath) s
+  ]
 
 renderKbGroup :: Titleize a => a -> [Keybinding v ctx] -> Widget Name
 renderKbGroup name kbs =

--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -10,7 +10,7 @@ module UI.Index.Main (
 import Brick.Types (Padding(..), Widget)
 import Brick.AttrMap (AttrName)
 import Brick.Widgets.Core
-       (hLimitPercent, padLeft, txt, vLimit, withAttr, (<+>))
+  (hBox, hLimitPercent, padLeft, txt, vLimit, withAttr, (<+>))
 import qualified Brick.Widgets.List as L
 import Control.Lens.Getter (view)
 import qualified Data.ByteString as B
@@ -55,21 +55,29 @@ listDrawMail :: AppState -> Bool -> NotmuchMail -> Widget Name
 listDrawMail s sel a =
     let settings = view (asConfig . confNotmuch) s
         isNewMail = hasTag (view nmNewTag settings) a
-        widget = padLeft (Pad 1) (txt $ formatDate (view mailDate a)) <+>
-                 padLeft (Pad 1) (renderAuthors sel $ view mailFrom a) <+>
-                 padLeft (Pad 1) (renderTagsWidget (view mailTags a) (view nmNewTag settings)) <+>
-                 padLeft (Pad 1) (txt (view mailSubject a)) <+> fillLine
+        widget = hBox
+          -- NOTE: I believe that inserting a `str " "` is more efficient than
+          -- `padLeft/Right (Pad 1)`.  This hypothesis should be tested.
+          [ padLeft (Pad 1) (txt $ formatDate (view mailDate a))
+          , padLeft (Pad 1) (renderAuthors sel $ view mailFrom a)
+          , padLeft (Pad 1) (renderTagsWidget (view mailTags a) (view nmNewTag settings))
+          , padLeft (Pad 1) (txt (view mailSubject a))
+          , fillLine
+          ]
     in withAttr (getListAttr isNewMail sel) widget
 
 listDrawThread :: AppState -> Bool -> NotmuchThread -> Widget Name
 listDrawThread s sel a =
     let settings = view (asConfig . confNotmuch) s
         isNewMail = hasTag (view nmNewTag settings) a
-        widget = padLeft (Pad 1) (txt $ formatDate (view thDate a)) <+>
-                 padLeft (Pad 1) (renderAuthors sel $ T.unwords $ view thAuthors a) <+>
-                 padLeft (Pad 1) (txt $ pack $ "(" <> show (view thReplies a) <> ")") <+>
-                 padLeft (Pad 1) (renderTagsWidget (view thTags a) (view nmNewTag settings)) <+>
-                 padLeft (Pad 1) (txt (view thSubject a)) <+> fillLine
+        widget = hBox
+          [ padLeft (Pad 1) (txt $ formatDate (view thDate a))
+          , padLeft (Pad 1) (renderAuthors sel $ T.unwords $ view thAuthors a)
+          , padLeft (Pad 1) (txt $ pack $ "(" <> show (view thReplies a) <> ")")
+          , padLeft (Pad 1) (renderTagsWidget (view thTags a) (view nmNewTag settings))
+          , padLeft (Pad 1) (txt (view thSubject a))
+          , fillLine
+          ]
     in withAttr (getListAttr isNewMail sel) widget
 
 getListAttr :: Bool  -- ^ new?

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -4,7 +4,7 @@ module UI.Mail.Main (renderMailView) where
 
 import Brick.Types (Padding(..), ViewportType(..), Widget)
 import Brick.Widgets.Core
-  (padTop, txt, txtWrap, viewport, (<+>), (<=>), withAttr)
+  (padTop, txt, txtWrap, viewport, (<+>), (<=>), withAttr, vBox)
 
 import Control.Applicative ((<|>))
 import Control.Lens (filtered, firstOf, folded, to, toListOf, view, preview)
@@ -52,7 +52,7 @@ messageToMailView s msg =
     bodyWidget = padTop (Pad 1) (maybe (txt "No entity selected") entityToView ent)
     ent = chooseEntity s msg
   in
-    foldr (<=>) (padTop (Pad 1) bodyWidget) headerWidgets
+    vBox headerWidgets <=> padTop (Pad 1) bodyWidget
 
 chooseEntity :: AppState -> MIMEMessage -> Maybe WireEntity
 chooseEntity s msg =

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -3,9 +3,8 @@
 
 module UI.Status.Main where
 
-import Brick.Types (Widget, Padding(..))
-import Brick.Widgets.Core
-       (txt, str, withAttr, (<+>), strWrap, padRight)
+import Brick.Types (Widget)
+import Brick.Widgets.Core (hBox, txt, str, withAttr, (<+>), strWrap)
 import qualified Brick.Widgets.List  as L
 import qualified Brick.Widgets.Edit  as E
 import Control.Lens (view)
@@ -65,12 +64,15 @@ instance WithContext (Maybe MIMEMessage) where
   renderContext s _ = currentItemW (view (asMailIndex . miListOfMails) s)
 
 renderStatusbar :: WithContext w => w -> AppState -> Widget Name
-renderStatusbar w s =
-    withAttr statusbarAttr
-    $ str "Purebred: "
-    <+> padRight (Pad 1) (renderContext s w)
-    <+> fillLine
-    <+> padRight (Pad 1) (txt (titleize (focusedViewName s) <> "-" <> titleize (focusedViewWidget s ListOfThreads)))
+renderStatusbar w s = withAttr statusbarAttr $ hBox
+  [ str "Purebred: "
+  , renderContext s w
+  , fillLine
+  , txt (
+      titleize (focusedViewName s) <> "-"
+      <> titleize (focusedViewWidget s ListOfThreads) <> " "
+      )
+  ]
 
 currentItemW :: Show e => L.List Name e -> Widget Name
 currentItemW l = str $


### PR DESCRIPTION
The (<+>) and (<=>) combinators create nested structures that are
less efficient than a flat hBox/vBox containing the widgets.
Convert such occurrences to hBox/vBox.

Also remove the VBox newtype whose Semigroup/Monoid instances would
be inefficient.

Also do a bit of drive-by refactoring and add commentary about other
possible optimisations to try in future.