### PR TITLE
Feature/manage attachments

### DIFF
--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, base, config-ini, containers, contravariant
+, data-clist, deepseq, directory, dlist, filepath, microlens
+, microlens-mtl, microlens-th, QuickCheck, stdenv, stm
+, template-haskell, text, text-zipper, transformers, unix, vector
+, vty, word-wrap
+}:
+mkDerivation {
+  pname = "brick";
+  version = "0.47";
+  sha256 = "47ce722f7a5f0457c97222823e863e455fe8b30710c2a9926d5930a9703892be";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base config-ini containers contravariant data-clist deepseq
+    directory dlist filepath microlens microlens-mtl microlens-th stm
+    template-haskell text text-zipper transformers unix vector vty
+    word-wrap
+  ];
+  testHaskellDepends = [
+    base containers microlens QuickCheck vector
+  ];
+  homepage = "https://github.com/jtdaugherty/brick/";
+  description = "A declarative terminal user interface library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -6,6 +6,7 @@ let
     haskellPackages = super.haskell.packages.${compilerVersion}.override {
       overrides = hself: hsuper: {
         purebred = hsuper.callPackage ./purebred.nix { };
+        brick = hsuper.callPackage ./brick.nix {};
         notmuch = hsuper.callPackage ./hs-notmuch.nix {
           notmuch = self.pkgs.notmuch;
           talloc = self.pkgs.talloc;

--- a/.nix/purebred.nix
+++ b/.nix/purebred.nix
@@ -17,8 +17,8 @@ mkDerivation {
   libraryHaskellDepends = [
     attoparsec base brick bytestring case-insensitive containers
     deepseq directory dyre exceptions filepath lens mime-types mtl
-    notmuch optparse-applicative purebred-email random text text-zipper
-    time typed-process vector vty
+    notmuch optparse-applicative purebred-email random temporary text
+    text-zipper time typed-process vector vty
   ];
   testTarget = "unit";
   executableHaskellDepends = [ base ];

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -70,6 +70,7 @@ library
                      , Purebred.LazyVector
                      , Purebred.Tags
                      , Purebred.System.Directory
+                     , Purebred.System.Process
                      , UI.FileBrowser.Main
                      , UI.FileBrowser.Keybindings
                      , Config.Main
@@ -103,6 +104,7 @@ library
                      , mime-types
                      , random
                      , time
+                     , temporary
 
 executable purebred
   hs-source-dirs:      app

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -32,7 +32,8 @@ import UI.Index.Keybindings
         manageMailTagsKeybindings)
 import UI.Mail.Keybindings
        (displayMailKeybindings, mailViewManageMailTagsKeybindings,
-        mailAttachmentsKeybindings, openWithKeybindings)
+        mailAttachmentsKeybindings, openWithKeybindings,
+        pipeToKeybindings)
 import UI.Help.Keybindings (helpKeybindings)
 import UI.ComposeEditor.Keybindings
        (listOfAttachmentsKeybindings, composeFromKeybindings,
@@ -174,6 +175,7 @@ defaultConfig =
       , _mvManageMailTagsKeybindings = mailViewManageMailTagsKeybindings
       , _mvMailListOfAttachmentsKeybindings = mailAttachmentsKeybindings
       , _mvOpenWithKeybindings = openWithKeybindings
+      , _mvPipeToKeybindings = pipeToKeybindings
       }
     , _confIndexView = IndexViewSettings
       { _ivBrowseThreadsKeybindings = browseThreadsKeybindings

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -31,7 +31,8 @@ import UI.Index.Keybindings
         searchThreadsKeybindings, manageThreadTagsKeybindings,
         manageMailTagsKeybindings)
 import UI.Mail.Keybindings
-       (displayMailKeybindings, mailViewManageMailTagsKeybindings)
+       (displayMailKeybindings, mailViewManageMailTagsKeybindings,
+        mailAttachmentsKeybindings)
 import UI.Help.Keybindings (helpKeybindings)
 import UI.ComposeEditor.Keybindings
        (listOfAttachmentsKeybindings, composeFromKeybindings,
@@ -171,6 +172,7 @@ defaultConfig =
       , _mvHeadersToShow = (`elem` ["subject", "to", "from", "cc"])
       , _mvKeybindings = displayMailKeybindings
       , _mvManageMailTagsKeybindings = mailViewManageMailTagsKeybindings
+      , _mvMailListOfAttachmentsKeybindings = mailAttachmentsKeybindings
       }
     , _confIndexView = IndexViewSettings
       { _ivBrowseThreadsKeybindings = browseThreadsKeybindings

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -32,7 +32,7 @@ import UI.Index.Keybindings
         manageMailTagsKeybindings)
 import UI.Mail.Keybindings
        (displayMailKeybindings, mailViewManageMailTagsKeybindings,
-        mailAttachmentsKeybindings)
+        mailAttachmentsKeybindings, openWithKeybindings)
 import UI.Help.Keybindings (helpKeybindings)
 import UI.ComposeEditor.Keybindings
        (listOfAttachmentsKeybindings, composeFromKeybindings,
@@ -173,6 +173,7 @@ defaultConfig =
       , _mvKeybindings = displayMailKeybindings
       , _mvManageMailTagsKeybindings = mailViewManageMailTagsKeybindings
       , _mvMailListOfAttachmentsKeybindings = mailAttachmentsKeybindings
+      , _mvOpenWithKeybindings = openWithKeybindings
       }
     , _confIndexView = IndexViewSettings
       { _ivBrowseThreadsKeybindings = browseThreadsKeybindings

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -34,6 +34,7 @@ data Error
   | FileParseError FilePath String -- ^ failed to parse a file
   | SendMailError String
   | GenericError String
+  | ProcessError String
   deriving (Show, Eq)
 
 instance AsNotmuchError Error where

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -1,0 +1,50 @@
+-- This file is part of purebred
+-- Copyright (C) 2019 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+module Purebred.System.Process
+  ( tryRunProcess
+  , handleIOException
+  , handleExitCode
+  ) where
+
+import System.Exit (ExitCode(..))
+import Control.Exception (try, IOException)
+import System.Process.Typed (readProcessStderr, ProcessConfig)
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.ByteString.Lazy.Char8 as L8
+import Control.Lens (set, (&))
+import Data.Semigroup ((<>))
+
+import Error
+import Types
+
+
+-- | Handler to handle exit failures and possibly showing an error in the UI.
+handleExitCode :: AppState -> (ExitCode, LB.ByteString) -> AppState
+handleExitCode s (ExitFailure e, stderr) = s & setError (ProcessError (show e <> ": " <> L8.unpack stderr))
+handleExitCode s (ExitSuccess, _) = s
+
+-- | Handle only IOExceptions, everything else is fair game.
+handleIOException :: AppState -> IOException -> IO AppState
+handleIOException s' ex = pure $ s' & setError (ProcessError (show ex))
+
+-- | Try running a process given by the `FilePath` and catch an IOExceptions.
+-- This is to avoid a crashing process also take down the running Brick program.
+tryRunProcess :: ProcessConfig stdout stderr stdin -> IO (Either IOException (ExitCode, LB.ByteString))
+tryRunProcess = try . readProcessStderr
+
+setError :: Error -> AppState -> AppState
+setError = set asError . Just

--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -59,6 +59,14 @@ chooseEntity preferredContentType msg =
     -- otherwise select first entity;
   in firstOf (entities . filtered match) msg <|> firstOf entities msg
 
+entityToBytes :: WireEntity -> Either Error B.ByteString
+entityToBytes msg = either err Right (convert msg)
+  where
+    err :: EncodingError -> Either Error B.ByteString
+    err e = Left $ GenericError ("Decoding error: " <> show e)
+    convert :: WireEntity -> Either EncodingError B.ByteString
+    convert m = view body <$> view transferDecoded m
+
 entityToText :: WireEntity -> T.Text
 entityToText msg = either err (view body) $
   view transferDecoded msg >>= view charsetDecoded

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -58,6 +58,7 @@ data Name =
     | ManageFileBrowserSearchPath
     | MailListOfAttachments
     | MailAttachmentOpenWithEditor
+    | MailAttachmentPipeToEditor
     | StatusBar
     deriving (Eq,Show,Ord)
 
@@ -129,6 +130,7 @@ data MailView = MailView
     , _mvHeadersState :: HeadersState
     , _mvAttachments :: L.List Name WireEntity
     , _mvOpenCommand:: E.Editor T.Text Name
+    , _mvPipeCommand :: E.Editor T.Text Name
     }
 
 mvMail :: Lens' MailView (Maybe MIMEMessage)
@@ -142,6 +144,9 @@ mvAttachments = lens _mvAttachments (\mv hs -> mv { _mvAttachments = hs })
 
 mvOpenCommand :: Lens' MailView (E.Editor T.Text Name)
 mvOpenCommand = lens _mvOpenCommand (\mv hs -> mv { _mvOpenCommand = hs })
+
+mvPipeCommand :: Lens' MailView (E.Editor T.Text Name)
+mvPipeCommand = lens _mvPipeCommand (\mv hs -> mv { _mvPipeCommand = hs })
 
 data Compose = Compose
     { _cMail :: B.ByteString
@@ -336,6 +341,7 @@ data MailViewSettings = MailViewSettings
     , _mvManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
     , _mvMailListOfAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
     , _mvOpenWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
+    , _mvPipeToKeybindings :: [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
     }
     deriving (Generic, NFData)
 
@@ -359,6 +365,9 @@ mvMailListOfAttachmentsKeybindings = lens _mvMailListOfAttachmentsKeybindings (\
 
 mvOpenWithKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
 mvOpenWithKeybindings = lens _mvOpenWithKeybindings (\s x -> s { _mvOpenWithKeybindings = x })
+
+mvPipeToKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
+mvPipeToKeybindings = lens _mvPipeToKeybindings (\s x -> s { _mvPipeToKeybindings = x })
 
 data ViewName
     = Threads

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -56,6 +56,7 @@ data Name =
     | ManageThreadTagsEditor
     | ListOfFiles
     | ManageFileBrowserSearchPath
+    | MailListOfAttachments
     | StatusBar
     deriving (Eq,Show,Ord)
 
@@ -125,6 +126,7 @@ data HeadersState = ShowAll | Filtered
 data MailView = MailView
     { _mvMail :: Maybe MIMEMessage
     , _mvHeadersState :: HeadersState
+    , _mvAttachments :: L.List Name WireEntity
     }
 
 mvMail :: Lens' MailView (Maybe MIMEMessage)
@@ -132,6 +134,9 @@ mvMail = lens _mvMail (\mv pm -> mv { _mvMail = pm })
 
 mvHeadersState :: Lens' MailView HeadersState
 mvHeadersState = lens _mvHeadersState (\mv hs -> mv { _mvHeadersState = hs })
+
+mvAttachments :: Lens' MailView (L.List Name WireEntity)
+mvAttachments = lens _mvAttachments (\mv hs -> mv { _mvAttachments = hs })
 
 data Compose = Compose
     { _cMail :: B.ByteString
@@ -324,6 +329,7 @@ data MailViewSettings = MailViewSettings
     , _mvHeadersToShow       :: CI.CI B.ByteString -> Bool
     , _mvKeybindings         :: [Keybinding 'ViewMail 'ScrollingMailView]
     , _mvManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
+    , _mvMailListOfAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
     }
     deriving (Generic, NFData)
 
@@ -341,6 +347,10 @@ mvKeybindings = lens _mvKeybindings (\mv x -> mv { _mvKeybindings = x })
 
 mvManageMailTagsKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'ManageMailTagsEditor]
 mvManageMailTagsKeybindings = lens _mvManageMailTagsKeybindings (\mv x -> mv { _mvManageMailTagsKeybindings = x })
+
+mvMailListOfAttachmentsKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'MailListOfAttachments]
+mvMailListOfAttachmentsKeybindings = lens _mvMailListOfAttachmentsKeybindings (\s x -> s { _mvMailListOfAttachmentsKeybindings = x })
+
 
 data ViewName
     = Threads

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -57,6 +57,7 @@ data Name =
     | ListOfFiles
     | ManageFileBrowserSearchPath
     | MailListOfAttachments
+    | MailAttachmentOpenWithEditor
     | StatusBar
     deriving (Eq,Show,Ord)
 
@@ -127,6 +128,7 @@ data MailView = MailView
     { _mvMail :: Maybe MIMEMessage
     , _mvHeadersState :: HeadersState
     , _mvAttachments :: L.List Name WireEntity
+    , _mvOpenCommand:: E.Editor T.Text Name
     }
 
 mvMail :: Lens' MailView (Maybe MIMEMessage)
@@ -137,6 +139,9 @@ mvHeadersState = lens _mvHeadersState (\mv hs -> mv { _mvHeadersState = hs })
 
 mvAttachments :: Lens' MailView (L.List Name WireEntity)
 mvAttachments = lens _mvAttachments (\mv hs -> mv { _mvAttachments = hs })
+
+mvOpenCommand :: Lens' MailView (E.Editor T.Text Name)
+mvOpenCommand = lens _mvOpenCommand (\mv hs -> mv { _mvOpenCommand = hs })
 
 data Compose = Compose
     { _cMail :: B.ByteString
@@ -330,6 +335,7 @@ data MailViewSettings = MailViewSettings
     , _mvKeybindings         :: [Keybinding 'ViewMail 'ScrollingMailView]
     , _mvManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
     , _mvMailListOfAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
+    , _mvOpenWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
     }
     deriving (Generic, NFData)
 
@@ -351,6 +357,8 @@ mvManageMailTagsKeybindings = lens _mvManageMailTagsKeybindings (\mv x -> mv { _
 mvMailListOfAttachmentsKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'MailListOfAttachments]
 mvMailListOfAttachmentsKeybindings = lens _mvMailListOfAttachmentsKeybindings (\s x -> s { _mvMailListOfAttachmentsKeybindings = x })
 
+mvOpenWithKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
+mvOpenWithKeybindings = lens _mvOpenWithKeybindings (\s x -> s { _mvOpenWithKeybindings = x })
 
 data ViewName
     = Threads

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -50,10 +50,10 @@ data Name =
     | ComposeFrom
     | ComposeTo
     | ComposeSubject
+    | ComposeListOfAttachments
     | ScrollingHelpView
     | ManageMailTagsEditor
     | ManageThreadTagsEditor
-    | ListOfAttachments
     | ListOfFiles
     | ManageFileBrowserSearchPath
     | StatusBar
@@ -250,7 +250,7 @@ data ComposeViewSettings = ComposeViewSettings
     , _cvToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
     , _cvSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
     , _cvSendMailCmd :: B.ByteString -> IO (Either Error ())
-    , _cvListOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ListOfAttachments]
+    , _cvListOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
     , _cvIdentities :: [Mailbox]
     }
     deriving (Generic, NFData)
@@ -267,7 +267,7 @@ cvSubjectKeybindings = lens _cvSubjectKeybindings (\cv x -> cv { _cvSubjectKeybi
 cvSendMailCmd :: Lens' ComposeViewSettings (B.ByteString -> IO (Either Error ()))
 cvSendMailCmd = lens _cvSendMailCmd (\cv x -> cv { _cvSendMailCmd = x })
 
-cvListOfAttachmentsKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ListOfAttachments]
+cvListOfAttachmentsKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeListOfAttachments]
 cvListOfAttachmentsKeybindings = lens _cvListOfAttachmentsKeybindings (\cv x -> cv { _cvListOfAttachmentsKeybindings = x })
 
 cvIdentities :: Lens' ComposeViewSettings [Mailbox]

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -101,9 +101,10 @@ import Storage.ParsedMail
        (parseMail, getTo, getFrom, getSubject, toQuotedMail)
 import Types
 import Error
-import UI.Utils
-       (focusedViewWidget, selectedFiles, takeFileName)
-import UI.Views (listOfMailsView, mailView, focusNext, toggleLastVisibleWidget, indexView, resetView)
+import UI.Utils (selectedFiles, takeFileName)
+import UI.Views
+       (listOfMailsView, mailView, focusNext, toggleLastVisibleWidget, indexView, resetView,
+        focusedViewWidget)
 import Purebred.Tags (parseTagOps)
 import Purebred.System.Directory (listDirectory')
 
@@ -508,7 +509,7 @@ listUp :: Action v m AppState
 listUp =
     Action
     { _aDescription = ["mail index up one e-mail"]
-    , _aAction = \s -> case focusedViewWidget s ListOfThreads of
+    , _aAction = \s -> case focusedViewWidget s of
         ListOfThreads -> pure $ over (asMailIndex . miListOfThreads) L.listMoveUp s
         ScrollingMailView -> pure $ over (asMailIndex . miListOfMails) L.listMoveUp s
         ListOfAttachments -> pure $ over (asCompose . cAttachments) L.listMoveUp s
@@ -520,7 +521,7 @@ listDown :: Action v m AppState
 listDown =
     Action
     { _aDescription = ["mail index down one e-mail"]
-    , _aAction = \s -> case focusedViewWidget s ListOfThreads of
+    , _aAction = \s -> case focusedViewWidget s of
         ListOfThreads -> pure $ over (asMailIndex . miListOfThreads) L.listMoveDown s
         ScrollingMailView -> pure $ over (asMailIndex . miListOfMails) L.listMoveDown s
         ListOfAttachments -> pure $ over (asCompose . cAttachments) L.listMoveDown s
@@ -531,7 +532,7 @@ listDown =
 listJumpToEnd :: Action v m AppState
 listJumpToEnd = Action
   { _aDescription = ["move selection to last element"]
-    , _aAction = \s -> case focusedViewWidget s ListOfThreads of
+    , _aAction = \s -> case focusedViewWidget s of
         ListOfThreads -> pure $ listSetSelectionEnd (asMailIndex . miListOfThreads) s
         ScrollingMailView -> pure $ listSetSelectionEnd (asMailIndex . miListOfMails) s
         ListOfAttachments -> pure $ listSetSelectionEnd (asCompose . cAttachments) s
@@ -542,7 +543,7 @@ listJumpToEnd = Action
 listJumpToStart :: Action v m AppState
 listJumpToStart = Action
   { _aDescription = ["move selection to first element"]
-    , _aAction = \s -> case focusedViewWidget s ListOfThreads of
+    , _aAction = \s -> case focusedViewWidget s of
         ListOfThreads -> pure $ over (asMailIndex . miListOfThreads) (L.listMoveTo 0) s
         ScrollingMailView -> pure $ over (asMailIndex . miListOfMails) (L.listMoveTo 0) s
         ListOfAttachments -> pure $ over (asCompose . cAttachments) (L.listMoveTo 0) s
@@ -581,7 +582,7 @@ setTags :: [TagOp] -> Action v ctx AppState
 setTags ops =
     Action
     { _aDescription = ["apply given tags"]
-    , _aAction = \s -> case focusedViewWidget s ListOfThreads of
+    , _aAction = \s -> case focusedViewWidget s of
           ListOfMails -> selectedItemHelper (asMailIndex . miListOfMails) s (manageMailTags s ops)
           _ -> selectedItemHelper (asMailIndex . miListOfThreads) s (manageThreadTags s ops)
     }

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -59,6 +59,7 @@ module UI.Actions (
   , createAttachments
   , delete
   , applySearch
+  , openWithCommand
   ) where
 
 import Data.Functor.Identity (Identity(..))
@@ -80,9 +81,11 @@ import qualified Data.ByteString.Char8 as C8
 import Data.Attoparsec.ByteString.Char8 (parseOnly)
 import Data.Vector.Lens (vector)
 import System.Exit (ExitCode(..))
-import System.IO (openTempFile, hClose)
+import System.IO (openTempFile, hClose, hFlush)
+import GHC.IO.Handle (Handle)
+import System.IO.Temp (withSystemTempFile)
 import System.Directory (getTemporaryDirectory, removeFile)
-import System.Process.Typed (proc, runProcess)
+import System.Process.Typed (shell, proc, runProcess)
 import System.FilePath (takeDirectory, (</>))
 import qualified Data.Vector as Vector
 import Prelude hiding (readFile, unlines)
@@ -101,7 +104,6 @@ import Data.Text.Zipper
        (insertMany, currentLine, gotoEOL, clearZipper)
 import Data.Time.Clock (getCurrentTime)
 
-import Data.RFC5322 (Message(..))
 import qualified Data.RFC5322.Address.Text as AddressText (renderMailboxes)
 import Data.MIME
        (createMultipartMixedMessage, contentTypeApplicationOctetStream,
@@ -113,7 +115,7 @@ import Data.MIME
         WireEntity, DispositionType(..), ContentType(..), Mailbox(..))
 import qualified Storage.Notmuch as Notmuch
 import Storage.ParsedMail
-       (parseMail, getTo, getFrom, getSubject, toQuotedMail)
+       (parseMail, getTo, getFrom, getSubject, toQuotedMail, entityToBytes)
 import Types
 import Error
 import UI.Utils (selectedFiles, takeFileName)
@@ -122,6 +124,7 @@ import UI.Views
         focusedViewWidget)
 import Purebred.Tags (parseTagOps)
 import Purebred.System.Directory (listDirectory')
+import Purebred.System.Process (tryRunProcess, handleIOException, handleExitCode)
 
 class Scrollable (n :: Name) where
   makeViewportScroller :: Proxy n -> Brick.ViewportScroll Name
@@ -183,6 +186,10 @@ instance Completable 'ManageFileBrowserSearchPath where
     <$> (either setError updateBrowseFileContents
          <$> runExceptT (listDirectory' (currentLine $ view (asFileBrowser . fbSearchPath . E.editContentsL) s)))
 
+instance Completable 'MailAttachmentOpenWithEditor where
+  complete _ = pure
+               . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentOpenWithEditor . veState) Hidden
+
 -- | Generalisation of reset actions, whether they reset editors back to their
 -- initial state or throw away composed, but not yet sent mails.
 --
@@ -217,6 +224,10 @@ instance Resetable 'ManageFileBrowserSearchPath where
 
 instance Resetable 'MailListOfAttachments where
   reset _ = pure . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailListOfAttachments . veState) Hidden
+
+instance Resetable 'MailAttachmentOpenWithEditor where
+  reset _ = pure . over (asMailView . mvOpenCommand . E.editContentsL) clearZipper
+            . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentOpenWithEditor . veState) Hidden
 
 clearMailComposition :: AppState -> AppState
 clearMailComposition s =
@@ -286,6 +297,10 @@ instance Focusable 'ViewMail 'ListOfMails where
 instance Focusable 'ViewMail 'MailListOfAttachments where
   switchFocus _ _ = pure . set (asViews . vsViews . at ViewMail . _Just . vFocus) MailListOfAttachments
                     . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailListOfAttachments . veState) Visible
+
+instance Focusable 'ViewMail 'MailAttachmentOpenWithEditor where
+  switchFocus _ _ = pure . set (asViews . vsViews . at ViewMail . _Just . vFocus) MailAttachmentOpenWithEditor
+                    . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentOpenWithEditor . veState) Visible
 
 instance Focusable 'Help 'ScrollingHelpView where
   switchFocus _ _ = pure . over (asViews . vsFocusedView) (Brick.focusSetCurrent Help)
@@ -372,6 +387,9 @@ instance HasName 'ManageFileBrowserSearchPath where
 instance HasName 'MailListOfAttachments where
   name _ = MailListOfAttachments
 
+instance HasName 'MailAttachmentOpenWithEditor where
+  name _ = MailAttachmentOpenWithEditor
+
 -- | Allow to change the view to a different view in order to put the focus on a widget there
 class ViewTransition (v :: ViewName) (v' :: ViewName) where
   transitionHook :: Proxy v -> Proxy v' -> AppState -> AppState
@@ -442,6 +460,15 @@ invokeEditor = Action ["invoke external editor"] (Brick.suspendAndResume . liftI
 
 edit :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
 edit = Action ["edit file"] (Brick.suspendAndResume . liftIO . editAttachment)
+
+openWithCommand :: Action 'ViewMail 'MailAttachmentOpenWithEditor (T.Next AppState)
+openWithCommand =
+  Action
+  { _aDescription = ["pass to external command"]
+  , _aAction = \s ->
+    let cmd = view (asMailView . mvOpenCommand . E.editContentsL . to (T.unpack . currentLine)) s
+    in Brick.suspendAndResume $ liftIO $ openCommand' s cmd
+  }
 
 chain :: Action v ctx AppState -> Action v ctx a -> Action v ctx a
 chain (Action d1 f1) (Action d2 f2) = Action (d1 <> d2) (f1 >=> f2)
@@ -906,6 +933,16 @@ invokeEditor' s = do
       let mail = createTextPlainMessage contents
       pure $ s & over (asCompose . cAttachments) (upsertPart mail)
 
+openCommand' :: AppState -> FilePath -> IO AppState
+openCommand' s cmd
+  | null cmd = pure $ s & setError (GenericError "Empty command")
+  | otherwise = liftIO $ do
+      let maybeEntity = preview (asMailView . mvAttachments . to L.listSelectedElement . _Just . _2) s
+          filenameTemplate = view (_Just . headers . contentDisposition . filename . to T.unpack) maybeEntity
+      withSystemTempFile ("purebred." <> filenameTemplate) $ \fp handle -> do
+        updateFileContents handle maybeEntity
+        tryRunProcess (shell (cmd <> " " <> fp)) >>= either (handleIOException s) (pure . handleExitCode s)
+
 removeIfExists :: FilePath -> IO ()
 removeIfExists fp = removeFile fp `catch` handleError
   where
@@ -937,11 +974,15 @@ upsertPart newPart list =
 -- return an empty filepath
 getTempFileForEditing :: Maybe WireEntity -> IO String
 getTempFileForEditing m = do
-    tempfile <- getTemporaryDirectory >>= \tdir -> emptyTempFile tdir "purebred.txt"
+    tempfile <- getTemporaryDirectory >>= \tdir -> emptyTempFile tdir "purebred"
     f tempfile m
  where
-   f fp (Just (Message _ body)) = B.writeFile fp body >> pure fp
+   f fp (Just entity) = either (\_ -> pure fp) (\x -> B.writeFile fp x >> pure fp) (entityToBytes entity)
    f fp _ = pure fp
+
+updateFileContents :: Handle -> Maybe WireEntity -> IO ()
+updateFileContents h (Just entity) = either (\_ -> pure ()) (\x -> B.hPut h x >> hFlush h) (entityToBytes entity)
+updateFileContents _ _ = pure ()
 
 getTextPlainPart :: MIMEMessage -> Maybe WireEntity
 getTextPlainPart = firstOf (entities . filtered f)

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1,3 +1,18 @@
+-- This file is part of purebred
+-- Copyright (C) 2017 Róman Joost and Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -39,7 +39,7 @@ import UI.Index.Main
 import UI.Actions (applySearch, initialCompose)
 import UI.FileBrowser.Main
        (renderFileBrowser, renderFileBrowserSearchPathEditor)
-import UI.Mail.Main (renderMailView)
+import UI.Mail.Main (renderMailView, renderAttachmentsList)
 import UI.Help.Main (renderHelp)
 import UI.Status.Main (statusbar)
 import UI.Views
@@ -57,6 +57,7 @@ renderWidget s _ ListOfThreads = renderListOfThreads s
 renderWidget s ViewMail ListOfMails = vLimit (view (asConfig . confMailView . mvIndexRows) s) (renderListOfMails s)
 renderWidget s _ ListOfMails = renderListOfMails s
 renderWidget s _ ComposeListOfAttachments = attachmentsEditor s
+renderWidget s _ MailListOfAttachments = renderAttachmentsList s
 renderWidget s _ ListOfFiles = renderFileBrowser s
 renderWidget s _ ManageFileBrowserSearchPath = renderFileBrowserSearchPathEditor s
 renderWidget s _ SearchThreadsEditor = renderSearchThreadsEditor s
@@ -84,6 +85,7 @@ handleViewEvent = f where
   f Threads ManageThreadTagsEditor = dispatch eventHandlerManageThreadTagsEditor
   f Threads SearchThreadsEditor = dispatch eventHandlerSearchThreadsEditor
   f ViewMail ManageMailTagsEditor = dispatch eventHandlerViewMailManageMailTagsEditor
+  f ViewMail MailListOfAttachments = dispatch eventHandlerMailsListOfAttachments
   f ViewMail _ = dispatch eventHandlerScrollingMailView
   f _ ScrollingHelpView = dispatch eventHandlerScrollingHelpView
   f _ ListOfFiles = dispatch eventHandlerComposeFileBrowser
@@ -115,7 +117,7 @@ initialState conf =
             (E.editorText SearchThreadsEditor Nothing searchterms)
             (E.editorText ManageMailTagsEditor Nothing "")
             (E.editorText ManageThreadTagsEditor Nothing "")
-    mv = MailView Nothing Filtered
+    mv = MailView Nothing Filtered (L.list MailListOfAttachments mempty 1)
     viewsettings =
         ViewSettings
         { _vsViews = Map.fromList

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -1,3 +1,18 @@
+-- This file is part of purebred
+-- Copyright (C) 2017 Róman Joost and Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -39,7 +39,8 @@ import UI.Index.Main
 import UI.Actions (applySearch, initialCompose)
 import UI.FileBrowser.Main
        (renderFileBrowser, renderFileBrowserSearchPathEditor)
-import UI.Mail.Main (renderMailView, renderAttachmentsList)
+import UI.Mail.Main (renderMailView, renderAttachmentsList,
+                     renderMailAttachmentOpenWithEditor)
 import UI.Help.Main (renderHelp)
 import UI.Status.Main (statusbar)
 import UI.Views
@@ -55,6 +56,7 @@ drawUI s = [vBox (renderWidget s (focusedViewName s) <$> focusedViewWidgets s)]
 renderWidget :: AppState -> ViewName -> Name -> Widget Name
 renderWidget s _ ListOfThreads = renderListOfThreads s
 renderWidget s ViewMail ListOfMails = vLimit (view (asConfig . confMailView . mvIndexRows) s) (renderListOfMails s)
+renderWidget s _ MailAttachmentOpenWithEditor = renderMailAttachmentOpenWithEditor s
 renderWidget s _ ListOfMails = renderListOfMails s
 renderWidget s _ ComposeListOfAttachments = attachmentsEditor s
 renderWidget s _ MailListOfAttachments = renderAttachmentsList s
@@ -86,6 +88,7 @@ handleViewEvent = f where
   f Threads SearchThreadsEditor = dispatch eventHandlerSearchThreadsEditor
   f ViewMail ManageMailTagsEditor = dispatch eventHandlerViewMailManageMailTagsEditor
   f ViewMail MailListOfAttachments = dispatch eventHandlerMailsListOfAttachments
+  f ViewMail MailAttachmentOpenWithEditor = dispatch eventHandlerMailAttachmentOpenWithEditor
   f ViewMail _ = dispatch eventHandlerScrollingMailView
   f _ ScrollingHelpView = dispatch eventHandlerScrollingHelpView
   f _ ListOfFiles = dispatch eventHandlerComposeFileBrowser
@@ -117,7 +120,11 @@ initialState conf =
             (E.editorText SearchThreadsEditor Nothing searchterms)
             (E.editorText ManageMailTagsEditor Nothing "")
             (E.editorText ManageThreadTagsEditor Nothing "")
-    mv = MailView Nothing Filtered (L.list MailListOfAttachments mempty 1)
+    mv = MailView
+           Nothing
+           Filtered
+           (L.list MailListOfAttachments mempty 1)
+           (E.editorText MailAttachmentOpenWithEditor Nothing "")
     viewsettings =
         ViewSettings
         { _vsViews = Map.fromList

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -39,8 +39,9 @@ import UI.Index.Main
 import UI.Actions (applySearch, initialCompose)
 import UI.FileBrowser.Main
        (renderFileBrowser, renderFileBrowserSearchPathEditor)
-import UI.Mail.Main (renderMailView, renderAttachmentsList,
-                     renderMailAttachmentOpenWithEditor)
+import UI.Mail.Main
+  ( renderAttachmentsList, renderMailAttachmentOpenWithEditor
+  , renderMailAttachmentPipeToEditor, renderMailView)
 import UI.Help.Main (renderHelp)
 import UI.Status.Main (statusbar)
 import UI.Views
@@ -57,6 +58,7 @@ renderWidget :: AppState -> ViewName -> Name -> Widget Name
 renderWidget s _ ListOfThreads = renderListOfThreads s
 renderWidget s ViewMail ListOfMails = vLimit (view (asConfig . confMailView . mvIndexRows) s) (renderListOfMails s)
 renderWidget s _ MailAttachmentOpenWithEditor = renderMailAttachmentOpenWithEditor s
+renderWidget s _ MailAttachmentPipeToEditor = renderMailAttachmentPipeToEditor s
 renderWidget s _ ListOfMails = renderListOfMails s
 renderWidget s _ ComposeListOfAttachments = attachmentsEditor s
 renderWidget s _ MailListOfAttachments = renderAttachmentsList s
@@ -89,6 +91,7 @@ handleViewEvent = f where
   f ViewMail ManageMailTagsEditor = dispatch eventHandlerViewMailManageMailTagsEditor
   f ViewMail MailListOfAttachments = dispatch eventHandlerMailsListOfAttachments
   f ViewMail MailAttachmentOpenWithEditor = dispatch eventHandlerMailAttachmentOpenWithEditor
+  f ViewMail MailAttachmentPipeToEditor = dispatch eventHandlerMailAttachmentPipeToEditor
   f ViewMail _ = dispatch eventHandlerScrollingMailView
   f _ ScrollingHelpView = dispatch eventHandlerScrollingHelpView
   f _ ListOfFiles = dispatch eventHandlerComposeFileBrowser
@@ -125,6 +128,7 @@ initialState conf =
            Filtered
            (L.list MailListOfAttachments mempty 1)
            (E.editorText MailAttachmentOpenWithEditor Nothing "")
+           (E.editorText MailAttachmentPipeToEditor Nothing "")
     viewsettings =
         ViewSettings
         { _vsViews = Map.fromList

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -56,7 +56,7 @@ renderWidget :: AppState -> ViewName -> Name -> Widget Name
 renderWidget s _ ListOfThreads = renderListOfThreads s
 renderWidget s ViewMail ListOfMails = vLimit (view (asConfig . confMailView . mvIndexRows) s) (renderListOfMails s)
 renderWidget s _ ListOfMails = renderListOfMails s
-renderWidget s _ ListOfAttachments = attachmentsEditor s
+renderWidget s _ ComposeListOfAttachments = attachmentsEditor s
 renderWidget s _ ListOfFiles = renderFileBrowser s
 renderWidget s _ ManageFileBrowserSearchPath = renderFileBrowserSearchPathEditor s
 renderWidget s _ SearchThreadsEditor = renderSearchThreadsEditor s
@@ -74,7 +74,7 @@ handleViewEvent = f where
   f ComposeView ComposeFrom = dispatch eventHandlerComposeFrom
   f ComposeView ComposeSubject = dispatch eventHandlerComposeSubject
   f ComposeView ComposeTo = dispatch eventHandlerComposeTo
-  f ComposeView ListOfAttachments = dispatch eventHandlerComposeListOfAttachments
+  f ComposeView ComposeListOfAttachments = dispatch eventHandlerComposeListOfAttachments
   f Mails ListOfMails = dispatch eventHandlerListOfMails
   f Mails ManageMailTagsEditor = dispatch eventHandlerManageMailTagsEditor
   f Threads ComposeFrom =  dispatch eventHandlerThreadComposeFrom

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -27,10 +27,10 @@ import UI.FileBrowser.Main
 import UI.Mail.Main (renderMailView)
 import UI.Help.Main (renderHelp)
 import UI.Status.Main (statusbar)
-import UI.Utils (focusedViewWidget, focusedViewWidgets, focusedViewName)
 import UI.Views
        (indexView, mailView, composeView, helpView, listOfMailsView,
-        filebrowserView)
+        filebrowserView, focusedViewWidget, focusedViewWidgets,
+        focusedViewName)
 import UI.ComposeEditor.Main (attachmentsEditor)
 import Types
 
@@ -80,7 +80,7 @@ appEvent
   :: AppState               -- ^ program state
   -> T.BrickEvent Name PurebredEvent  -- ^ event
   -> T.EventM Name (T.Next AppState)
-appEvent s (T.VtyEvent ev) = handleViewEvent (focusedViewName s) (focusedViewWidget s ListOfThreads) s ev
+appEvent s (T.VtyEvent ev) = handleViewEvent (focusedViewName s) (focusedViewWidget s) s ev
 appEvent s (T.AppEvent ev) = case ev of
   NotifyNumThreads n gen -> M.continue $
     if gen == view (asMailIndex . miListOfThreadsGeneration) s

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -16,7 +16,7 @@ commonKeybindings =
 composeSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
 composeSubjectKeybindings =
     [ Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
     ] <> commonKeybindings
 
 composeFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
@@ -31,7 +31,7 @@ composeToKeybindings =
     , Keybinding (V.EvKey V.KEsc []) (abort `chain` continue)
     ] <> commonKeybindings
 
-listOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ListOfAttachments]
+listOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
 listOfAttachmentsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 
-module UI.ComposeEditor.Main (attachmentsEditor) where
+module UI.ComposeEditor.Main (attachmentsEditor, renderPart) where
 
 import Brick.Types (Padding(Max), Widget)
 import Brick.Widgets.Core (hBox, padLeftRight, padRight, txt, withAttr)

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -13,12 +13,13 @@ import Data.MIME
         filename, contentDisposition, isAttachment, showContentType)
 
 import Config.Main (listSelectedAttr, listAttr)
-import UI.Utils (focusedViewWidget, takeFileName)
+import UI.Utils (takeFileName)
+import UI.Views (focusedViewWidget)
 import Types
 
 attachmentsEditor :: AppState -> Widget Name
 attachmentsEditor s =
-    let hasFocus = ListOfAttachments == focusedViewWidget s ComposeFrom
+    let hasFocus = ListOfAttachments == focusedViewWidget s
         attachmentsList = L.renderList renderPart hasFocus (view (asCompose . cAttachments) s)
     in attachmentsList
 

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -19,7 +19,7 @@ import Types
 
 attachmentsEditor :: AppState -> Widget Name
 attachmentsEditor s =
-    let hasFocus = ListOfAttachments == focusedViewWidget s
+    let hasFocus = ComposeListOfAttachments == focusedViewWidget s
         attachmentsList = L.renderList renderPart hasFocus (view (asCompose . cAttachments) s)
     in attachmentsList
 

--- a/src/UI/FileBrowser/Keybindings.hs
+++ b/src/UI/FileBrowser/Keybindings.hs
@@ -8,8 +8,8 @@ import Types
 -- | Default Keybindings
 fileBrowserKeybindings :: [Keybinding 'FileBrowser 'ListOfFiles]
 fileBrowserKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
     , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)

--- a/src/UI/FileBrowser/Main.hs
+++ b/src/UI/FileBrowser/Main.hs
@@ -10,11 +10,11 @@ import qualified Brick.Widgets.List as L
 import Control.Lens.Getter (view)
 import Config.Main (listSelectedAttr, listAttr)
 import UI.Draw.Main (fillLine)
-import UI.Utils (focusedViewWidget)
+import UI.Views (focusedViewWidget)
 import Types
 
 renderFileBrowser :: AppState -> Widget Name
-renderFileBrowser s = L.renderList drawListItem (ListOfFiles == focusedViewWidget s ListOfThreads)
+renderFileBrowser s = L.renderList drawListItem (ListOfFiles == focusedViewWidget s)
                       $ view (asFileBrowser . fbEntries) s
 
 drawListItem :: Bool -> (Bool, FileSystemEntry) -> Widget Name
@@ -30,7 +30,7 @@ drawListItem sel (toggled, x) =
 
 renderFileBrowserSearchPathEditor :: AppState -> Widget Name
 renderFileBrowserSearchPathEditor s =
-  let hasFocus = ManageFileBrowserSearchPath == focusedViewWidget s ListOfThreads
+  let hasFocus = ManageFileBrowserSearchPath == focusedViewWidget s
       editorDrawContent = str . unlines
       inputW = E.renderEditor editorDrawContent hasFocus (view (asFileBrowser . fbSearchPath) s)
       labelW = txt "Path: "

--- a/src/UI/FileBrowser/Main.hs
+++ b/src/UI/FileBrowser/Main.hs
@@ -1,3 +1,18 @@
+-- This file is part of purebred
+-- Copyright (C) 2018 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE OverloadedStrings #-}
 module UI.FileBrowser.Main
        (renderFileBrowser, renderFileBrowserSearchPathEditor) where

--- a/src/UI/GatherHeaders/Keybindings.hs
+++ b/src/UI/GatherHeaders/Keybindings.hs
@@ -23,5 +23,5 @@ gatherSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]
 gatherSubjectKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` invokeEditor)
+    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` invokeEditor)
     ]

--- a/src/UI/GatherHeaders/Main.hs
+++ b/src/UI/GatherHeaders/Main.hs
@@ -1,3 +1,18 @@
+-- This file is part of purebred
+-- Copyright (C) 2018 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 

--- a/src/UI/GatherHeaders/Main.hs
+++ b/src/UI/GatherHeaders/Main.hs
@@ -9,13 +9,13 @@ import Brick.Types (Widget)
 
 import Types
 import UI.Draw.Main (renderEditorWithLabel)
-import UI.Utils (focusedViewWidget)
+import UI.Views (focusedViewWidget)
 
 drawFrom :: AppState -> Widget Name
-drawFrom s = renderEditorWithLabel "From:" (ComposeFrom == focusedViewWidget s ComposeFrom) (view (asCompose . cFrom) s)
+drawFrom s = renderEditorWithLabel "From:" (ComposeFrom == focusedViewWidget s) (view (asCompose . cFrom) s)
 
 drawTo :: AppState -> Widget Name
-drawTo s = renderEditorWithLabel "To:" (ComposeTo == focusedViewWidget s ComposeFrom) (view (asCompose . cTo) s)
+drawTo s = renderEditorWithLabel "To:" (ComposeTo == focusedViewWidget s) (view (asCompose . cTo) s)
 
 drawSubject :: AppState -> Widget Name
-drawSubject s = renderEditorWithLabel "Subject:" (ComposeSubject == focusedViewWidget s ComposeFrom) (view (asCompose . cSubject) s)
+drawSubject s = renderEditorWithLabel "Subject:" (ComposeSubject == focusedViewWidget s) (view (asCompose . cSubject) s)

--- a/src/UI/Help/Main.hs
+++ b/src/UI/Help/Main.hs
@@ -25,7 +25,7 @@ renderHelp s = viewport ScrollingHelpView T.Vertical $ vBox
   , views (asConfig . confIndexView . ivManageThreadTagsKeybindings) (renderKbGroup ManageThreadTagsEditor) s
   , views (asConfig . confMailView . mvKeybindings) (renderKbGroup ScrollingMailView) s
   , views (asConfig . confHelpView . hvKeybindings) (renderKbGroup ScrollingHelpView) s
-  , views (asConfig . confComposeView . cvListOfAttachmentsKeybindings) (renderKbGroup ListOfAttachments) s
+  , views (asConfig . confComposeView . cvListOfAttachmentsKeybindings) (renderKbGroup ComposeListOfAttachments) s
   , views (asConfig . confFileBrowserView . fbKeybindings) (renderKbGroup ListOfFiles) s
   , views (asConfig . confFileBrowserView . fbSearchPathKeybindings) (renderKbGroup ManageFileBrowserSearchPath) s
   ]

--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -22,7 +22,7 @@ import Data.Text as T (Text, pack, unwords)
 import Notmuch (getTag)
 
 import UI.Draw.Main (renderEditorWithLabel, fillLine)
-import UI.Utils (focusedViewWidget)
+import UI.Views (focusedViewWidget)
 import Storage.Notmuch (hasTag)
 import Types
 import Config.Main
@@ -38,17 +38,17 @@ renderListOfMails s = L.renderList (listDrawMail s) True $ view (asMailIndex . m
 
 renderSearchThreadsEditor :: AppState -> Widget Name
 renderSearchThreadsEditor s =
-    let hasFocus = SearchThreadsEditor == focusedViewWidget s ListOfThreads
+    let hasFocus = SearchThreadsEditor == focusedViewWidget s
     in renderEditorWithLabel "Query:" hasFocus (view (asMailIndex . miSearchThreadsEditor) s)
 
 renderMailTagsEditor :: AppState -> Widget Name
 renderMailTagsEditor s =
-    let hasFocus = ManageMailTagsEditor == focusedViewWidget s ListOfThreads
+    let hasFocus = ManageMailTagsEditor == focusedViewWidget s
     in renderEditorWithLabel "Labels:" hasFocus (view (asMailIndex . miMailTagsEditor) s)
 
 renderThreadTagsEditor :: AppState -> Widget Name
 renderThreadTagsEditor s =
-    let hasFocus = ManageThreadTagsEditor == focusedViewWidget s ListOfThreads
+    let hasFocus = ManageThreadTagsEditor == focusedViewWidget s
     in renderEditorWithLabel "Labels:" hasFocus (view (asMailIndex . miThreadTagsEditor) s)
 
 listDrawMail :: AppState -> Bool -> NotmuchMail -> Widget Name

--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -1,3 +1,18 @@
+-- This file is part of purebred
+-- Copyright (C) 2018 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE OverloadedStrings #-}
 
 module UI.Index.Main (

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -106,7 +106,7 @@ eventHandlerComposeSubject = EventHandler
   (asConfig . confComposeView . cvSubjectKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asCompose . cSubject) E.handleEditorEvent)
 
-eventHandlerComposeListOfAttachments :: EventHandler 'ComposeView 'ListOfAttachments
+eventHandlerComposeListOfAttachments :: EventHandler 'ComposeView 'ComposeListOfAttachments
 eventHandlerComposeListOfAttachments = EventHandler
   (asConfig . confComposeView . cvListOfAttachmentsKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asCompose . cAttachments) L.handleListEvent)

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -71,6 +71,11 @@ eventHandlerMailAttachmentOpenWithEditor = EventHandler
   (asConfig . confMailView . mvOpenWithKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailView . mvOpenCommand) E.handleEditorEvent)
 
