### PR TITLE
constrain list actions to contexts with lists

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
 import Purebred (purebred, defaultConfig)

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -145,7 +145,7 @@ test-suite uat
   main-is:             TestUserAcceptance.hs
   default-language:    Haskell2010
   build-depends:       base
-                     , purebred-email
+                     , purebred-email >= 0.1 && < 0.2
                      , tasty
                      , tasty-hunit
                      , directory

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -19,8 +19,7 @@ displayMailKeybindings =
     , Keybinding (V.EvKey V.KDown []) (noop `chain'` (focus :: Action 'ViewMail 'ListOfMails AppState) `chain` listDown `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'J') []) (noop
-                                             `chain'` (focus :: Action 'Threads 'ListOfThreads AppState)
-                                             `chain` listDown
+                                             `chain'` (listDown :: Action 'Threads 'ListOfThreads AppState)
                                              `chain'` displayThreadMails
                                              `chain'` selectNextUnread
                                              `chain'` displayMail

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -116,6 +116,7 @@ main = defaultMain $
 testPipeEntitiesSuccessfully :: TestCase
 testPipeEntitiesSuccessfully = withTmuxSession "pipe entities successfully" $
   \step -> do
+    setEnvVarInSession "LESS" ""
     startApplication
 
     liftIO $ step "open thread"
@@ -140,6 +141,7 @@ testPipeEntitiesSuccessfully = withTmuxSession "pipe entities successfully" $
 testOpenEntitiesSuccessfully :: TestCase
 testOpenEntitiesSuccessfully = withTmuxSession "open entities successfully" $
   \step -> do
+    setEnvVarInSession "LESS" ""
     startApplication
 
     liftIO $ step "open thread"


### PR DESCRIPTION
Just a refactor I've wanted to do for a little while...

Changes:

```
a31b581 (Fraser Tweedale, 76 minutes ago)
   add purebred-email upper bound

   Ahead of anticipated breaking API changes in purebred-email, constrain
   purebred to <= 0.2.

deadd88 (Fraser Tweedale, 76 minutes ago)
   remove obsolete language extension

425c967 (Fraser Tweedale, 2 hours ago)
   constrain list actions to contexts with lists

   Add the HasList class and constrain list actions to contexts that have an
   instance of HasList.  This simplifies the implementation of current (or
   future) list actions.

   Also fix descriptions of the list actions.
```