### PR TITLE
lay groundwork for custom event processing

### DIFF
--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -188,7 +188,6 @@ defaultConfig =
       , _cvSubjectKeybindings = composeSubjectKeybindings
       , _cvSendMailCmd = renderSendMail
       , _cvListOfAttachmentsKeybindings = listOfAttachmentsKeybindings
-      , _cvBoundary = []
       , _cvIdentities = []
       }
     , _confHelpView = HelpViewSettings
@@ -200,4 +199,5 @@ defaultConfig =
       , _fbSearchPathKeybindings = manageSearchPathKeybindings
       , _fbHomePath = getHomeDirectory
       }
+    , _confExtra = ()
     }

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -785,7 +785,7 @@ sendMail s = do
         from = either (pure []) id $ parseOnly mailboxList $ T.encodeUtf8 $ T.unlines $ E.getEditContents $ view (asCompose . cFrom) s
         subject = T.unlines $ E.getEditContents $ view (asCompose . cSubject) s
         attachments' = toListOf (asCompose . cAttachments . L.listElementsL . traversed) s
-        (b, l') = splitAt 50 $ view (asConfig . confComposeView . cvBoundary) s
+        (b, l') = splitAt 50 $ view (asConfig . confBoundary) s
         mail = if has (asCompose . cAttachments . L.listElementsL . traversed . filtered isAttachment) s
                 then Just $ createMultipartMixedMessage (C8.pack b) attachments'
                 else firstOf (asCompose . cAttachments . L.listElementsL . traversed) s
@@ -812,7 +812,7 @@ trySendAndCatch l' m s = do
     catch
         (cmd m $> (s
          & set asCompose (initialCompose defMailboxes)
-         . set (asConfig . confComposeView . cvBoundary) l'))
+         . set (asConfig . confBoundary) l'))
         (\e ->
               let err = show (e :: IOException)
               in pure $ s & setError (SendMailError err))

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | The main application module
@@ -79,8 +80,13 @@ handleViewEvent = f where
   f _ _ = dispatch nullEventHandler
 
 
-appEvent :: AppState -> T.BrickEvent Name e -> T.EventM Name (T.Next AppState)
+appEvent
+  :: AppState               -- ^ program state
+  -> T.BrickEvent Name PurebredEvent  -- ^ event
+  -> T.EventM Name (T.Next AppState)
 appEvent s (T.VtyEvent ev) = handleViewEvent (focusedViewName s) (focusedViewWidget s ListOfThreads) s ev
+appEvent _ (T.AppEvent ev) = case ev of
+  { }  -- handle "internal" events (none defined yet; remove EmptyCase when there are)
 appEvent s _ = M.continue s
 
 initialState :: InternalConfiguration -> IO AppState
@@ -117,7 +123,9 @@ initialState conf = do
             in pure $
                AppState conf mi mv (initialCompose mailboxes) Nothing viewsettings fb
 
-theApp :: AppState -> M.App AppState e Name
+theApp
+  :: AppState               -- ^ initial state
+  -> M.App AppState PurebredEvent Name
 theApp s =
     M.App
     { M.appDraw = drawUI


### PR DESCRIPTION
brick supports custom events.  In time we will use custom events,
supplied to the event loop via a 'BChan', for various purposes.
This commit lays some groundwork for the use of custom events.  In
particular:

- the PurebredEvent type is defined (with no constructors, for now)

- the app event handler has an equation for processing PurebredEvent
  events (an empty case, for now)

- during initialisation, a BChan is constructed and stored in the
  InternalConfiguration

Additionally, drive-by refactor the Configuration data type so that
the "boundary" field is only present in the InternalConfiguration
(it makes no sense to expose it to users).  Also, simplify several
lens definitions for the Configuration data type.