+eventHandlerMailAttachmentPipeToEditor :: EventHandler 'ViewMail 'MailAttachmentPipeToEditor
+eventHandlerMailAttachmentPipeToEditor = EventHandler
+  (asConfig . confMailView . mvPipeToKeybindings)
+  (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailView . mvPipeCommand) E.handleEditorEvent)
+
 eventHandlerManageThreadTagsEditor :: EventHandler 'Threads 'ManageThreadTagsEditor
 eventHandlerManageThreadTagsEditor = EventHandler
   (asConfig . confIndexView . ivManageThreadTagsKeybindings)

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -66,6 +66,11 @@ eventHandlerMailsListOfAttachments = EventHandler
   (asConfig . confMailView . mvMailListOfAttachmentsKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailView . mvAttachments) L.handleListEvent)
 
+eventHandlerMailAttachmentOpenWithEditor :: EventHandler 'ViewMail 'MailAttachmentOpenWithEditor
+eventHandlerMailAttachmentOpenWithEditor = EventHandler
+  (asConfig . confMailView . mvOpenWithKeybindings)
+  (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailView . mvOpenCommand) E.handleEditorEvent)
+
 eventHandlerManageThreadTagsEditor :: EventHandler 'Threads 'ManageThreadTagsEditor
 eventHandlerManageThreadTagsEditor = EventHandler
   (asConfig . confIndexView . ivManageThreadTagsKeybindings)

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -61,6 +61,11 @@ eventHandlerViewMailManageMailTagsEditor = EventHandler
   (asConfig . confMailView . mvManageMailTagsKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailIndex . miMailTagsEditor) E.handleEditorEvent)
 
