### PR TITLE
Adjust the notmuch version for nix builds

### DIFF
--- a/.nix/hs-notmuch.nix
+++ b/.nix/hs-notmuch.nix
@@ -1,16 +1,10 @@
-{ mkDerivation, base, bytestring, c2hs, containers, deepseq
-, fetchgit, mtl, notmuch, profunctors, stdenv, tagged, talloc, text
-, time
+{ mkDerivation, base, bytestring, c2hs, deepseq, mtl, notmuch
+, profunctors, stdenv, tagged, talloc, text, time
 }:
 mkDerivation {
   pname = "notmuch";
-  version = "0.1.0.0";
-  src = fetchgit {
-    url = "https://github.com/purebred-mua/hs-notmuch.git";
-    sha256 = "0p9q48lpvib2l2fy9k2s77d7rxm0vkiclji3s016ic7jpyqpmyv0";
-    rev = "2d2ceedbe3d612ec273477fed0217228b3f35914";
-    fetchSubmodules = true;
-  };
+  version = "0.2.0.0";
+  sha256 = "feeafa5bdc00c1036755c92d72e7b69cb388ae9bab5064410655007cc8216ff0";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
@@ -18,7 +12,6 @@ mkDerivation {
   ];
   librarySystemDepends = [ notmuch talloc ];
   libraryToolDepends = [ c2hs ];
-  executableHaskellDepends = [ base bytestring containers mtl ];
   homepage = "https://github.com/purebred-mua/hs-notmuch";
   description = "Haskell binding to Notmuch, the mail indexer";
   license = stdenv.lib.licenses.gpl3;


### PR DESCRIPTION
Because the latest notmuch version bump, we'll need to bump the nix build
version too.