### PR TITLE
UAT fixes and cleanups

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -103,7 +103,7 @@ executable purebred
   build-depends:       base >= 4.9 && < 5
                      , purebred
 
-test-suite unittests
+test-suite unit
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   ghc-options:         -Wall

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -140,7 +140,6 @@ test-suite uat
                      , directory
                      , typed-process
                      , bytestring
-                     , ini
                      , temporary
                      , text
                      , regex-posix

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -26,7 +26,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as T
 import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
-import Data.Ini (parseIni, writeIniFileWith, KeySeparator(..), WriteIniSettings(..))
 import Data.Semigroup ((<>))
 import Data.Either (isRight)
 import Control.Concurrent (threadDelay)
@@ -796,14 +795,12 @@ setUpTempMaildir = do
 setUpNotmuch :: FilePath -> IO ()
 setUpNotmuch notmuchcfg = void $ readProcess_ $ proc "notmuch" ["--config=" <> notmuchcfg, "new" ]
 
--- | write a notmuch config
--- Note: currently writes a minimal config pointing to our database
+-- | Write a minimal notmuch config pointing to the database.
 setUpNotmuchCfg :: FilePath -> IO FilePath
-setUpNotmuchCfg testmdir = do
-  let (Right ini) = parseIni (T.pack "[database]\npath=" <> T.pack testmdir)
-  let nmcfg = testmdir <> "/notmuch-config"
-  writeIniFileWith (WriteIniSettings EqualsKeySeparator) nmcfg ini
-  pure nmcfg
+setUpNotmuchCfg dir = do
+  let cfgData = "[database]\npath=" <> dir <> "\n"
+      cfgFile = dir <> "/notmuch-config"
+  writeFile cfgFile cfgData *> pure cfgFile
 
 -- | create a tmux session running in the background
 -- Note: the width and height are the default values tmux uses, but I thought

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -188,7 +188,7 @@ testUpdatesReadState = withTmuxSession "updates read state for mail and thread" 
 
     liftIO $ step "set one mail to unread"
     sendKeys "Enter" (Literal "Beginning of large text")
-    sendKeys "q t" (Regex (buildAnsiRegex ["1"] ["37"] [] <> "\\sWIP Refactor\\s" <> buildAnsiRegex ["0"] ["34"] ["40"]))
+    sendKeys "q t" (Regex (buildAnsiRegex ["1"] ["37"] [] <> "\\sWIP Refactor\\s+" <> buildAnsiRegex ["0"] ["34"] ["40"]))
 
     liftIO $ step "returning to thread list shows thread unread"
     sendKeys "q" (Regex (buildAnsiRegex ["1"] ["37"] [] <> "\\sWIP Refactor\\s"))
@@ -366,10 +366,8 @@ testManageTagsOnMails = withTmuxSession "manage tags on mails" $
 
     liftIO $ step "cancel tagging and expect old UI"
     -- instead of asserting the absence of the tagging editor, we assert the
-    -- last visible "item" in the UI followed by whitespace. Give it an
-    -- estimated upper range, since there could be some variable amount of
-    -- whitespace.
-    sendKeys "Escape" (Regex "This is a test mail for purebred\\s{4,8}$")
+    -- last visible "item" in the UI followed by whitespace.
+    sendKeys "Escape" (Regex "This is a test mail for purebred\\s+$")
 
     pure ()
 
@@ -839,7 +837,11 @@ sendLiteralKeys keys = do
 
 capture :: ReaderT Env IO String
 capture =
-  tmuxSessionProc "capture-pane" ["-e", "-p"]
+  tmuxSessionProc "capture-pane"
+    [ "-e"  -- include escape sequences
+    , "-p"  -- send output to stdout
+    , "-J"  -- join wrapped lines and preserve trailing whitespace
+    ]
   >>= liftIO . readProcessWithErrorOutput_
 
 holdOffTime :: Int

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -315,13 +315,11 @@ testAddAttachments = withTmuxSession "use file browser to add attachments" $
 
     let fpath = testdir </> "sentMail"
     contents <- liftIO $ B.readFile fpath
-    let decoded = (chr . fromEnum <$> B.unpack contents)
+    let decoded = chr . fromEnum <$> B.unpack contents
     assertSubstrInOutput "attachment; filename" decoded
     assertSubstrInOutput "screenshot.png" decoded
     assertSubstrInOutput "stack.yaml" decoded
     assertSubstrInOutput "This is a test body" decoded
-
-    pure ()
 
 testManageTagsOnMails :: Int -> TestTree
 testManageTagsOnMails = withTmuxSession "manage tags on mails" $
@@ -639,7 +637,7 @@ testSendMail =
           sendKeys "user@to.test\r" (Literal "Subject")
 
           liftIO $ step "enter subject"
-          let subj = ("test subject from directory " <> testdir)
+          let subj = "test subject from directory " <> testdir
           sendKeys (subj <> "\r") (Literal "~")
 
           liftIO $ step "enter mail body"
@@ -672,7 +670,6 @@ testSendMail =
           liftIO $ step "parse mail with purebred-email"
           assertMailSuccessfullyParsed (testdir </> "sentMail")
 
