### PR TITLE
simplify tag management internals

### DIFF
--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -226,6 +226,6 @@ reloadThreadTags fp item = withDatabaseReadOnly fp go
     go db = fmap (`setTags` item) . Notmuch.tags =<< getThread db (view thId item)
 
 fixupWhitespace :: T.Text -> T.Text
-fixupWhitespace = T.map f . T.filter (not . (== '\n'))
+fixupWhitespace = T.map f . T.filter (/= '\n')
   where f '\t' = ' '
         f c = c


### PR DESCRIPTION
The code to deal with updating tags and updating the selected list item is
not great.  Especially the parts dealing with ((,) Int). Use
Brick.Widgets.List.listModify to modify the currently selected item,
avoiding the need to pass the index around.

Also simplify the 'haveTagsChanged' implementation while driving through.