### PR TITLE
implement lazy thread search result loading

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -85,7 +85,7 @@ library
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0
-                     , notmuch >= 0.1 && < 0.2
+                     , notmuch >= 0.2 && < 0.3
                      , text
                      , typed-process >= 0.2.1.0
                      , directory >= 1.2.5.0

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -66,6 +66,7 @@ library
                      , UI.Help.Keybindings
                      , UI.Utils
                      , UI.Views
+                     , Purebred.Events
                      , Purebred.LazyVector
                      , Purebred.Tags
                      , Purebred.System.Directory

--- a/src/Purebred/Events.hs
+++ b/src/Purebred/Events.hs
@@ -1,0 +1,55 @@
+-- This file is part of purebred
+-- Copyright (C) 2019  Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{- |
+
+Types and functions for custom brick events.
+
+-}
+module Purebred.Events
+  (
+    PurebredEvent(..)
+
+  , Generation
+  , firstGeneration
+  , nextGeneration
+  ) where
+
+-- | A serial number that can be used to match (or ignore as
+-- irrelevant) asynchronous events to current application state.
+--
+-- Use the 'Eq' and 'Ord' instances to compare generations.  The
+-- constructor is hidden; use 'firstGeneration' as the first
+-- generation, and use 'nextGeneration' to monotonically increment
+-- it.
+--
+newtype Generation = Generation Integer
+  deriving (Eq, Ord)
+
+firstGeneration :: Generation
+firstGeneration = Generation 0
+
+nextGeneration :: Generation -> Generation
+nextGeneration (Generation n) = Generation (succ n)
+
+
+-- | Purebred event type.  In the future we can abstract this over
+-- a custom event type to allow plugins to define their own events.
+-- But I've YAGNI'd it for now because it will require an event
+-- type parameter on 'AppState', which will be a noisy change.
+--
+data PurebredEvent
+  = NotifyNumThreads Int Generation

