### PR TITLE
selectNextUnread: use brick listFindBy

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -73,7 +73,7 @@ library
                      , deepseq >= 1.4.2
                      , dyre >= 0.8.12
                      , lens
-                     , brick >= 0.44
+                     , brick >= 0.45
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0
@@ -124,7 +124,7 @@ test-suite unittests
                      , lens
                      , notmuch
                      , time
-                     , brick >= 0.44
+                     , brick
                      , vector
 
 test-suite uat

--- a/stack.yaml
+++ b/stack.yaml
@@ -55,7 +55,7 @@ extra-deps:
 - data-clist-0.1.2.1
 - word-wrap-0.4.1
 - vty-5.25.1
-- brick-0.44
+- brick-0.45
 - megaparsec-6.5.0
 - parser-combinators-1.0.0
 


### PR DESCRIPTION
Use the listFindBy function, available as of brick 0.45, to
implement the "find next unread message" behaviour.