### PR TITLE
Allow to build packages for nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist-newstyle
 
 *.o
 *.hi
+
+result

--- a/.nix/Cabal.nix
+++ b/.nix/Cabal.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, array, base, base-compat, base-orphans, binary
+, bytestring, containers, deepseq, Diff, directory, filepath
+, integer-logarithms, mtl, optparse-applicative, parsec, pretty
+, process, QuickCheck, stdenv, tagged, tar, tasty, tasty-golden
+, tasty-hunit, tasty-quickcheck, temporary, text, time
+, transformers, tree-diff, unix
+}:
+mkDerivation {
+  pname = "Cabal";
+  version = "2.4.1.0";
+  sha256 = "736a902da9fb2c826e75e9f7b4b591983bf58a6a62c8cae9866f6a9d5ace3594";
+  revision = "1";
+  editedCabalFile = "1dvs2i0kfk8rji9wbrv7y0iydbif9jzg4c7rmaa6lxg8hp7mij2n";
+  setupHaskellDepends = [ mtl parsec ];
+  libraryHaskellDepends = [
+    array base binary bytestring containers deepseq directory filepath
+    mtl parsec pretty process text time transformers unix
+  ];
+  testHaskellDepends = [
+    array base base-compat base-orphans bytestring containers deepseq
+    Diff directory filepath integer-logarithms optparse-applicative
+    pretty process QuickCheck tagged tar tasty tasty-golden tasty-hunit
+    tasty-quickcheck temporary text tree-diff
+  ];
+  doCheck = false;
+  homepage = "http://www.haskell.org/cabal/";
+  description = "A framework for packaging Haskell software";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, base, config-ini, containers, contravariant
+, data-clist, deepseq, directory, dlist, fetchgit, filepath
+, microlens, microlens-mtl, microlens-th, QuickCheck, stdenv, stm
+, template-haskell, text, text-zipper, transformers, unix, vector
+, vty, word-wrap
+}:
+mkDerivation {
+  pname = "brick";
+  version = "0.45";
+  src = fetchgit {
+    url = "https://github.com/jtdaugherty/brick.git";
+    sha256 = "1w9sa46nvr2abf2pzr0n6psdcffv7w62fa0l985scmy9v8qnizjm";
+    rev = "2f6f7c3e013d48c72b781fb4d46ce86c66835259";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base config-ini containers contravariant data-clist deepseq
+    directory dlist filepath microlens microlens-mtl microlens-th stm
+    template-haskell text text-zipper transformers unix vector vty
+    word-wrap
+  ];
+  testHaskellDepends = [
+    base containers microlens QuickCheck vector
+  ];
+  homepage = "https://github.com/jtdaugherty/brick/";
+  description = "A declarative terminal user interface library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/.nix/hs-notmuch.nix
+++ b/.nix/hs-notmuch.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, base, bytestring, c2hs, containers, deepseq
+, fetchgit, mtl, notmuch, profunctors, stdenv, tagged, talloc, text
+, time
+}:
+mkDerivation {
+  pname = "notmuch";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/purebred-mua/hs-notmuch.git";
+    sha256 = "0p9q48lpvib2l2fy9k2s77d7rxm0vkiclji3s016ic7jpyqpmyv0";
+    rev = "2d2ceedbe3d612ec273477fed0217228b3f35914";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring deepseq mtl profunctors tagged text time
+  ];
+  librarySystemDepends = [ notmuch talloc ];
+  libraryToolDepends = [ c2hs ];
+  executableHaskellDepends = [ base bytestring containers mtl ];
+  homepage = "https://github.com/purebred-mua/hs-notmuch";
+  description = "Haskell binding to Notmuch, the mail indexer";
+  license = stdenv.lib.licenses.gpl3;
+}