+eventHandlerMailsListOfAttachments:: EventHandler 'ViewMail 'MailListOfAttachments
+eventHandlerMailsListOfAttachments = EventHandler
+  (asConfig . confMailView . mvMailListOfAttachmentsKeybindings)
+  (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailView . mvAttachments) L.handleListEvent)
+
 eventHandlerManageThreadTagsEditor :: EventHandler 'Threads 'ManageThreadTagsEditor
 eventHandlerManageThreadTagsEditor = EventHandler
   (asConfig . confIndexView . ivManageThreadTagsKeybindings)

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -33,7 +33,7 @@ displayMailKeybindings =
                                              `chain'` displayMail
                                              `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` invokeEditor)
+    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` invokeEditor)
     ]
 
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -34,6 +34,14 @@ displayMailKeybindings =
                                              `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` invokeEditor)
+    , Keybinding (V.EvKey (V.KChar 'v') []) (noop `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
+    ]
+
+mailAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
+mailAttachmentsKeybindings =
+    [ Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
     ]
 
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -42,6 +42,14 @@ mailAttachmentsKeybindings =
     [ Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentOpenWithEditor AppState) `chain` continue)
+    ]
+
+openWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
+openWithKeybindings =
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` openWithCommand)
     ]
 
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -43,13 +43,23 @@ mailAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentOpenWithEditor AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '|') []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentPipeToEditor AppState) `chain` continue)
     ]
 
 openWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
 openWithKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `chain'` (focus :: Action 'ViewMail 'MailAttachmentPipeToEditor AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` openWithCommand)
