### PR TITLE
declare notmuch version bounds

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -77,7 +77,7 @@ library
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0
-                     , notmuch
+                     , notmuch >= 0.1 && < 0.2
                      , text
                      , process
                      , directory


### PR DESCRIPTION
In anticipation of upcoming 'notmuch' breaking changes and to
prevent me from frequently shooting myself in the foot by running
against the wrong commit, declare version bounds.