--- a/.nix/purebred-email.nix
+++ b/.nix/purebred-email.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, attoparsec, base, base64-bytestring, bytestring
+, case-insensitive, concise, deepseq, fetchgit, lens, QuickCheck
+, quickcheck-instances, semigroupoids, semigroups, stdenv
+, stringsearch, tasty, tasty-golden, tasty-hunit, tasty-quickcheck
+, text, time
+}:
+mkDerivation {
+  pname = "purebred-email";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/purebred-mua/purebred-email.git";
+    sha256 = "0vc2bcagd60mqfx96k9s83kfkq3wcj5ibacr4a1n3xh6gcr1qg4i";
+    rev = "89928795c06abc48cbc7ac4eb00422fe176eab32";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    attoparsec base base64-bytestring bytestring case-insensitive
+    concise deepseq lens semigroupoids semigroups stringsearch text
+    time
+  ];
+  executableHaskellDepends = [
+    attoparsec base bytestring semigroups
+  ];
+  testHaskellDepends = [
+    attoparsec base bytestring case-insensitive lens QuickCheck
+    quickcheck-instances semigroups tasty tasty-golden tasty-hunit
+    tasty-quickcheck text time
+  ];
+  homepage = "https://github.com/purebred-mua/purebred-email";
+  description = "types and parser for email messages (including MIME)";
+  license = stdenv.lib.licenses.agpl3;
+}

--- a/.nix/purebred.nix
+++ b/.nix/purebred.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, attoparsec, base, brick, bytestring
+, case-insensitive, containers, deepseq, directory, dyre
+, exceptions, filepath, ini, lens, mime-types, mtl, notmuch
+, optparse-applicative, purebred-email, quickcheck-instances
+, random, regex-posix, stdenv, stm, tasty, tasty-hunit
+, tasty-quickcheck, temporary, text, text-zipper, time
+, typed-process, vector, vty, tmux
+, Cabal
+}:
+mkDerivation {
+  pname = "purebred";
+  version = "0.1.0.0";
+  src = ../.;
+  isLibrary = true;
+  isExecutable = true;
+  setupHaskellDepends = [ Cabal ];
+  libraryHaskellDepends = [
+    attoparsec base brick bytestring case-insensitive containers
+    deepseq directory dyre exceptions filepath lens mime-types mtl
+    notmuch optparse-applicative purebred-email random text text-zipper
+    time typed-process vector vty
+  ];
+  testTarget = "unit";
+  executableHaskellDepends = [ base ];
+  testHaskellDepends = [
+    base brick bytestring directory filepath ini lens mtl notmuch
+    purebred-email quickcheck-instances regex-posix stm tasty
+    tasty-hunit tasty-quickcheck temporary text time typed-process
+    vector tmux
+  ];
+  homepage = "https://github.com/githubuser/purebred#readme";
+  description = "An mail user agent built around notmuch";
+  license = stdenv.lib.licenses.agpl3;
+}

--- a/.nix/vty.nix
+++ b/.nix/vty.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, base, blaze-builder, bytestring, Cabal, containers
+, deepseq, directory, filepath, hashable, HUnit, microlens
+, microlens-mtl, microlens-th, mtl, parallel, parsec, QuickCheck
+, quickcheck-assertions, random, smallcheck, stdenv, stm, string-qq
+, terminfo, test-framework, test-framework-hunit
+, test-framework-smallcheck, text, transformers, unix, utf8-string
+, vector
+}:
+mkDerivation {
+  pname = "vty";
+  version = "5.25.1";
+  sha256 = "3cab792e32c59647c2bdb2785c9c9a94bdb84fc85499bb1ab488999e1c9525f4";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base blaze-builder bytestring containers deepseq directory filepath
+    hashable microlens microlens-mtl microlens-th mtl parallel parsec
+    stm terminfo text transformers unix utf8-string vector
+  ];
+  executableHaskellDepends = [
+    base containers microlens microlens-mtl mtl
+  ];
+  testHaskellDepends = [
+    base blaze-builder bytestring Cabal containers deepseq HUnit
+    microlens microlens-mtl mtl QuickCheck quickcheck-assertions random
+    smallcheck stm string-qq terminfo test-framework
+    test-framework-hunit test-framework-smallcheck text unix
+    utf8-string vector
+  ];
+  doCheck = false;
+  homepage = "https://github.com/jtdaugherty/vty";
+  description = "A simple terminal UI library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/README.md
+++ b/README.md
@@ -24,9 +24,28 @@ are welcome.  See [HACKING] for more info.
 - [ ] extensible with plug-ins
 - [x] enforce sane configuration by using Haskell's type system
 