+    ]
+
+pipeToKeybindings :: [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
+pipeToKeybindings =
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `chain'` (focus :: Action 'ViewMail 'MailAttachmentOpenWithEditor AppState) `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` pipeToCommand)
     ]
 
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module UI.Mail.Main (renderMailView, renderAttachmentsList) where
+module UI.Mail.Main (
+    renderMailView
+  , renderAttachmentsList
+  , renderMailAttachmentOpenWithEditor) where
 
 import Brick.Types (Padding(..), ViewportType(..), Widget)
 import qualified Brick.Widgets.List as L
@@ -18,6 +21,7 @@ import Data.MIME
 import Storage.ParsedMail (chooseEntity, entityToText)
 
 import Types
+import UI.Draw.Main (renderEditorWithLabel)
 import UI.Views (focusedViewWidget)
 import Config.Main (headerKeyAttr, headerValueAttr, mailViewAttr,
                     listSelectedAttr, listAttr)
@@ -66,6 +70,11 @@ renderAttachmentsList s =
     let hasFocus = MailListOfAttachments == focusedViewWidget s
         attachmentsList = L.renderList renderPart hasFocus (view (asMailView . mvAttachments) s)
     in attachmentsList
+
+renderMailAttachmentOpenWithEditor :: AppState -> Widget Name
+renderMailAttachmentOpenWithEditor s =
+    let hasFocus = MailAttachmentOpenWithEditor == focusedViewWidget s
+    in renderEditorWithLabel "Open With:" hasFocus (view (asMailView . mvOpenCommand) s)
 
 -- TODO: Both these functions are basically duplicates. Use classes for
 -- WireEntity and MIMEMessage to don't repeat our selfs?

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module UI.Mail.Main (
-    renderMailView
+module UI.Mail.Main
+  ( renderMailView
   , renderAttachmentsList
-  , renderMailAttachmentOpenWithEditor) where
+  , renderMailAttachmentOpenWithEditor
+  , renderMailAttachmentPipeToEditor
+  ) where
 
 import Brick.Types (Padding(..), ViewportType(..), Widget)
 import qualified Brick.Widgets.List as L