--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -23,7 +23,6 @@ import qualified Data.Text as T
 import Control.Lens (view, over, set, firstOf, folded, Lens')
 
 import qualified Notmuch
-import Notmuch.Search
 
 import Error
 import Types
@@ -121,7 +120,7 @@ getMessages
 getMessages s settings =
   withDatabaseReadOnly (view nmDatabase settings) go
   where go db = do
-              msgs <- Notmuch.query db (FreeForm $ T.unpack s) >>= Notmuch.messages
+              msgs <- Notmuch.query db (Notmuch.Bare $ T.unpack s) >>= Notmuch.messages
               mails <- liftIO $ mapM messageToMail msgs
               pure $ Vec.fromList mails
 
@@ -181,7 +180,7 @@ getThreads s settings =
   withDatabaseReadOnly (view nmDatabase settings) go
   where
     go db = do
-        ts <- Notmuch.query db (FreeForm $ T.unpack s) >>= Notmuch.threads
+        ts <- Notmuch.query db (Notmuch.Bare $ T.unpack s) >>= Notmuch.threads
         t <- liftIO $ lazyTraverse threadToThread ts
         pure $ fromList 128 {- chunk size -} t
 
@@ -212,7 +211,7 @@ getThread
   :: (MonadError Error m, MonadIO m)
   => Notmuch.Database mode -> B.ByteString -> m (Notmuch.Thread mode)
 getThread db tid = do
-  t <- Notmuch.query db (Thread tid) >>= Notmuch.threads
+  t <- Notmuch.query db (Notmuch.Thread tid) >>= Notmuch.threads
   maybe (throwError (ThreadNotFound tid)) pure (firstOf folded t)
 
 threadToThread

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -34,6 +34,7 @@ import Notmuch (Tag)
 import Data.MIME
 
 import Error
+import Purebred.LazyVector (V)
 
 {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
@@ -84,7 +85,7 @@ search and composes e-mails from here.
 -}
 data MailIndex = MailIndex
     { _miListOfMails  :: ListWithLength V.Vector NotmuchMail
-    , _miListOfThreads :: ListWithLength V.Vector NotmuchThread
+    , _miListOfThreads :: ListWithLength V NotmuchThread
     , _miSearchThreadsEditor :: E.Editor T.Text Name
     , _miMailTagsEditor :: E.Editor T.Text Name
     , _miThreadTagsEditor :: E.Editor T.Text Name
@@ -93,13 +94,13 @@ data MailIndex = MailIndex
 miMails :: Lens' MailIndex (ListWithLength V.Vector NotmuchMail)
 miMails = lens _miListOfMails (\m v -> m { _miListOfMails = v })
 
-miThreads :: Lens' MailIndex (ListWithLength V.Vector NotmuchThread)
+miThreads :: Lens' MailIndex (ListWithLength V NotmuchThread)
 miThreads = lens _miListOfThreads (\m v -> m { _miListOfThreads = v})
 
 miListOfMails :: Lens' MailIndex (L.GenericList Name V.Vector NotmuchMail)
 miListOfMails = miMails . listList
 
-miListOfThreads :: Lens' MailIndex (L.GenericList Name V.Vector NotmuchThread)
+miListOfThreads :: Lens' MailIndex (L.GenericList Name V NotmuchThread)
 miListOfThreads = miThreads . listList
 
 miSearchThreadsEditor :: Lens' MailIndex (E.Editor T.Text Name)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -518,4 +518,4 @@ data TagOp = RemoveTag Tag | AddTag Tag | ResetTags
 -- type parameter on 'AppState', which will be a noisy change.
 --
 data PurebredEvent
-  -- internal event types will go here
+  = NotifyNumThreads !Int

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -9,6 +8,7 @@
 module Types
   ( module Types
   , Tag
+  , module Purebred.Events
   ) where
 
 import GHC.Generics (Generic)
@@ -35,6 +35,7 @@ import Notmuch (Tag)
 import Data.MIME
 
 import Error
+import Purebred.Events
 import Purebred.LazyVector (V)
 
 {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
@@ -56,12 +57,6 @@ data Name =
     | ManageFileBrowserSearchPath
     | StatusBar
     deriving (Eq,Show,Ord)
-
--- | A serial number that can be used to match (or ignore as
--- irrelevant) asynchronous events to current application state.
---
-newtype Generation = Generation Integer
-  deriving (Eq, Ord, Enum)
 
 -- | A brick list, with a field that optionally contains its length.
 --
@@ -522,12 +517,3 @@ decodeLenient = T.decodeUtf8With T.lenientDecode
 -- | Tag operations
 data TagOp = RemoveTag Tag | AddTag Tag | ResetTags
   deriving (Show, Eq)
-
-
--- | Purebred event type.  In the future we can abstract this over
--- a custom event type to allow plugins to define their own events.
--- But I've YAGNI'd it for now because it will require an event
--- type parameter on 'AppState', which will be a noisy change.
---
-data PurebredEvent
-  = NotifyNumThreads Int Generation

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -719,7 +719,7 @@ notifyNumThreads :: (MonadIO m, Foldable t) => AppState -> t a -> m AppState
 notifyNumThreads s l =
   let
     len = length l
-    nextGen = views (asMailIndex . miListOfThreadsGeneration) succ s
+    nextGen = views (asMailIndex . miListOfThreadsGeneration) nextGeneration s
     s' = set (asMailIndex . miListOfThreadsGeneration) nextGen s
     go = len `seq` writeBChan (view (asConfig . confBChan) s) (NotifyNumThreads len nextGen)
   in

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -703,7 +703,7 @@ applySearch s = runExceptT (Notmuch.getThreads searchterms (view (asConfig . con
    where searchterms = currentLine $ view (asMailIndex . miSearchThreadsEditor . E.editContentsL) s
          updateList vec =
            over (asMailIndex . miThreads . listList) (L.listReplace vec (Just 0))
-           . set (asMailIndex . miThreads . listLength) (Just (length vec))
+           . set (asMailIndex . miThreads . listLength) Nothing
 
 setMailsForThread :: AppState -> IO AppState
 setMailsForThread s = selectedItemHelper (asMailIndex . miListOfThreads) s $ \t ->
@@ -714,10 +714,10 @@ setMailsForThread s = selectedItemHelper (asMailIndex . miListOfThreads) s $ \t 
   in either setError updateThreadMails <$> runExceptT (Notmuch.getThreadMessages dbpath t)
 
 selectedItemHelper
-    :: Applicative f
-    => Getting (L.List n t) AppState (L.List n t)
+    :: (Applicative f, Foldable t, L.Splittable t)
+    => Getting (L.GenericList n t a) AppState (L.GenericList n t a)
     -> AppState
-    -> (t -> f (AppState -> AppState))
+    -> (a -> f (AppState -> AppState))
     -> f AppState
 selectedItemHelper l s func =
   ($ s) <$> case L.listSelectedElement (view l s) of

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -75,10 +75,10 @@ import Prelude hiding (readFile, unlines)
 import Data.Functor (($>))
 import Control.Lens
        (_Just, to, at, ix, _1, _2, toListOf, traversed, has, snoc,
-        filtered, set, over, preview, view, (&), nullOf, firstOf,
+        filtered, set, over, preview, view, views, (&), nullOf, firstOf,
         traversed, traverse, Getting, Lens')
 import Control.Concurrent (forkIO)
-import Control.Monad ((>=>), void)
+import Control.Monad ((>=>))
 import Control.Monad.Except (runExceptT)
 import Control.Exception (catch, IOException)
 import Control.Monad.IO.Class (liftIO, MonadIO)
@@ -705,7 +705,7 @@ applySearch s = do
   r <- runExceptT (Notmuch.getThreads searchterms (view (asConfig . confNotmuch) s))
   case r of
     Left e -> pure $ setError e s
-    Right threads -> notifyNumThreads s threads $> updateList threads s
+    Right threads -> updateList threads <$> notifyNumThreads s threads
    where searchterms = currentLine $ view (asMailIndex . miSearchThreadsEditor . E.editContentsL) s
          updateList vec =
            over (asMailIndex . miThreads . listList) (L.listReplace vec (Just 0))
@@ -713,11 +713,17 @@ applySearch s = do
 
 -- | Fork a thread to compute the length of the container and send a
 -- NotifyNumThreads event.  'seq' ensures that the work is actually
--- done by the spawned thread.
-notifyNumThreads :: (MonadIO m, Foldable t) => AppState -> t a -> m ()
-notifyNumThreads s l = void $ liftIO $ forkIO $
-  let len = length l
-  in len `seq` writeBChan (view (asConfig . confBChan) s) (NotifyNumThreads len)
+-- done by the spawned thread.  Increments the generation and updates
+-- the 'AppState' with it.
+notifyNumThreads :: (MonadIO m, Foldable t) => AppState -> t a -> m AppState
+notifyNumThreads s l =
+  let
+    len = length l
+    nextGen = views (asMailIndex . miListOfThreadsGeneration) succ s
+    s' = set (asMailIndex . miListOfThreadsGeneration) nextGen s
+    go = len `seq` writeBChan (view (asConfig . confBChan) s) (NotifyNumThreads len nextGen)
+  in
+    liftIO $ forkIO go $> s'
 
 setMailsForThread :: AppState -> IO AppState
 setMailsForThread s = selectedItemHelper (asMailIndex . miListOfThreads) s $ \t ->

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -96,7 +96,7 @@ initialState conf =
         MailIndex
             (ListWithLength (L.list ListOfMails mempty 1) (Just 0))
             (ListWithLength (L.list ListOfThreads mempty 1) (Just 0))
-            (Generation 0)
+            firstGeneration
             (E.editorText SearchThreadsEditor Nothing searchterms)
             (E.editorText ManageMailTagsEditor Nothing "")
             (E.editorText ManageThreadTagsEditor Nothing "")

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -82,7 +82,10 @@ appEvent
   -> T.EventM Name (T.Next AppState)
 appEvent s (T.VtyEvent ev) = handleViewEvent (focusedViewName s) (focusedViewWidget s ListOfThreads) s ev
 appEvent s (T.AppEvent ev) = case ev of
-  NotifyNumThreads n -> M.continue $ set (asMailIndex . miThreads . listLength) (Just n) s
+  NotifyNumThreads n gen -> M.continue $
+    if gen == view (asMailIndex . miListOfThreadsGeneration) s
+    then set (asMailIndex . miThreads . listLength) (Just n) s
+    else s
 appEvent s _ = M.continue s
 
 initialState :: InternalConfiguration -> IO AppState
@@ -93,6 +96,7 @@ initialState conf =
         MailIndex
             (ListWithLength (L.list ListOfMails mempty 1) (Just 0))
             (ListWithLength (L.list ListOfThreads mempty 1) (Just 0))
+            (Generation 0)
             (E.editorText SearchThreadsEditor Nothing searchterms)
             (E.editorText ManageMailTagsEditor Nothing "")
             (E.editorText ManageThreadTagsEditor Nothing "")

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -99,7 +99,7 @@ initialState conf = do
             let mi =
                     MailIndex
                         (ListWithLength (L.list ListOfMails mempty 1) (Just 0))
-                        (ListWithLength (L.list ListOfThreads vec 1) (Just (length vec)))
+                        (ListWithLength (L.list ListOfThreads vec 1) Nothing)
                         (E.editorText SearchThreadsEditor Nothing searchterms)
                         (E.editorText ManageMailTagsEditor Nothing "")
                         (E.editorText ManageThreadTagsEditor Nothing "")


### PR DESCRIPTION
Here it is!

How to test:

1. Start a big search (e.g. "*")

2. Observe that the search returns quickly, and you are able to scroll around.
   But do not jump to bottom!

3. Observe that the number of items is reported as "?"

4. Watch in breathless awe as, at some point, the "?" turns into a number!

5. Jump to bottom.  This should, now that the spine of the list has been
   traversed, in order to determine its length, be near-instantaneous.


For code review, it is best to digest this PR on a commit-by-commit basis.

Changes (reverse order):

```
20e58ed (Fraser Tweedale, 3 days ago)
   use correct notmuch SearchTerm constructors

   The 'FreeForm' constructor is not correct.  Although the current
   'show' instance does not quote it, this is a bug.  The correct constructor
   for passing a query string to libnotmuch as-is is Bare. Change to the
   correct contstructor and also access them via the qualified Notmuch import
   (Notmuch.Search will be removed in a future release).

b4548db (Fraser Tweedale, 18 minutes ago)
   move event types to new module

   Add the Purebred.Events module and move types and functions related to
   events to it.

   Update the generation 'Generation' to hide the constructor and avoid the
   'Enum' instance.  This avoids a conflict between
   -XDeriveAnyClass and -XGeneralizedNewtypeDeriving, which caused a build
   failure with GHC 8.0 and warnings with later versions.  The removal of the
   'Enum' type class also lets us enforce monotonicity.

bb88515 (Fraser Tweedale, 21 hours ago)
   ignore obsolete NotifyNumThreads events

   If a search with a small result is performed after a search with a large
   result, the NotifyNumThreads event for the earlier search can arrive after
   the NotifyNumThreads event for the later search.  As a consequence, the
   wrong number of items will be displayed.

   Define the 'Generation' data type for recording a particular
   "generation" of the 'AppState' (or some aspect thereof).  Events can also
   carry a 'Generation' to indicate the generation(s) of the AppState to which
   it is related.

   Update the 'NotifyNumThreads' event data type and the application state for
   the thread index to each include a generation field. Update the event
   handler to ignore 'NotifyNumThreads' events that do not match the current
   generation of the thread index.

   Part of: https://github.com/purebred-mua/purebred/issues/233

367a739 (Fraser Tweedale, 2 days ago)
   fork thread to compute length of thread index

   After performing a notmuch search, fork a thread to compute the length of
   the result (fully evaluating the spine of the list) and send a notification
   to brick to update the model.

   This adds the 'NotifyNumThreads' constructor to the 'PurebredEvent' type,
   and updates the event handler to process it.

   The 'initialState' function is refactored to reuse 'applyThreads', where
   the "fork background thread" behaviour is defined, so that the thread is
   spawned for the initial search upon startup, too.

   Part of: https://github.com/purebred-mua/purebred/issues/233

9c8c21f (Fraser Tweedale, 5 weeks ago)
   lazily load threads

   If search result is very long, it takes a long time to load all the items. 
   Preliminary work in brick, hs-notmuch and purebred leads to what is now a
   small change to enable lazy loading of search results.

   First, we move to (Haskell) notmuch-0.2 which fixes issues with lazy result
   loads.  In particular, derived objects always hold a reference to their
   parent object, to prevent it being GC'd, which caused segfaults when the
   child object (wihch is an opaque pointer) held pointers into the parent. 
   One programmer-friendly consequence of this is that resource management of
   the database handle is now implicit.  The database will be closed when it
   gets GC'd, which will only happen when all derived objects (queries,
   threads and messages) have been GC'd.

   Second, we update the thread index list to use the 'V' container type added
   a little while ago, which supports lazy loading.

   Third, for processing notmuch Thread objects into purebred's NotmuchThread
   type, we define a []- and IO-specific 'lazyTraverse' function that uses
   'unsafeInterleaveIO' to retain the lazy loading behaviour afforded by
   hs-notmuch.

   Finally, we tweak the functions that update the AppState to not set the
   'length' of the list (because 'length' would force the entire spine of the
   container).

   Fixes: https://github.com/purebred-mua/purebred/issues/233
```