-## Development packages
+## Try it
+
+Try out purebred with the following choices. Keep in mind that *none of these* are
+*currently tested* in our CI and may be broken.
+
 ### Fedora
 
 We operate a
 [Fedora Copr](https://copr.fedorainfracloud.org/coprs/romanofski/purebred/)
 repository which provides easily installable RPM packages.
+
+### Nix
+
+If you're using the nix package manager - whether on NixOS or any other Linux distribution - you can build purebred too.
+You can use `nix-build` to try out purebred without installing it:
+
+```
+$ nix-build default.nix
+```
+
+and `nix-env` to install the application:
+
+```
+$ nix-env --file default.nix --install
+```

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,8 +2,8 @@
 
 ## Framework
 
-The current test framework uses tmux and executes certain key strokes against
-the started application.
+Purebred comes with an extensive suite of user acceptance tests. It expects that
+the `purebred` binary can be found in the `$PATH` as well as can be recompiled.
 
 ## Writing new user acceptance tests
 
@@ -28,12 +28,14 @@ You can limit which tests to run. Tasty provides extensive documentation
 example:
 
     # would only run a user acceptance test with an "error" substring
-    stack test --test-arguments='-p "tests/user*/*error*"'
+    cabal test --show-details=streaming --test-option='-p "tests/user*/*error*"'
+    
+    # On NixOS, keep in mind that you will need to build the binary first and then run the acceptance tests in a NIX shell
+    PATH=$PATH:result/bin cabal test --show-details=streaming --test-option='-p "tests/user*/*error*"'
 
-## Running purebred with a custom config and stack
+## Running purebred with a custom config
 
 Purebred accepts environment variables which are also used in the acceptance
-tests. To run purebred with stack and a custom config, here is an example:
+tests. To point purebred to a custom config:
 
-    # Purebred invokes: "stack ghc --" + additional compile arguments
-    GHC="stack" GHC_ARGS="ghc --" PUREBRED_CONFIG_DIR=configs stack exec purebred
+    PUREBRED_CONFIG_DIR=configs cabal new-run purebred

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,80 @@
+# Building purebred
+#
+# You should be able to simply invoke:
+#
+# $ nix-build
+#
+# or, to be explicit:
+#
+# $ nix-build default.nix
+#
+# in purebred's root directory in order to build purebred. You'll find the binary under:
+#
+# $ ls result/bin/purebred
+#
+# if the build was successful.
+#
+#
+# Choosing a different compiler than the default
+#
+# In order to choose a different compiler, invoke nix build like so (escaping
+# the quotes is needed, since we're passing a string literal):
+#
+# $ nix-build --arg compiler \"ghc442\"
+#
+#
+# Use as a development environment
+#
+# $ nix-shell default.nix
+#
+{ compiler ? "ghc822" }:
+
+let
+  config = {
+    packageOverrides = super: let self = super.pkgs; in
+    {
+      haskell = super.haskell // {
+        packages = super.haskell.packages // {
+          "${compiler}" = super.haskell.packages."${compiler}".override {
+            overrides = self: super: {
+              # Build with latest known stable version.
+              purebred = with pkgs.haskell.lib; dontHaddock (self.callPackage ./.nix/purebred.nix { });
+              purebred-email = self.callPackage ./.nix/purebred-email.nix { };
+              # Version pins since those versions were bleeding edge and not on
+              # hackage/stackage or Nix yet. Remove these once builds without
+              # these pass.
+              notmuch = self.callPackage ./.nix/hs-notmuch.nix {
+                notmuch = pkgs.notmuch;
+                talloc = pkgs.talloc;
+              };
+              brick = self.callPackage ./.nix/brick.nix { };
+              vty = self.callPackage ./.nix/vty.nix { };
+              Cabal = self.callPackage ./.nix/Cabal.nix { };
+            };
+          };
+        };
+      };
+    };
+  };
+  pkgs = import <nixpkgs> { inherit config; };
+  env = pkgs.haskell.packages.${compiler}.ghcWithPackages (self: [
+    self.purebred
+  ]);
+  in
+    if pkgs.lib.inNixShell
+    then pkgs.haskell.packages.${compiler}.purebred.env
+    else {
+        purebred = pkgs.stdenv.mkDerivation {
+          name = "purebred-with-packages-${env.version}";
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          # This creates a Bash script, which sets the GHC in order for dyre to be
+          # able to build the config file.
+          buildCommand = ''
+            mkdir -p $out/bin
+            makeWrapper ${env}/bin/purebred $out/bin/purebred \
+            --set NIX_GHC "${env}/bin/ghc"
+          '';
+          preferLocalBuild = true;
+          allowSubstitutes = false;
+        };
+      }


### PR DESCRIPTION
This adds a few overwrites needed for packages which are not in the known good
set for GHC 8.2.2. Also, we pin Cabal with which we won't be able to build
purebred.