@@ -75,6 +77,11 @@ renderMailAttachmentOpenWithEditor :: AppState -> Widget Name
 renderMailAttachmentOpenWithEditor s =
     let hasFocus = MailAttachmentOpenWithEditor == focusedViewWidget s
     in renderEditorWithLabel "Open With:" hasFocus (view (asMailView . mvOpenCommand) s)
+
+renderMailAttachmentPipeToEditor :: AppState -> Widget Name
+renderMailAttachmentPipeToEditor s =
+    let hasFocus = MailAttachmentPipeToEditor == focusedViewWidget s
+    in renderEditorWithLabel "Pipe to:" hasFocus (view (asMailView . mvPipeCommand) s)
 
 -- TODO: Both these functions are basically duplicates. Use classes for
 -- WireEntity and MIMEMessage to don't repeat our selfs?

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -49,6 +49,7 @@ statusbar s =
                 ManageMailTagsEditor -> renderStatusbar (view (asMailIndex . miMailTagsEditor) s) s
                 ManageThreadTagsEditor -> renderStatusbar (view (asMailIndex . miThreadTagsEditor) s) s
                 MailAttachmentOpenWithEditor -> renderStatusbar (view (asMailView . mvOpenCommand) s) s
+                MailAttachmentPipeToEditor -> renderStatusbar (view (asMailView . mvPipeCommand) s) s
                 ListOfThreads -> renderStatusbar (view (asMailIndex . miThreads) s) s
                 ListOfMails -> renderStatusbar (view (asMailIndex . miMails) s) s
                 ScrollingMailView -> renderStatusbar (view (asMailIndex . miMails) s) s

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -48,6 +48,7 @@ statusbar s =
                 SearchThreadsEditor -> renderStatusbar (view (asMailIndex . miSearchThreadsEditor) s) s
                 ManageMailTagsEditor -> renderStatusbar (view (asMailIndex . miMailTagsEditor) s) s
                 ManageThreadTagsEditor -> renderStatusbar (view (asMailIndex . miThreadTagsEditor) s) s
