### PR TITLE
tests: Exponentially back off waiting

### DIFF
--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -765,7 +765,7 @@ sendKeys :: String -> Condition -> ReaderT Env IO String
 sendKeys keys expect = do
     sessionName <- getSessionName
     liftIO $ callProcess "tmux" $ communicateSessionArgs sessionName keys False
-    waitForCondition expect defaultCountdown
+    waitForCondition expect defaultCountdown initialBackoffMicroseconds
 
 sendLiteralKeys :: String -> ReaderT Env IO String
 sendLiteralKeys keys = do
@@ -784,8 +784,8 @@ getSessionName = view (envSessionName . ask)
 getTestMaildir :: (Monad m) => ReaderT Env m FilePath
 getTestMaildir = view (envMaildir . ask)
 
-holdOffTime :: Int
-holdOffTime = 10 ^ (6 :: Int)
+initialBackoffMicroseconds :: Int
+initialBackoffMicroseconds = 20 * 10 ^ (3 :: Int)
 
 -- | convenience function to print captured output to STDERR
 debugOutput :: String -> IO ()
@@ -794,11 +794,15 @@ debugOutput out = do
   when (isJust d) $ hPutStr stderr ("\n\n" <> out)
 
 -- | wait for the application to render a new interface which we determine with
---   a given condition. We check up to @n@ times, waiting a short duration
---   between each check, and failing if the tries exhaust with the condition
---   not met.
-waitForCondition :: Condition -> Int -> ReaderT Env IO String
-waitForCondition cond n = do
+--   a given condition. We wait a short duration and increase the wait time
+--   exponentially until the count down reaches 0. We fail if until then the
+--   condition is not met.
+waitForCondition ::
+ Condition
+ -> Int  -- ^ count down value
+ -> Int  -- ^ milliseconds to back off
+ -> ReaderT Env IO String
+waitForCondition cond n backOff = do
   out <- capture >>= checkPane
   liftIO $ assertBool
     ( "Wait time exceeded. Condition not met: '" <> show cond
@@ -811,8 +815,8 @@ waitForCondition cond n = do
       | checkCondition cond out = pure out
       | n <= 0 = pure out
       | otherwise = do
-          liftIO $ threadDelay holdOffTime
-          waitForCondition cond (n - 1)
+          liftIO $ threadDelay backOff
+          waitForCondition cond (n - 1) (backOff * 4)
 
 checkCondition :: Condition -> String -> Bool
 checkCondition (Literal s) = (s `isInfixOf`)
@@ -822,7 +826,7 @@ checkCondition (Regex re) = (=~ re)
 -- literal string.
 --
 waitForString :: String -> Int -> ReaderT Env IO String
-waitForString = waitForCondition . Literal
+waitForString substr n = waitForCondition (Literal substr) n initialBackoffMicroseconds
 
 defaultCountdown :: Int
 defaultCountdown = 5


### PR DESCRIPTION
This patch adds an exponential back off to the wait times when waiting
for a repaint of the UI. With the default count down of 5 we wait:

	Prelude> [(20*10^3)*x | x<-[4,8,12,16,20]]
	[80000,160000,240000,320000,400000]

up overal up to 1.2s for the UI to be repainted for every step. This is
shorter to the previous setting which waited for every step 0.5s which
was cumulatively 2.5s until it bailed out.

This has the potential to shorten the test run time from 98s down to
30s.

Note: The UI repaint depends on the IO rate of the machine the tests
run. No consideration has taken into account to determine the IO rate
for an optimal initial back off time with this patch.