-          pure ()
 
 parseMail :: B.ByteString -> Either String MIMEMessage
 parseMail = parse (message mime)

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -61,7 +61,8 @@ import Data.MIME (parse, message, mime, MIMEMessage)
 
 -- | A condition to check for in the output of the program
 data Condition
-  = Literal String
+  = Unconditional
+  | Literal String
   | Regex String
   deriving (Show)
 
@@ -588,6 +589,8 @@ testUserCanSwitchBackToIndex =
             sendKeys "m" (Literal "From")
 
             liftIO $ step "enter from email"
+            sendKeys "C-a" Unconditional
+            sendKeys "C-k" Unconditional
             sendKeys "testuser@foo.test\r" (Literal "To")
 
             liftIO $ step "enter to: email"
@@ -872,6 +875,7 @@ waitForCondition cond n = do
           waitForCondition cond (n - 1)
 
 checkCondition :: Condition -> String -> Bool
+checkCondition Unconditional = const True
 checkCondition (Literal s) = (s `isInfixOf`)
 checkCondition (Regex re) = (=~ re)
 


### PR DESCRIPTION
This is some preliminary work before the changeover to using cabal
for the test suite and CI.

There are quite a log of changes - I really recommend to review each
commit independently rather than look at the whole diff.

The most significant change is to share a single binary across all
test cases, which saves a significant amount of time.  We also avoid
confounding local user config / custom binaries (isolates the test
suite from users' own purebred configs, which may e.g. have
keybindings that are incompatible with the test suite).

Although not included in this PR, I have tried out your "exponential
backoff" commit on top of these changes, which works fine for me and
reduces the duration of the UAT suite to 15 seconds.  We should
probably look at reapplying that patch soon.

Changes:

```
4f85063 (Fraser Tweedale, 19 minutes ago)
   tests: rename unit test test-suite to "unit"

   "cabal new-test unittests" is a bit of a pain to type.  Keep things short
   and sweet but renaming the test suite to "unit".

c2048e1 (Fraser Tweedale, 3 minutes ago)
   uat: avoid 'ini' dependency

   The contents of the notmuch configuration used by the tests is so trivial,
   there is no need for the ini dependency.  Avoid it.

738148f (Fraser Tweedale, 12 hours ago)
   uat: share config dir and binary across test cases

   All our test cases do (or can) use the same configuration.  Right now, we
   are incurring the recompile cost for every test case.  But we only need to
   incur it once, and just point the program to a fresh maildir for each test
   case.  This saves some time in the test suite.

   This commit also resolves another problem: if the config dir was not 
   explicitly specified (via the PUREBRED_CONFIG_DIR environment variable) and
   the tests are being run by a user who already had a purebred configuration,
   the _user's_ purebred configuration would be used.  The mail directory was
   overridden, but the user's custom binary could have, for example, incorrect
   keybindings that will cause tests to fail.  Explicitly setting the config
   dir for every test session averts this problem.

   In terms of implementation, config dir setup and cleanup moves to
   'main', and a new 'GlobalEnv' data type conveys the details to the 
   individual test cases.

   The ability to use a custom configuration for a single test case is 
   provided for, but not used.  The only change that would be required is to
   enhance 'withTmuxSession' to provide the datum to 'setUp', and
   'setUp' to actually create it and set 'envDir' field in the session
   'Env'.  The cleanup side of things is already implemented.

3b66c95 (Fraser Tweedale, 17 hours ago)
   uat: clear any existing "From" value

   When composing a mail, if the current purebred configuration has existing
   identities configured, the "From" text field will be pre-populated.  The
   current test code simply appends to the value without clearing it.

   Clear the value in the "From" prompt before entering the desired value.

3034eca (Fraser Tweedale, 18 hours ago)
   uat: dispel hlint suggestions

e8c4ea1 (Fraser Tweedale, 21 hours ago)
   uat: tell capture-pane to unwrap wrapped lines

   When sending strings into a tmux session, if the lines wraps in the 
   terminal, capture-pane will return the _wrapped_ output, newlines and all.

   With long environment variables and (when running tests locally) a long
   command prompt, the line can wrap and confuse the condition checker.  For
   example:

     sending mail successfully:                           FAIL (5.04s)
      Wait time exceeded. Condition not met:
          'Literal "export PUREBRED_CONFIG_DIR=/tmp/purebredtest10834"'
           last screen shot:

       [T470s:~/dev/purebred] [ ci/avoid-stack● ] ftweedal% export TERM=ansi
      [T470s:~/dev/purebred] [ ci/avoid-stack● ] ftweedal% export
   PUREBRED_CONFIG_DIR=
      /tmp/purebredtest10834

       <lots of blank lines (expected)>

        raw: <snip>export PUREBRED_CONFIG_DIR=\n/tmp/purebredtest10834<snip>

   Observe the unexpected "\n" in the middle of the line.  (The fact that this
   occurs right after an '=' is mere coincidence.

   tmux capture-pane provides the '-J' option for unwrapping lines
   (even though they rae bieng displayed wrapped).  Use this option to avoid
   confusing the condition checker.

   This change requires tweaking a couple of the regex conditions due to the
   presense of additional whitespace in the captured pane.

2201ea0 (Fraser Tweedale, 22 hours ago)
   uat: refactoring and cleanup

   Do some minor and not-so-minor cleanups in UAT code.
```