+                MailAttachmentOpenWithEditor -> renderStatusbar (view (asMailView . mvOpenCommand) s) s
                 ListOfThreads -> renderStatusbar (view (asMailIndex . miThreads) s) s
                 ListOfMails -> renderStatusbar (view (asMailIndex . miMails) s) s
                 ScrollingMailView -> renderStatusbar (view (asMailIndex . miMails) s) s

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -1,3 +1,18 @@
+-- This file is part of purebred
+-- Copyright (C) 2018 Róman Joost and Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -52,6 +52,7 @@ statusbar s =
                 ListOfMails -> renderStatusbar (view (asMailIndex . miMails) s) s
                 ScrollingMailView -> renderStatusbar (view (asMailIndex . miMails) s) s
                 ComposeListOfAttachments -> renderStatusbar (views (asCompose . cAttachments) lwl s) s
+                MailListOfAttachments -> renderStatusbar (views (asMailView . mvAttachments) lwl s) s
                 ListOfFiles -> renderStatusbar (views (asFileBrowser . fbEntries) lwl s) s
                 ComposeTo -> renderStatusbar (view (asCompose . cTo) s) s
                 ComposeFrom -> renderStatusbar (view (asCompose . cFrom) s) s

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -11,8 +11,10 @@ import Control.Lens (view, views)
 import Data.Semigroup ((<>))
 import Data.Text (Text)
 import Data.Text.Zipper (cursorPosition)
+
 import UI.Draw.Main (fillLine)
-import UI.Utils (focusedViewWidget, focusedViewName, titleize)
+import UI.Utils (titleize)
+import UI.Views (focusedViewWidget, focusedViewName)
 import Types
 import Config.Main (statusbarAttr, statusbarErrorAttr)
 
@@ -27,7 +29,7 @@ statusbar s =
     case view asError s of
         Just e -> withAttr statusbarErrorAttr $ strWrap (show e)
         Nothing ->
-            case focusedViewWidget s ListOfThreads of
+            case focusedViewWidget s of
                 SearchThreadsEditor -> renderStatusbar (view (asMailIndex . miSearchThreadsEditor) s) s
                 ManageMailTagsEditor -> renderStatusbar (view (asMailIndex . miMailTagsEditor) s) s
                 ManageThreadTagsEditor -> renderStatusbar (view (asMailIndex . miThreadTagsEditor) s) s
@@ -57,7 +59,7 @@ renderStatusbar w s = withAttr statusbarAttr $ hBox
   , fillLine
   , txt (
       titleize (focusedViewName s) <> "-"
-      <> titleize (focusedViewWidget s ListOfThreads) <> " "
+      <> titleize (focusedViewWidget s) <> " "
       )
   ]
 

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -51,7 +51,7 @@ statusbar s =
                 ListOfThreads -> renderStatusbar (view (asMailIndex . miThreads) s) s
                 ListOfMails -> renderStatusbar (view (asMailIndex . miMails) s) s
                 ScrollingMailView -> renderStatusbar (view (asMailIndex . miMails) s) s
-                ListOfAttachments -> renderStatusbar (views (asCompose . cAttachments) lwl s) s
+                ComposeListOfAttachments -> renderStatusbar (views (asCompose . cAttachments) lwl s) s
                 ListOfFiles -> renderStatusbar (views (asFileBrowser . fbEntries) lwl s) s
                 ComposeTo -> renderStatusbar (view (asCompose . cTo) s) s
                 ComposeFrom -> renderStatusbar (view (asCompose . cFrom) s) s

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -62,6 +62,7 @@ instance Titleize Name where
   titleize ListOfFiles = "Directory Listing"
   titleize ComposeListOfAttachments = "Attachments"
   titleize ManageFileBrowserSearchPath = "Filepath for Directory Listing"
