### PR TITLE
More preparation for the lazy list work.  There will probably be a few more of these PRs before the main event.

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -692,10 +692,10 @@ updateBrowseFileContents contents s =
   let contents' = view vector ((False, ) <$> contents)
   in over (asFileBrowser . fbEntries) (L.listReplace contents' (Just 0)) s
 
-listSetSelectionEnd :: Lens' AppState (L.List Name a) -> AppState -> AppState
-listSetSelectionEnd list s =
-  let index = view (list . L.listElementsL . to length) s
-  in over list (L.listMoveTo index) s
+listSetSelectionEnd
+  :: (Foldable t, L.Splittable t)
+  => Lens' s (L.GenericList Name t a) -> s -> s
+listSetSelectionEnd l = over l (L.listMoveTo (-1))
 
 -- | Seek forward from an offset, returning the offset if
 -- nothing after it matches the predicate.

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -15,7 +15,6 @@ import qualified Brick.Widgets.List as L
 import qualified Graphics.Vty.Input.Events as Vty
 import Control.Lens (to, view)
 import Control.Monad.Except (runExceptT)
-import qualified Data.Vector as Vector
 import System.Exit (die)
 import qualified Data.Map as Map
 
@@ -93,7 +92,7 @@ initialState conf = do
         Right vec ->
             let mi =
                     MailIndex
-                        (L.list ListOfMails Vector.empty 1)
+                        (L.list ListOfMails mempty 1)
                         (L.list ListOfThreads vec 1)
                         (E.editorText SearchThreadsEditor Nothing searchterms)
                         (E.editorText ManageMailTagsEditor Nothing "")
@@ -112,7 +111,7 @@ initialState conf = do
                     }
                 path = view (confFileBrowserView . fbHomePath) conf
                 fb = CreateFileBrowser
-                     (L.list ListOfFiles Vector.empty 1)
+                     (L.list ListOfFiles mempty 1)
                      (E.editor ManageFileBrowserSearchPath Nothing path)
                 mailboxes = view (confComposeView . cvIdentities) conf
             in pure $

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -17,11 +17,9 @@
 --
 {-# LANGUAGE OverloadedStrings #-}
 module UI.Utils
-       (safeUpdate, focusedViewWidget, focusedViewWidgets,
+       (focusedViewWidget, focusedViewWidgets,
         focusedViewName, focusedView, titleize, Titleize, toggledItems, selectedFiles)
        where
-import qualified Data.Vector as Vector
-import Data.Foldable (toList)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text, pack)
 import Data.List (union)
@@ -34,9 +32,6 @@ import UI.Views (indexView)
 
 
 import Types
-
-safeUpdate :: Foldable t => Vector.Vector a -> t (Int, a) -> Vector.Vector a
-safeUpdate v = (Vector.//) v  . filter ((\i -> i >= 0 && i < length v) . fst) . toList
 
 focusedViewWidget :: AppState -> Name -> Name
 focusedViewWidget s defaultWidget =


### PR DESCRIPTION
Changes:

```
09eeea0 (Fraser Tweedale, 23 minutes ago)
   generalise 'seekIndex'

   Update 'seekIndex' to work not only for 'Vector' but any container type
   that is 'Foldable' and 'Splittable'.

50abeee (Fraser Tweedale, 30 minutes ago)
   add generic 'updateAtIndex' function

   'manageMailTags' uses 'safeUpdate' which was specific to Vector. Alter it
   to use a more general version that works for any
   'Traversable' and remove 'safeUpdate'.

147cdd4 (Fraser Tweedale, 37 minutes ago)
   use 'mempty' to construct initial state

   To smooth the way for later changes, remove mentions of 'Vector' from
   UI.App and rely in the Monoid instance instead.
```