### PR TITLE
Do not guess filename when opening an attachment

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -960,8 +960,7 @@ openCommand' s cmd
   | null cmd = pure $ s & setError (GenericError "Empty command")
   | otherwise = liftIO $ do
       let maybeEntity = preview (asMailView . mvAttachments . to L.listSelectedElement . _Just . _2) s
-          filenameTemplate = view (_Just . headers . contentDisposition . filename . to T.unpack) maybeEntity
-      withSystemTempFile ("purebred." <> filenameTemplate) $ \fp handle -> do
+      withSystemTempFile "purebred" $ \fp handle -> do
         updateFileContents handle maybeEntity
         tryRunProcess (shell (cmd <> " " <> fp)) >>= either (handleIOException s) (pure . handleExitCode s)
 


### PR DESCRIPTION
This removes code to use the filename from an attachment for the tempfile
template. It caused problems with filename quoting when passed down to the
shell. Taking the filename into consideration is only needed for saving
attachments, so there is no need to be smart here.