### PR TITLE
Mailcap to automatically open attachments

### DIFF
--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -17,7 +17,7 @@ import System.Directory (getHomeDirectory)
 import Data.Maybe (fromMaybe)
 import System.Exit (ExitCode(..))
 
-import Data.MIME (contentTypeTextPlain)
+import Data.MIME (contentTypeTextPlain, matchContentType)
 
 import UI.FileBrowser.Keybindings
        (fileBrowserKeybindings, manageSearchPathKeybindings)
@@ -178,6 +178,10 @@ defaultConfig =
       , _mvMailListOfAttachmentsKeybindings = mailAttachmentsKeybindings
       , _mvOpenWithKeybindings = openWithKeybindings
       , _mvPipeToKeybindings = pipeToKeybindings
+      , _mvMailcap = [
+            ((matchContentType "text" (Just "html")), "elinks -force-html")
+          , (const True, "xdg-open")
+          ]
       }
     , _confIndexView = IndexViewSettings
       { _ivBrowseThreadsKeybindings = browseThreadsKeybindings

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -347,6 +347,7 @@ data MailViewSettings = MailViewSettings
     , _mvMailListOfAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
     , _mvOpenWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
     , _mvPipeToKeybindings :: [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
+    , _mvMailcap :: [(ContentType -> Bool, String)]
     }
     deriving (Generic, NFData)
 
@@ -373,6 +374,9 @@ mvOpenWithKeybindings = lens _mvOpenWithKeybindings (\s x -> s { _mvOpenWithKeyb
 
 mvPipeToKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
 mvPipeToKeybindings = lens _mvPipeToKeybindings (\s x -> s { _mvPipeToKeybindings = x })
+
+mvMailcap :: Lens' MailViewSettings [(ContentType -> Bool, String)]
+mvMailcap = lens _mvMailcap (\s x -> s { _mvMailcap = x })
 
 data ViewName
     = Threads

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -10,7 +10,7 @@ module UI.ComposeEditor.Main
 import Brick.Types (Padding(..), Widget)
 import Brick.Widgets.Core
        (hBox, padLeftRight, padLeft, padRight, padBottom, txt, withAttr, (<=>),
-       (<+>), vLimit, hLimit, fill)
+       (<+>), vLimit, hLimit)
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
 import Control.Lens (view, preview, to)
@@ -21,17 +21,17 @@ import Data.MIME
        (MIMEMessage, headers, contentType,
         filename, contentDisposition, isAttachment, showContentType)
 
-import Config.Main (listSelectedAttr, listAttr, statusbarAttr)
+import Config.Main (listSelectedAttr, listAttr)
 import UI.Utils (takeFileName)
 import UI.Views (focusedViewWidget)
+import UI.Draw.Main (attachmentsHeader)
 import Types
 
 attachmentsEditor :: AppState -> Widget Name
 attachmentsEditor s =
     let hasFocus = ComposeListOfAttachments == focusedViewWidget s
         attachmentsList = L.renderList renderPart hasFocus (view (asCompose . cAttachments) s)
-        header = withAttr statusbarAttr $ hBox [ padLeft (Pad 1) (txt "-- Attachments") , (vLimit 1 (fill '-'))]
-    in header <=> attachmentsList
+    in attachmentsHeader <=> attachmentsList
 
 renderPart :: Bool -> MIMEMessage -> Widget Name
 renderPart selected m =

--- a/src/UI/Draw/Main.hs
+++ b/src/UI/Draw/Main.hs
@@ -3,14 +3,18 @@
 module UI.Draw.Main where
 
 import Brick.Types (Padding(..), Widget)
-import Brick.Widgets.Core (fill, txt, vLimit, padRight, (<+>), withAttr)
+import Brick.Widgets.Core
+       (fill, txt, vLimit, padRight, (<+>), withAttr, padLeft, hBox)
 import qualified Brick.Widgets.Edit as E
 import qualified Data.Text as T
 import Types
-import Config.Main (editorLabelAttr, editorAttr, editorFocusedAttr)
+import Config.Main (editorLabelAttr, editorAttr, editorFocusedAttr, statusbarAttr)
 
 fillLine :: Widget Name
 fillLine = vLimit 1 (fill ' ')
+
+attachmentsHeader :: Widget Name
+attachmentsHeader = withAttr statusbarAttr $ hBox [ padLeft (Pad 1) (txt "-- Attachments") , (vLimit 1 (fill '-'))]
 
 editorDrawContent :: [T.Text] -> Widget Name
 editorDrawContent st = txt $ T.unlines st

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -41,7 +41,8 @@ mailAttachmentsKeybindings =
     [ Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentOpenWithEditor AppState) `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) openAttachment
+    , Keybinding (V.EvKey (V.KChar 'o') []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentOpenWithEditor AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '|') []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentPipeToEditor AppState) `chain` continue)
     ]
 

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -23,7 +23,7 @@ import Data.MIME
 import Storage.ParsedMail (chooseEntity, entityToText)
 
 import Types
-import UI.Draw.Main (renderEditorWithLabel)
+import UI.Draw.Main (renderEditorWithLabel, attachmentsHeader)
 import UI.Views (focusedViewWidget)
 import Config.Main (headerKeyAttr, headerValueAttr, mailViewAttr,
                     listSelectedAttr, listAttr)
@@ -71,7 +71,7 @@ renderAttachmentsList :: AppState -> Widget Name
 renderAttachmentsList s =
     let hasFocus = MailListOfAttachments == focusedViewWidget s
         attachmentsList = L.renderList renderPart hasFocus (view (asMailView . mvAttachments) s)
-    in attachmentsList
+    in attachmentsHeader <=> attachmentsList
 
 renderMailAttachmentOpenWithEditor :: AppState -> Widget Name
 renderMailAttachmentOpenWithEditor s =

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -503,7 +503,7 @@ testManageTagsOnMails = withTmuxSession "manage tags on mails" $
       >>= assertSubstrInOutput "This is a test mail"
 
     liftIO $ step "go back to list of mails"
-    sendKeys "Escape" (Literal "Item 1 of 1")
+    sendKeys "Escape" (Literal "List of Mails")
 
     liftIO $ step "go back to list of threads"
     sendKeys "Escape" (Literal "List of Threads")

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -196,7 +196,7 @@ testOpenEntitiesSuccessfully = withTmuxSession "open entities successfully" $
     sendKeys "v" (Literal "text/plain")
 
     liftIO $ step "open one entity"
-    sendKeys "Enter" (Literal "Open With")
+    sendKeys "o" (Literal "Open With")
     _ <- sendLiteralKeys "less -e"
 
     sendKeys "Enter" (Regex ("This is a test mail for purebred"
@@ -217,7 +217,7 @@ testOpenCommandDoesNotKillPurebred = withTmuxSession "open attachment does not k
     sendKeys "v" (Literal "text/plain")
 
     liftIO $ step "open with"
-    sendKeys "Enter" (Literal "Open With")
+    sendKeys "o" (Literal "Open With")
 
     liftIO $ step "Open with bogus command"
     _ <- sendLiteralKeys "asdfasdfasdf"


### PR DESCRIPTION
This adds a proof of concept way to lookup commands for content types. Some notes I'm currently thinking over:
* The new `Action` encapsulates two actions with a condition (can we lookup a content type for which a command is defined?) and continues from that. We currently have no ability to access the `AppState` from our `Keybinding`s. Perhaps we don't need to and keep those `Action`s "special". I would keep it as it is and perhaps create a new backlog item for the future. We already have a few more items like this (e.g. `invokeEditor`)
* the mailcap is a `Map.Map (CI ByteString, CI ByteString) String`. The lookup for the content type is a bit clumsy at the moment. I figured that we most likely don't want to specify the full `ContentType` since we don't need different commands for different `Parameter`s. At least I couldn't think of a good reason. I'm not sure if I leave the key as a tuple or make a better data type.
