### PR TITLE
tests: move UAT into separate test suite

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -110,17 +110,33 @@ test-suite unittests
   main-is:             Main.hs
   other-modules:       TestMail
                      , TestActions
-                     , TestUserAcceptance
                      , TestTagParser
                      , LazyVector
   default-language:    Haskell2010
   build-depends:       base
                      , purebred
-                     , purebred-email
                      , tasty
                      , tasty-hunit
                      , tasty-quickcheck
                      , quickcheck-instances
+                     , bytestring
+                     , text
+                     , lens
+                     , notmuch
+                     , time
+                     , brick >= 0.44
+                     , vector
+
+test-suite uat
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  ghc-options:         -Wall
+  main-is:             TestUserAcceptance.hs
+  default-language:    Haskell2010
+  build-depends:       base
+                     , purebred-email
+                     , tasty
+                     , tasty-hunit
                      , directory
                      , process
                      , bytestring
@@ -130,8 +146,4 @@ test-suite unittests
                      , regex-posix
                      , mtl
                      , lens
-                     , notmuch
-                     , time
                      , filepath
-                     , brick >= 0.44
-                     , vector

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,26 +1,16 @@
 module Main where
 
+import Test.Tasty (defaultMain, testGroup)
+
 import qualified LazyVector
 import TestMail (mailTests)
-import TestUserAcceptance (systemTests)
 import TestActions (actionTests)
 import TestTagParser (tagparserTests)
-import Test.Tasty (TestTree, defaultMain, testGroup)
 
-tests ::
-  TestTree
-tests = testGroup "tests" [unittests, systemTests]
-
--- unit tests
---
-unittests :: TestTree
-unittests = testGroup "unit tests"
+main :: IO ()
+main = defaultMain $ testGroup "unit tests"
   [ mailTests
   , tagparserTests
   , actionTests
   , LazyVector.tests
   ]
-
-main ::
-  IO ()
-main = defaultMain tests

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -18,7 +18,7 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 
-module TestUserAcceptance where
+module Main where
 
 import Data.Char (isAscii, isAlphaNum, chr)
 import qualified Data.Text as T
@@ -43,7 +43,7 @@ import Data.List (isInfixOf, intercalate)
 import System.Process (callProcess, readProcess)
 import System.Directory
        (getCurrentDirectory, removeDirectoryRecursive, removeFile, copyFile)
-import Test.Tasty (TestTree, TestName, testGroup, withResource)
+import Test.Tasty (TestTree, TestName, defaultMain, testGroup, withResource)
 import Test.Tasty.HUnit (testCaseSteps, assertBool)
 import Text.Regex.Posix ((=~))
 
@@ -57,9 +57,8 @@ data Condition
   | Regex String
   deriving (Show)
 
-systemTests ::
-  TestTree
-systemTests =
+main :: IO ()
+main = defaultMain $
   withResource pre post $ \_ ->
     testGroup "user acceptance tests" $ zipWith ($) tests [0..]
   where


### PR DESCRIPTION
Add a second test-suite called "uat" and move TestUserAcceptance
into it.  The main advantage is so that you can run just the unit
tests via 'cabal (new-)test unittests' and avoid the expensive UAT
suite.