+  titleize MailAttachmentOpenWithEditor = "Open With Editor"
   titleize m = pack $ show m
 
 instance Titleize ViewName where

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -17,48 +17,21 @@
 --
 {-# LANGUAGE OverloadedStrings #-}
 module UI.Utils
-  ( focusedViewWidget
-  , focusedViewWidgets
-  , focusedViewName
-  , focusedView
-  , titleize
+  ( titleize
   , Titleize
   , toggledItems
   , selectedFiles
   , takeFileName
   ) where
-import Data.Maybe (fromMaybe)
 import Data.Text (Text, pack, unpack)
 import Data.List (union)
 import qualified System.FilePath as FP (takeFileName)
 import Control.Lens
-       (folded, traversed, filtered, toListOf, view, at, _Just, _2)
-import Brick.Focus (focusGetCurrent)
+       (folded, traversed, filtered, toListOf, view, _2)
 import qualified Brick.Widgets.List as L
-
-import UI.Views (indexView)
-
 
 import Types
 
-focusedViewWidget :: AppState -> Name -> Name
-focusedViewWidget s defaultWidget = view vFocus (focusedView s)
-
-focusedViewWidgets :: AppState -> [Name]
-focusedViewWidgets s =
-    let defaultV = view (asConfig . confDefaultView) s
-        focused = fromMaybe defaultV $ focusGetCurrent $ view (asViews . vsFocusedView) s
-    in toListOf (asViews . vsViews . at focused . _Just . vWidgets . tileiso . traversed
-                 . filtered (\ve -> view veState ve == Visible) . veName) s
-
-focusedViewName :: AppState -> ViewName
-focusedViewName s =
-    let defaultV = view (asConfig . confDefaultView) s
-    in fromMaybe defaultV $ focusGetCurrent $ view (asViews . vsFocusedView) s
-
-focusedView :: AppState -> View
-focusedView s = let focused = view (asViews . vsViews . at (focusedViewName s)) s
-                in fromMaybe indexView focused
 
 toggledItems :: L.List Name (Bool, a) -> [(Bool, a)]
 toggledItems = toListOf (L.listElementsL . folded . filtered fst)

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -60,7 +60,7 @@ instance Titleize Name where
   titleize ComposeFrom = "Editor to Compose a new Mail"
   titleize ComposeSubject = "Editor to Compose a new Mail"
   titleize ListOfFiles = "Directory Listing"
-  titleize ListOfAttachments = "Attachments"
+  titleize ComposeListOfAttachments = "Attachments"
   titleize ManageFileBrowserSearchPath = "Filepath for Directory Listing"
   titleize m = pack $ show m
 

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -42,15 +42,14 @@ import UI.Views (indexView)
 import Types
 
 focusedViewWidget :: AppState -> Name -> Name
-focusedViewWidget s defaultWidget =
-    let ring = view vFocus (focusedView s)
-    in fromMaybe defaultWidget $ focusGetCurrent ring
+focusedViewWidget s defaultWidget = view vFocus (focusedView s)
 
 focusedViewWidgets :: AppState -> [Name]
 focusedViewWidgets s =
     let defaultV = view (asConfig . confDefaultView) s
         focused = fromMaybe defaultV $ focusGetCurrent $ view (asViews . vsFocusedView) s
-    in view (asViews . vsViews . at focused . _Just . vWidgets) s
+    in toListOf (asViews . vsViews . at focused . _Just . vWidgets . tileiso . traversed
+                 . filtered (\ve -> view veState ve == Visible) . veName) s
 
 focusedViewName :: AppState -> ViewName
 focusedViewName s =

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -63,6 +63,7 @@ instance Titleize Name where
   titleize ComposeListOfAttachments = "Attachments"
   titleize ManageFileBrowserSearchPath = "Filepath for Directory Listing"
   titleize MailAttachmentOpenWithEditor = "Open With Editor"
+  titleize MailAttachmentPipeToEditor = "Pipe to Editor"
   titleize m = pack $ show m
 
 instance Titleize ViewName where

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -134,10 +134,9 @@ composeView =
           , Tile Visible ComposeTo
           , Tile Visible ComposeSubject
           , Tile Visible StatusBar
-          , Tile Visible ListOfAttachments
+          , Tile Visible ComposeListOfAttachments
           ]
     , _vFocus = ComposeFrom
-    }
 
 helpView :: View
 helpView =

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -123,6 +123,7 @@ mailView =
           , Tile Hidden ManageMailTagsEditor
           , Tile Hidden MailListOfAttachments
           , Tile Hidden MailAttachmentOpenWithEditor
+          , Tile Hidden MailAttachmentPipeToEditor
           ]
     , _vFocus = ListOfMails
     }

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -122,6 +122,7 @@ mailView =
           , Tile Visible ScrollingMailView
           , Tile Hidden ManageMailTagsEditor
           , Tile Hidden MailListOfAttachments
+          , Tile Hidden MailAttachmentOpenWithEditor
           ]
     , _vFocus = ListOfMails
     }

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -121,6 +121,7 @@ mailView =
           , Tile Visible StatusBar
           , Tile Visible ScrollingMailView
           , Tile Hidden ManageMailTagsEditor
+          , Tile Hidden MailListOfAttachments
           ]
     , _vFocus = ListOfMails
     }
@@ -137,6 +138,7 @@ composeView =
           , Tile Visible ComposeListOfAttachments
           ]
     , _vFocus = ComposeFrom
+    }
 
 helpView :: View
 helpView =

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -1,53 +1,145 @@
 module UI.Views
-       (indexView, listOfMailsView, mailView, composeView, helpView, filebrowserView) where
+  ( indexView
+  , listOfMailsView
+  , mailView
+  , composeView
+  , helpView
+  , filebrowserView
+  , swapWidget
+  , focusNext
+  , toggleLastVisibleWidget
+  , resetView
+  , findNextVisibleWidget
+  ) where
 
-import Brick.Focus (focusRing)
+import Data.Vector (find, fromList, splitAt, findIndex, Vector)
+import Data.Maybe (fromMaybe)
+import Data.Semigroup ((<>))
+import Prelude hiding (splitAt)
+
+import Control.Lens ((&), _Just, ix, at, preview, set, lastOf, view, filtered, over)
+import Brick.Focus (focusGetCurrent)
 import Types
 
+focusedViewWidget :: AppState -> Name
+focusedViewWidget s = view vFocus (focusedView s)
+
+focusedView :: AppState -> View
+focusedView s = let focused = view (asViews . vsViews . at (focusedViewName s)) s
+                in fromMaybe indexView focused
+
+-- | Swap the widget with the given name with the current widget shown at the bottom of the UI
+toggleLastVisibleWidget :: Name -> AppState -> AppState
+toggleLastVisibleWidget n s =
+  let fallback = focusedViewWidget s
+  in s
+     & over (asViews . vsViews . at (focusedViewName s) . _Just . vWidgets) (swapWidget fallback n)
+     . set (asViews . vsViews . at (focusedViewName s) . _Just . vFocus) n
+
+swapWidget :: Name -> Name -> Tiles -> Tiles
+swapWidget fallback n m =
+  let lastWidget = fromMaybe fallback $ lastOf (tileiso . traverse . filtered (\x -> view veState x == Visible) . veName) m
+   in m & set (ix lastWidget . veState) Hidden . set (ix n . veState) Visible
+
+focusedViewName :: AppState -> ViewName
+focusedViewName s =
+    let defaultV = view (asConfig . confDefaultView) s
+    in fromMaybe defaultV $ focusGetCurrent $ view (asViews . vsFocusedView) s
+
+-- | Ugh so what do we do here? We want to determine the next visible view
+-- element. We used a circular list, which allows us to search forward until
+-- we've re-visit the same position from where we left off again. In order to do
+-- the same with a list-type data structure, we split the list and tack on the
+-- head so we can be sure that we either find a next visible element or well the
+-- currently focused.
+focusNext :: AppState -> AppState
+focusNext s = let focused = preview (asViews . vsViews . at (focusedViewName s) . _Just . vFocus) s
+                  widgets = view (asViews . vsViews . at (focusedViewName s) . _Just . vWidgets . tileiso) s
+                  index = maybe 0 (\n -> fromMaybe 0 $ findIndex (\x -> view veName x == n) widgets) focused
+              in maybe s (\x -> set (asViews . vsViews . at (focusedViewName s) . _Just . vFocus) (findNextVisibleWidget x index widgets) s) focused
+
+resetView :: ViewName -> View -> AppState -> AppState
+resetView n = set (asViews . vsViews . at n . _Just)
+
+findNextVisibleWidget ::
+     Name -- ^ default fallback
+  -> Int -- ^ current index
+  -> Vector Tile
+  -> Name
+findNextVisibleWidget fallback i v =
+  let (head', tail') = splitAt (i + 1) v
+  in maybe fallback (view veName) $ find (\x -> view veState x == Visible) (tail' <> head')
 
 indexView :: View
 indexView =
