### PR TITLE
Allow to navigate between threads

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -394,6 +394,8 @@ instance ViewTransition 'ViewMail 'ComposeView where
 
 instance ViewTransition 'FileBrowser 'ComposeView where
 
+instance ViewTransition 'ViewMail 'Threads where
+
 
 class HasViewName (a :: ViewName) where
   viewname :: Proxy a -> ViewName

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -18,7 +18,20 @@ displayMailKeybindings =
     , Keybinding (V.EvKey V.KUp []) (noop `chain'` (focus :: Action 'ViewMail 'ListOfMails AppState) `chain` listUp `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey V.KDown []) (noop `chain'` (focus :: Action 'ViewMail 'ListOfMails AppState) `chain` listDown `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain'` displayMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'J') []) (noop
+                                             `chain'` (focus :: Action 'Threads 'ListOfThreads AppState)
+                                             `chain` listDown
+                                             `chain'` displayThreadMails
+                                             `chain'` selectNextUnread
+                                             `chain'` displayMail
+                                             `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain'` displayMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'K') []) (noop
+                                             `chain'` (listUp :: Action 'Threads 'ListOfThreads AppState)
+                                             `chain'` displayThreadMails
+                                             `chain'` selectNextUnread
+                                             `chain'` displayMail
+                                             `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain'` (focus :: Action 'ComposeView 'ListOfAttachments AppState) `chain` invokeEditor)
     ]

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -106,7 +106,27 @@ main = defaultMain $
       , testAddAttachments
       , testFromAddressIsProperlyReset
       , testRepliesToMailSuccessfully
+      , testUserCanMoveBetweenThreads
       ]
+
+testUserCanMoveBetweenThreads :: TestCase
+testUserCanMoveBetweenThreads = withTmuxSession "user can navigate between threads" $
+  \step -> do
+    startApplication
+    -- assert that the first mail is really the one we're later navigating back
+    -- to
+    out <- capture
+    assertRegex (buildAnsiRegex ["1"] ["37"] ["43"] <> "\\s17/Aug.*Testmail with whitespace") out
+
+    liftIO $ step "View Mail"
+    sendKeys "Enter" (Literal "This is a test mail for purebred")
+
+    liftIO $ step "Navigate down the threads list"
+    sendKeys "J" (Literal "HOLY PUREBRED")
+
+    liftIO $ step "Navigate up the threads list"
+    sendKeys "K" (Literal "This is a test mail for purebred")
+    pure ()
 
 testRepliesToMailSuccessfully :: TestCase
 testRepliesToMailSuccessfully = withTmuxSession "replies to mail successfully" $


### PR DESCRIPTION
This patch adds an additional view transition and key bindings to navigate
between threads from the mail view. Before this was not possible because of the
missing transition instance declaration.

Fixes https://github.com/purebred-mua/purebred/issues/261