### PR TITLE
Fix reloading of thread tags

### DIFF
--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -228,13 +228,6 @@ threadToThread m = do
       <*> Notmuch.threadTotalMessages m
       <*> Notmuch.threadId m
 
-reloadThreadTags
-    :: (MonadError Error m, MonadIO m)
-    => FilePath -> NotmuchThread -> m NotmuchThread
-reloadThreadTags fp item = withDatabaseReadOnly fp go
-  where
-    go db = fmap (`setTags` item) . Notmuch.tags =<< getThread db (view thId item)
-
 fixupWhitespace :: T.Text -> T.Text
 fixupWhitespace = T.map f . T.filter (/= '\n')
   where f '\t' = ' '

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -432,7 +432,7 @@ testManageTagsOnThreads = withTmuxSession "manage tags on threads" $
     sendKeys "Escape" (Literal "Item 2 of 2")
 
     liftIO $ step "thread tags shows new tags"
-    sendKeys "Escape" (Literal "archive inbox replied")
+    sendKeys "Escape" (Literal "archive replied")
 
     liftIO $ step "open thread tag editor"
     sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] []))
@@ -444,7 +444,7 @@ testManageTagsOnThreads = withTmuxSession "manage tags on threads" $
     _ <- sendLiteralKeys "+thread"
 
     liftIO $ step "apply"
-    sendKeys "Enter" (Literal "List of Threads")
+    sendKeys "Enter" (Literal "archive replied thread")
 
     liftIO $ step "show thread mails"
     sendKeys "Enter" (Literal "ViewMail")


### PR DESCRIPTION
Update the thread with the same tag operation to reflect tag changes on it's
associated mails. This patch removes associated code used to always reloading
the thread item when focusing the list of threads.

Fixes https://github.com/purebred-mua/purebred/issues/249