### PR TITLE
Adds reply to mail feature

### DIFF
--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -5,10 +5,14 @@
 -- entire mail and it's attachments.
 module Storage.ParsedMail where
 
+import Control.Applicative ((<|>))
 import Control.Exception (try)
-import Control.Lens (firstOf)
+import Control.Lens
+       (firstOf, view, preview, filtered, to, (&), set, preview, at)
+import Data.Text.Lens (packed)
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Semigroup ((<>))
 import qualified Data.ByteString as B
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as T
@@ -42,3 +46,53 @@ getSubject = getHeader "subject"
 
 getTo :: Message s a -> T.Text
 getTo = getHeader "to"
+
+chooseEntity :: ContentType -> MIMEMessage -> Maybe WireEntity
+chooseEntity preferredContentType msg =
+  let
+    match x = matchContentType
+      (view (headers . contentType . ctType) x)
+      (preview (headers . contentType . ctSubtype) x)
+      preferredContentType
+
+    -- select first entity with matching content-type;
+    -- otherwise select first entity;
+  in firstOf (entities . filtered match) msg <|> firstOf entities msg
+
+entityToText :: WireEntity -> T.Text
+entityToText msg = either err (view body) $
+  view transferDecoded msg >>= view charsetDecoded
+  where
+    err :: EncodingError -> T.Text
+    err e =
+      "ERROR: " <> view (to show . packed) e <> ". Showing raw body.\n\n"
+      <> decodeLenient (view body msg)
+
+quoteText :: T.Text -> T.Text
+quoteText = T.unlines . fmap ("> " <>) . T.lines
+
+-- | Creates a new instance of `MIMEMessage` with a quoted plain text part if:
+-- a) the preferred content type can be extracted
+-- b) the text entity can be successfully decoded
+-- otherwise an empty plain text body is created
+toQuotedMail :: ContentType -> MIMEMessage -> Either Error MIMEMessage
+toQuotedMail ct msg =
+    let contents =
+            case chooseEntity ct msg of
+                Nothing ->
+                    Left
+                        (GenericError $
+                         "Unable to find preferred content type: " <>
+                         T.unpack (showContentType ct))
+                Just ent -> Right $ quoteText (entityToText ent)
+        replyToAddress m =
+            firstOf (headers . header "reply-to") m
+            <|> firstOf (headers . header "from") m
+    in fmap
+           (\x ->
+                 createTextPlainMessage x
+                 & set (headers . at "from") (view (headers . at "to") msg)
+                 . set (headers . at "to") (replyToAddress msg)
+                 . set (headers . at "references") (view (headers . replyHeaderReferences) msg)
+                 . set (headers . at "subject") (("Re: " <>) <$> view (headers . at "subject") msg))
+           contents

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -20,7 +20,6 @@ browseMailKeybindings =
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'Mails 'ManageMailTagsEditor AppState) `chain` continue)

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -20,6 +20,7 @@ displayMailKeybindings =
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` invokeEditor)
     ]
 
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -6,15 +6,13 @@ import Brick.Types (Padding(..), ViewportType(..), Widget)
 import Brick.Widgets.Core
   (padTop, txt, txtWrap, viewport, (<+>), (<=>), withAttr, vBox)
 
-import Control.Applicative ((<|>))
-import Control.Lens (filtered, firstOf, folded, to, toListOf, view, preview)
+import Control.Lens (filtered, folded, toListOf, view)
 import qualified Data.ByteString as B
 import qualified Data.CaseInsensitive as CI
 import Data.Semigroup ((<>))
-import Data.Text.Lens (packed)
-import qualified Data.Text as T
 
 import Data.MIME
+import Storage.ParsedMail (chooseEntity, entityToText)
 
 import Types
 import Config.Main (headerKeyAttr, headerValueAttr, mailViewAttr)
@@ -50,28 +48,10 @@ messageToMailView s msg =
 
     headerWidgets = headerToWidget <$> filteredHeaders
     bodyWidget = padTop (Pad 1) (maybe (txt "No entity selected") entityToView ent)
-    ent = chooseEntity s msg
+    preferredContentType = view (asConfig . confMailView . mvPreferredContentType) s
+    ent = chooseEntity preferredContentType msg
   in
     vBox headerWidgets <=> padTop (Pad 1) bodyWidget
 
-chooseEntity :: AppState -> MIMEMessage -> Maybe WireEntity
-chooseEntity s msg =
-  let
-    preferredContentType = view (asConfig . confMailView . mvPreferredContentType) s
-    match x = matchContentType
-      (view (headers . contentType . ctType) x)
-      (preview (headers . contentType . ctSubtype) x)
-      preferredContentType
-
-    -- select first entity with matching content-type;
-    -- otherwise select first entity;
-  in firstOf (entities . filtered match) msg <|> firstOf entities msg
-
 entityToView :: WireEntity -> Widget Name
-entityToView msg = txtWrap . either err (view body) $
-  view transferDecoded msg >>= view charsetDecoded
-  where
-    err :: EncodingError -> T.Text
-    err e =
-      "ERROR: " <> view (to show . packed) e <> ". Showing raw body.\n\n"
-      <> decodeLenient (view body msg)
+entityToView = txtWrap . entityToText

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,7 +43,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/purebred-mua/purebred-email.git
-    commit: 84bf3033a46146969dd4fd5c8da7321b1c7d0d29
+    commit: 89928795c06abc48cbc7ac4eb00422fe176eab32
   extra-dep: true
 
 # Dependency packages to be pulled from upstream that are not in the resolver

--- a/test/data/Maildir/new/1502941827.R15455991756849358775.url
+++ b/test/data/Maildir/new/1502941827.R15455991756849358775.url
@@ -1,16 +1,16 @@
-Return-Path: <rjoost@url.usersys.redhat.com>
+Return-Path: <rjoost@host.example>
 X-Original-To: rjoost
-Delivered-To: rjoost@url.usersys.redhat.com
-Received: by url.usersys.redhat.com (Postfix, from userid 20845)
+Delivered-To: rjoost@host.example
+Received: by host.example (Postfix, from userid 20845)
 	id 55C4580B8F; Thu, 17 Aug 2017 13:50:04 +1000 (AEST)
-From: <roman@url.usersys.redhat.com>
-To: <rjoost@url.usersys.redhat.com>
+From: <roman@host.example>
+To: <frase@host.example>
 Subject: Testmail with whitespace in the
 	subject
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
-Message-Id: <20170817035004.55C4580B8F@url.usersys.redhat.com>
+Message-Id: <20170817035004.55C4580B8F@host.example>
 Date: Thu, 17 Aug 2017 13:50:04 +1000 (AEST)
 Content-Length: 33
 


### PR DESCRIPTION
This "fixes" the reply to mail action, which was never correctly implemented due
to missing support in the email parsing library. Using purebred-email, there is
wide support for manipulating the mail body in order to properly quote the body.

This is the first take on the replying action and will only work for text/plain
content types.

Fixes https://github.com/purebred-mua/purebred/issues/114