### PR TITLE
Revert "tests: Exponentially back off waiting"

### DIFF
--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -765,7 +765,7 @@ sendKeys :: String -> Condition -> ReaderT Env IO String
 sendKeys keys expect = do
     sessionName <- getSessionName
     liftIO $ callProcess "tmux" $ communicateSessionArgs sessionName keys False
-    waitForCondition expect defaultCountdown initialBackoffMicroseconds
+    waitForCondition expect defaultCountdown
 
 sendLiteralKeys :: String -> ReaderT Env IO String
 sendLiteralKeys keys = do
@@ -784,8 +784,8 @@ getSessionName = view (envSessionName . ask)
 getTestMaildir :: (Monad m) => ReaderT Env m FilePath
 getTestMaildir = view (envMaildir . ask)
 
-initialBackoffMicroseconds :: Int
-initialBackoffMicroseconds = 20 * 10 ^ (3 :: Int)
+holdOffTime :: Int
+holdOffTime = 10 ^ (6 :: Int)
 
 -- | convenience function to print captured output to STDERR
 debugOutput :: String -> IO ()
@@ -794,15 +794,11 @@ debugOutput out = do
   when (isJust d) $ hPutStr stderr ("\n\n" <> out)
 
 -- | wait for the application to render a new interface which we determine with
---   a given condition. We wait a short duration and increase the wait time
---   exponentially until the count down reaches 0. We fail if until then the
---   condition is not met.
-waitForCondition ::
- Condition
- -> Int  -- ^ count down value
- -> Int  -- ^ milliseconds to back off
- -> ReaderT Env IO String
-waitForCondition cond n backOff = do
+--   a given condition. We check up to @n@ times, waiting a short duration
+--   between each check, and failing if the tries exhaust with the condition
+--   not met.
+waitForCondition :: Condition -> Int -> ReaderT Env IO String
+waitForCondition cond n = do
   out <- capture >>= checkPane
   liftIO $ assertBool
     ( "Wait time exceeded. Condition not met: '" <> show cond
@@ -815,8 +811,8 @@ waitForCondition cond n backOff = do
       | checkCondition cond out = pure out
       | n <= 0 = pure out
       | otherwise = do
-          liftIO $ threadDelay backOff
-          waitForCondition cond (n - 1) (backOff * 4)
+          liftIO $ threadDelay holdOffTime
+          waitForCondition cond (n - 1)
 
 checkCondition :: Condition -> String -> Bool
 checkCondition (Literal s) = (s `isInfixOf`)
@@ -826,7 +822,7 @@ checkCondition (Regex re) = (=~ re)
 -- literal string.
 --
 waitForString :: String -> Int -> ReaderT Env IO String
-waitForString substr n = waitForCondition (Literal substr) n initialBackoffMicroseconds
+waitForString = waitForCondition . Literal
 
 defaultCountdown :: Int
 defaultCountdown = 5


### PR DESCRIPTION
This reverts commit cb94323f8d7442e5f59f4169afc38b388d2ca61e.

The more aggressive (read shorter) initial timeouts could lead to more
failing tests. This is partially because after we've implemented the new
UI methods, we never investigated that the views now share more common
widgets. Widget labels show up in more different views. This leads to
more failures in combination with the aggressive timeouts, because the
assertions still find the same strings in the old views as well as in
the new views.

Therefore, tweaking more with the timeouts will make the tests more
brittle.