### PR TITLE
explicitly record list lengths in AppState

### DIFF
--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -92,8 +92,8 @@ initialState conf = do
         Right vec ->
             let mi =
                     MailIndex
-                        (L.list ListOfMails mempty 1)
-                        (L.list ListOfThreads vec 1)
+                        (ListWithLength (L.list ListOfMails mempty 1) (Just 0))
+                        (ListWithLength (L.list ListOfThreads vec 1) (Just (length vec)))
                         (E.editorText SearchThreadsEditor Nothing searchterms)
                         (E.editorText ManageMailTagsEditor Nothing "")
                         (E.editorText ManageThreadTagsEditor Nothing "")


### PR DESCRIPTION
For some lists - namely, those with an underlying type whose
'length' function may not be O(1), and especially if it may force
unwated computation - it is better for efficiency to record the
length separately, or not record it at all.  Add the ListWithLength
type to use for the thread and mail index lists.  Update
'currentItemW' to handle the case where the length is not recorded
(if length is not known it says "Item {i} of ?").

Also drive-by refactor the 'statusbar' function to avoid the
WithContext instance for (Maybe MIMEMessage).