### PR TITLE
sanitise control characters in message bodies

### DIFF
--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -22,6 +22,7 @@ import Data.MIME
 import Error
 import Storage.Notmuch (mailFilepath)
 import Types (NotmuchMail, decodeLenient)
+import UI.Utils (sanitise)
 
 parseMail
   :: (MonadError Error m, MonadIO m)
@@ -68,7 +69,7 @@ entityToBytes msg = either err Right (convert msg)
     convert m = view body <$> view transferDecoded m
 
 entityToText :: WireEntity -> T.Text
-entityToText msg = either err (view body) $
+entityToText msg = sanitise . either err (view body) $
   view transferDecoded msg >>= view charsetDecoded
   where
     err :: EncodingError -> T.Text


### PR DESCRIPTION
Control characters in message bodies can result in UI corruption
(e.g. when horizontal tab characters occur).  It is also a security
issue (ANSI escapes causing undesired terminal behaviour).

Add a Text sanitisation function and use it when converting entities
for display.

There are most certainly other places in the UI we need to employ
it, and we should properly audit the codebase - perhaps even using
phantom types to taint unsanitised external data.  But this is a
starting point.

Also do a drive-by tidy-up of UI.Utils.

Fixes: https://github.com/purebred-mua/purebred/issues/265