### PR TITLE
Replace process with typed-process

### DIFF
--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -43,15 +43,13 @@ myMailKeybindings =
     [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
     ]
 
--- Note: The empty string return value is currently used as an error condition,
--- but for this case it is not used.
-writeMailtoFile :: B.ByteString -> IO String
+writeMailtoFile :: B.ByteString -> IO (Either Error ())
 writeMailtoFile m = do
   confdir <- lookupEnv "PUREBRED_CONFIG_DIR"
   currentdir <- getCurrentDirectory
   let fname = fromMaybe currentdir confdir </> "sentMail"
   B.writeFile fname m
-  pure ""
+  pure (Right ())
 
 fromMail :: [Mailbox]
 fromMail =

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -79,7 +79,7 @@ library
                      , vector >= 0.12.0.0
                      , notmuch >= 0.1 && < 0.2
                      , text
-                     , process
+                     , typed-process >= 0.2.1.0
                      , directory
                      , bytestring
                      , time

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -112,6 +112,7 @@ To avoid this, don't use stack.  But if you insist, you can run
 -}
 module Purebred (
   module Types,
+  module Error,
   module UI.Actions,
   module UI.Index.Keybindings,
   module UI.Mail.Keybindings,
@@ -153,6 +154,7 @@ import UI.Actions
 import Storage.Notmuch (getDatabasePath)
 import Config.Main (defaultConfig, solarizedDark, solarizedLight)
 import Types
+import Error
 
 -- re-exports for configuration
 import Graphics.Vty.Input.Events (Event(..), Key(..), Modifier(..))

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -201,7 +201,7 @@ data ComposeViewSettings = ComposeViewSettings
     { _cvFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
     , _cvToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
     , _cvSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
-    , _cvSendMailCmd :: B.ByteString -> IO String
+    , _cvSendMailCmd :: B.ByteString -> IO (Either Error ())
     , _cvListOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ListOfAttachments]
     , _cvBoundary :: String
     , _cvIdentities :: [Mailbox]
@@ -217,7 +217,7 @@ cvToKeybindings = lens _cvToKeybindings (\cv x -> cv { _cvToKeybindings = x })
 cvSubjectKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeSubject]
 cvSubjectKeybindings = lens _cvSubjectKeybindings (\cv x -> cv { _cvSubjectKeybindings = x })
 
-cvSendMailCmd :: Lens' ComposeViewSettings (B.ByteString -> IO String)
+cvSendMailCmd :: Lens' ComposeViewSettings (B.ByteString -> IO (Either Error ()))
 cvSendMailCmd = lens _cvSendMailCmd (\cv x -> cv { _cvSendMailCmd = x })
 
 cvListOfAttachmentsKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ListOfAttachments]

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -66,7 +66,7 @@ import Data.List (union)
 import System.Exit (ExitCode(..))
 import System.IO (openTempFile, hClose)
 import System.Directory (getTemporaryDirectory, removeFile)
-import System.Process (system)
+import System.Process.Typed (proc, runProcess)
 import System.FilePath (takeFileName, takeDirectory, (</>))
 import qualified Data.Vector as Vector
 import Prelude hiding (readFile, unlines)
@@ -77,7 +77,7 @@ import Control.Lens
         traversed, traverse, Getting, Lens')
 import Control.Monad ((>=>))
 import Control.Monad.Except (runExceptT)
-import Control.Exception (onException, catch, IOException)
+import Control.Exception (catch, IOException)
 import Control.Monad.IO.Class (liftIO, MonadIO)
 import Control.Monad.Catch (bracket)
 import Data.Text.Zipper
@@ -832,7 +832,7 @@ invokeEditor' s = do
   let m = preview (asCompose . cAttachments . to L.listSelectedElement
                      . _Just . _2 . to getTextPlainPart . _Just) s
   tmpfile <- getTempFileForEditing m
-  status <- onException (system (editor <> " " <> tmpfile)) (pure $ setError editorError)
+  status <- runProcess (proc editor [tmpfile])
   case status of
     ExitFailure _ -> pure $ s & over (asViews . vsFocusedView) (Brick.focusSetCurrent Mails)
                               & setError editorError

--- a/stack.yaml
+++ b/stack.yaml
@@ -58,6 +58,7 @@ extra-deps:
 - brick-0.45
 - megaparsec-6.5.0
 - parser-combinators-1.0.0
+- typed-process-0.2.3.0@sha256:8e9206a2f3c2e1ba2233df97600bbf2bf0007b4670f36b87d456a066d1dee14d
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -691,7 +691,7 @@ precompileConfig testdir = do
   env <- getEnvironment
   let systemEnv = ("PUREBRED_CONFIG_DIR", testdir) : env
       config = setEnv systemEnv $ proc "stack" ["exec", "purebred", "--", "--version"]
-  void $ readProcess_ config
+  void $ runProcess_ config
 
 setUpPurebredConfig :: FilePath -> IO ()
 setUpPurebredConfig testdir = do


### PR DESCRIPTION
This removes the dependency from the process package in favour of the
typed-process package. It provides more expressive types to interact with the
system.

Fixes https://github.com/purebred-mua/purebred/issues/201