### PR TITLE
Make the path to sendmail configurable

### DIFF
--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -43,8 +43,8 @@ myMailKeybindings =
     [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
     ]
 
-writeMailtoFile :: B.ByteString -> IO (Either Error ())
-writeMailtoFile m = do
+writeMailtoFile :: FilePath -> B.ByteString -> IO (Either Error ())
+writeMailtoFile _ m = do
   confdir <- lookupEnv "PUREBRED_CONFIG_DIR"
   currentdir <- getCurrentDirectory
   let fname = fromMaybe currentdir confdir </> "sentMail"

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -48,8 +48,8 @@ import Storage.Notmuch (getDatabasePath)
 sendmailPath :: FilePath
 sendmailPath = "/usr/sbin/sendmail"
 
-renderSendMail :: B.ByteString -> IO (Either Error ())
-renderSendMail m = do
+renderSendMail :: FilePath -> B.ByteString -> IO (Either Error ())
+renderSendMail sendmail m = do
   -- -t which extracts recipients from the mail
   result <- tryRunProcess config
   pure $ case result of
@@ -57,7 +57,7 @@ renderSendMail m = do
     Right (ExitFailure _, stderr) -> Left $ SendMailError (untaint decode stderr)
     Right (ExitSuccess, _) -> Right ()
   where
-    config = setStdin (byteStringInput (LB.fromStrict m)) $ proc sendmailPath ["-t", "-v"]
+    config = setStdin (byteStringInput (LB.fromStrict m)) $ proc sendmail ["-t", "-v"]
     decode = T.unpack . sanitiseText . decodeLenient . LB.toStrict
 
 solarizedDark :: Theme
@@ -201,6 +201,7 @@ defaultConfig =
       , _cvToKeybindings = composeToKeybindings
       , _cvSubjectKeybindings = composeSubjectKeybindings
       , _cvSendMailCmd = renderSendMail
+      , _cvSendMailPath = sendmailPath
       , _cvListOfAttachmentsKeybindings = listOfAttachmentsKeybindings
       , _cvIdentities = []
       }

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -270,7 +270,8 @@ data ComposeViewSettings = ComposeViewSettings
     { _cvFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
     , _cvToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
     , _cvSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
-    , _cvSendMailCmd :: B.ByteString -> IO (Either Error ())
+    , _cvSendMailCmd :: FilePath -> B.ByteString -> IO (Either Error ())
+    , _cvSendMailPath :: FilePath
     , _cvListOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
     , _cvIdentities :: [Mailbox]
     }
@@ -285,8 +286,11 @@ cvToKeybindings = lens _cvToKeybindings (\cv x -> cv { _cvToKeybindings = x })
 cvSubjectKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeSubject]
 cvSubjectKeybindings = lens _cvSubjectKeybindings (\cv x -> cv { _cvSubjectKeybindings = x })
 
-cvSendMailCmd :: Lens' ComposeViewSettings (B.ByteString -> IO (Either Error ()))
+cvSendMailCmd :: Lens' ComposeViewSettings (FilePath -> B.ByteString -> IO (Either Error ()))
 cvSendMailCmd = lens _cvSendMailCmd (\cv x -> cv { _cvSendMailCmd = x })
+
+cvSendMailPath :: Lens' ComposeViewSettings FilePath
+cvSendMailPath = lens _cvSendMailPath (\cv x -> cv { _cvSendMailPath = x })
 
 cvListOfAttachmentsKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeListOfAttachments]
 cvListOfAttachmentsKeybindings = lens _cvListOfAttachmentsKeybindings (\cv x -> cv { _cvListOfAttachmentsKeybindings = x })

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -980,9 +980,10 @@ sendMail s = do
 trySendAndCatch :: String -> B.ByteString -> AppState -> IO AppState
 trySendAndCatch l' m s = do
     let cmd = view (asConfig . confComposeView . cvSendMailCmd) s
+        sendmail = view (asConfig . confComposeView . cvSendMailPath) s
         defMailboxes = view (asConfig . confComposeView . cvIdentities) s
     catch
-        (cmd m $> (s
+        (cmd sendmail m $> (s
          & set asCompose (initialCompose defMailboxes)
          . set (asConfig . confBoundary) l'))
         (\e ->


### PR DESCRIPTION
This path should be configurable, so that a) we can point to a sendmail command
not under /usr/bin and b) use explicitly a different MTA.