-    View
-    { _vFocus = focusRing [ListOfThreads, SearchThreadsEditor, ManageThreadTagsEditor, ComposeFrom, ComposeTo, ComposeSubject]
-    , _vWidgets = [ListOfThreads, StatusBar, SearchThreadsEditor]
+  View
+    { _vWidgets =
+        Tiles $ fromList
+          [ Tile Visible ListOfThreads
+          , Tile Visible StatusBar
+          , Tile Visible SearchThreadsEditor
+          , Tile Hidden ManageThreadTagsEditor
+          , Tile Hidden ComposeFrom
+          , Tile Hidden ComposeTo
+          , Tile Hidden ComposeSubject
+          ]
+    , _vFocus = ListOfThreads
     }
 
 listOfMailsView :: View
 listOfMailsView =
-    View
-    { _vFocus = focusRing [ListOfMails, ManageMailTagsEditor]
-    , _vWidgets = [ListOfMails, StatusBar]
+  View
+    { _vWidgets =
+        Tiles $ fromList
+          [ Tile Visible ListOfMails
+          , Tile Visible StatusBar
+          , Tile Visible ManageMailTagsEditor
+          ]
+    , _vFocus = ListOfMails
     }
 
 mailView :: View
 mailView =
-    View
-    { _vFocus = focusRing [ListOfMails, ScrollingMailView, ManageMailTagsEditor]
-    , _vWidgets = [ListOfMails, StatusBar, ScrollingMailView]
+  View
+    { _vWidgets =
+        Tiles $ fromList
+          [ Tile Visible ListOfMails
+          , Tile Visible StatusBar
+          , Tile Visible ScrollingMailView
+          , Tile Hidden ManageMailTagsEditor
+          ]
+    , _vFocus = ListOfMails
     }
 
 composeView :: View
 composeView =
-    View
-    { _vFocus = focusRing
-          [ComposeFrom, ComposeTo, ComposeSubject, ListOfAttachments]
-    , _vWidgets = [ ComposeFrom
-                  , ComposeTo
-                  , ComposeSubject
-                  , StatusBar
-                  , ListOfAttachments]
+  View
+    { _vWidgets =
+        Tiles $ fromList
+          [ Tile Visible ComposeFrom
+          , Tile Visible ComposeTo
+          , Tile Visible ComposeSubject
+          , Tile Visible StatusBar
+          , Tile Visible ListOfAttachments
+          ]
+    , _vFocus = ComposeFrom
     }
 
 helpView :: View
 helpView =
-    View
-    { _vFocus = focusRing [ScrollingHelpView]
-    , _vWidgets = [ScrollingHelpView]
+  View
+    { _vWidgets = Tiles $ fromList [Tile Visible ScrollingHelpView]
+    , _vFocus = ScrollingHelpView
     }
 
 filebrowserView :: View
 filebrowserView =
-    View
-    { _vFocus = focusRing [ListOfFiles, ManageFileBrowserSearchPath]
-    , _vWidgets = [ListOfFiles, StatusBar, ManageFileBrowserSearchPath]
+  View
+    { _vWidgets =
+        Tiles $ fromList
+          [ Tile Visible ListOfFiles
+          , Tile Visible StatusBar
+          , Tile Visible ManageFileBrowserSearchPath
+          ]
+    , _vFocus = ListOfFiles
     }

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -7,6 +7,10 @@ module UI.Views
   , filebrowserView
   , swapWidget
   , focusNext
+  , focusedViewWidgets
+  , focusedViewWidget
+  , focusedViewName
+  , focusedView
   , toggleLastVisibleWidget
   , resetView
   , findNextVisibleWidget
@@ -17,9 +21,19 @@ import Data.Maybe (fromMaybe)
 import Data.Semigroup ((<>))
 import Prelude hiding (splitAt)
 
-import Control.Lens ((&), _Just, ix, at, preview, set, lastOf, view, filtered, over)
+import Control.Lens
+  ((&), _Just, ix, at, preview, set, lastOf, view, filtered, over, toListOf,
+   traversed)
 import Brick.Focus (focusGetCurrent)
 import Types
+
+
+focusedViewWidgets :: AppState -> [Name]
+focusedViewWidgets s =
+    let defaultV = view (asConfig . confDefaultView) s
+        focused = fromMaybe defaultV $ focusGetCurrent $ view (asViews . vsFocusedView) s
+    in toListOf (asViews . vsViews . at focused . _Just . vWidgets . tileiso . traversed
+                 . filtered (\ve -> view veState ve == Visible) . veName) s
 
 focusedViewWidget :: AppState -> Name
 focusedViewWidget s = view vFocus (focusedView s)

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -1,3 +1,18 @@
+-- This file is part of purebred
+-- Copyright (C) 2018 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 module TestActions where

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -12,6 +12,7 @@ import qualified Data.Vector as Vector
 import Types
 import UI.Actions
 import UI.Utils (selectedFiles)
+import UI.Views (swapWidget, findNextVisibleWidget)
 
 
 actionTests ::
@@ -21,6 +22,8 @@ actionTests =
         "action tests"
         [ testModeDescription
         , testNoDupes
+        , testSwapBottom
+        , testFocusNext
         ]
 
 testModeDescription :: TestTree
@@ -39,3 +42,35 @@ testNoDupes =
         l = set L.listSelectedL (Just 1) $ L.list ListOfFiles vec 1
     in testCase "no duplicates when multiple items are selected" $
        selectedFiles l @?= ["file 1", "file 2"]
+
+testFocusNext :: TestTree
+testFocusNext = testCase "focuses next visible widget" $ findNextVisibleWidget ListOfThreads 1 tiles @?= SearchThreadsEditor
+  where
+    tiles =
+        Vector.fromList
+          [ Tile Visible ListOfThreads
+          , Tile Visible StatusBar
+          , Tile Visible SearchThreadsEditor
+          , Tile Hidden ManageThreadTagsEditor
+          , Tile Hidden ComposeFrom
+          ]
+
+testSwapBottom :: TestTree
+testSwapBottom = testCase "swaps last visible widget" $ swapWidget ListOfThreads ManageThreadTagsEditor tiles @?= expected
+  where
+    tiles =
+        Tiles $ Vector.fromList
+          [ Tile Visible ListOfThreads
+          , Tile Visible StatusBar
+          , Tile Visible SearchThreadsEditor
+          , Tile Hidden ManageThreadTagsEditor
+          , Tile Hidden ComposeFrom
+          ]
+    expected =
+        Tiles $ Vector.fromList
+          [ Tile Visible ListOfThreads
+          , Tile Visible StatusBar
+          , Tile Hidden SearchThreadsEditor
+          , Tile Visible ManageThreadTagsEditor
+          , Tile Hidden ComposeFrom
+          ]

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -110,7 +110,32 @@ main = defaultMain $
       , testShowsMailEntities
       , testOpenCommandDoesNotKillPurebred
       , testOpenEntitiesSuccessfully
+      , testPipeEntitiesSuccessfully
       ]
+
+testPipeEntitiesSuccessfully :: TestCase
+testPipeEntitiesSuccessfully = withTmuxSession "pipe entities successfully" $
+  \step -> do
+    startApplication
+
+    liftIO $ step "open thread"
+    sendKeys "Enter" (Literal "This is a test mail for purebred")
+
+    liftIO $ step "show entities"
+    sendKeys "v" (Literal "text/plain")
+
+    liftIO $ step "pipe to"
+    sendKeys "|" (Literal "Pipe to")
+
+    liftIO $ step "use less"
+    _ <- sendLiteralKeys "less -e"
+    sendKeys "Enter" (Regex ("This is a test mail for purebred"
+                             <> buildAnsiRegex [] ["37"] ["40"]
+                             <> "\\s+"
+                             <> buildAnsiRegex ["7"] ["39"] ["49"]
+                             <> "\\(END\\)"))
+
+    pure ()
 
 testOpenEntitiesSuccessfully :: TestCase
 testOpenEntitiesSuccessfully = withTmuxSession "open entities successfully" $

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -107,7 +107,30 @@ main = defaultMain $
       , testFromAddressIsProperlyReset
       , testRepliesToMailSuccessfully
       , testUserCanMoveBetweenThreads
+      , testShowsMailEntities
       ]
+
+testShowsMailEntities :: TestCase
+testShowsMailEntities = withTmuxSession "shows mail entities successfully" $
+  \step -> do
+    startApplication
+
+    liftIO $ step "open thread"
+    sendKeys "Enter" (Literal "This is a test mail for purebred")
+
+    liftIO $ step "show entities"
+    sendKeys "v" (Literal "text/plain")
+
+    liftIO $ step "select the second entity"
+    sendKeys "j" (Literal "text/html")
+
+    liftIO $ step "close the list of entities"
+    out <- sendKeys "q" (Literal "This is a test mail for purebred")
+
+    -- poor mans (?!text)
+    assertRegex "[^t][^e][^x][^t]" out
+
+    pure ()
 
 testUserCanMoveBetweenThreads :: TestCase
 testUserCanMoveBetweenThreads = withTmuxSession "user can navigate between threads" $

--- a/test/data/Maildir/new/1502941827.R15455991756849358775.url
+++ b/test/data/Maildir/new/1502941827.R15455991756849358775.url
@@ -8,10 +8,26 @@ To: <frase@host.example>
 Subject: Testmail with whitespace in the
 	subject
 MIME-Version: 1.0
-Content-Type: text/plain; charset=utf-8
+Content-Type: multipart/alternative; boundary=00asdf
 Content-Transfer-Encoding: quoted-printable
 Message-Id: <20170817035004.55C4580B8F@host.example>
 Date: Thu, 17 Aug 2017 13:50:04 +1000 (AEST)
 Content-Length: 33
 
+--00asdf
+Content-Type: text/plain; charset=utf-8
+
 This is a test mail for purebred
+
+--00asdf
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr">This is a test mail for purebred in which the HTML part co=
+ tains more crazy content than the text plain part and w &quot;linebreaks&q=
+uot; basically blah foo bar :<div><br></div><div><a href=3D"https://github.=
+purebred.com/purebred-mua/this/link/doesn/exist/really/bla/f" target=3D"_bl=
+ank">https://thislinkdoesnotexist/foo/bar/baz/just/to/fill/the/line/really/=
+XV3IJ</a> and this is were it ends.=C2=A0</div>
+
+--00asdf--


### PR DESCRIPTION
Here we go: listing, opening and piping attachments. Thankfully the default for piping shows you the output so there is not much more work to be done.

This is based upon #254 which will have to be reviewed first (or.. review this and throw #254 away).

This is all a bit primitive and I suppose subsequent work could make all of this way more pluggable and more safe. Yet it shall do for getting by.

Also, I think there will be a few backlog items for future work I could think of ...