### PR TITLE
Assert widget name

### DIFF
--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -366,7 +366,7 @@ testManageTagsOnMails = withTmuxSession "manage tags on mails" $
     sendKeys "Escape" (Literal "Item 1 of 1")
 
     liftIO $ step "go back to list of threads"
-    sendKeys "Escape" (Literal "Testmail")
+    sendKeys "Escape" (Literal "List of Threads")
 
     -- find newly tagged mail
     liftIO $ step "focus tag search"


### PR DESCRIPTION
Wait until the status bar shows the index of threads widget name. The problem of
the former sub string `Testmail` can cause random failures since it appears in
the list of mails *and* list of threads.

Fixes https://github.com/purebred-mua/purebred/issues/251