### PR TITLE
Refactor IO error handling for attachments

### DIFF
--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -11,6 +11,7 @@ import qualified Graphics.Vty as V
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
+import Control.Monad.Except (runExceptT)
 import System.Environment (lookupEnv)
 import System.Directory (getHomeDirectory)
 import Data.Maybe (fromMaybe)
@@ -50,7 +51,7 @@ sendmailPath = "/usr/sbin/sendmail"
 renderSendMail :: FilePath -> B.ByteString -> IO (Either Error ())
 renderSendMail sendmail m = do
   -- -t which extracts recipients from the mail
-  result <- tryRunProcess config
+  result <- runExceptT $ tryReadProcess config
   pure $ case result of
     Left e -> Left $ SendMailError (show e)
     Right (ExitFailure _, stderr) -> Left $ SendMailError (untaint decode stderr)

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -13,16 +13,18 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+{-# LANGUAGE FlexibleContexts #-}
 
 module Purebred.System.Process
-  ( tryRunProcess
+  ( tryReadProcess
   , handleIOException
   , handleExitCode
   , Purebred.System.Process.readProcess
   , tmpfileResource
   , emptyResource
   , toProcessConfigWithTempfile
-
+  , runEntityCommand
+  , tryIO
   -- * Re-exports from @System.Process.Typed@
   , ProcessConfig
   , proc
@@ -32,18 +34,21 @@ module Purebred.System.Process
   ) where
 
 import Data.Bifunctor (bimap)
+import Data.Functor (($>))
 import System.Exit (ExitCode(..))
 import Control.Exception (try, IOException)
+import Control.Monad.Catch (bracket, MonadMask)
+import Control.Monad.IO.Class (liftIO, MonadIO)
 import System.Process.Typed
+import Control.Monad.Except (MonadError, throwError)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.ByteString as B
 import System.IO.Temp (emptySystemTempFile)
 import System.Directory (removeFile)
-import Control.Lens (set, (&))
+import Control.Lens ((&), _2, over, set, view)
 import Data.Semigroup ((<>))
 import Data.Foldable (toList)
 
-import Control.Monad.IO.Class (MonadIO)
 import qualified Data.Text as T
 
 import Error
@@ -60,7 +65,10 @@ handleExitCode s (ExitSuccess, _) = s
 
 -- | Handle only IOExceptions, everything else is fair game.
 handleIOException :: AppState -> IOException -> IO AppState
-handleIOException s' ex = pure $ s' & setError (ProcessError (show ex))
+handleIOException s = pure . flip setError s . exceptionToError
+
+exceptionToError :: IOException -> Error
+exceptionToError = ProcessError . show
 
 setError :: Error -> AppState -> AppState
 setError = set asError . Just
@@ -70,10 +78,11 @@ setError = set asError . Just
 --
 -- Returns the exit code and the standard error output.
 --
-tryRunProcess
-  :: ProcessConfig stdout stderrIgnored stdin
-  -> IO (Either IOException (ExitCode, Tainted LB.ByteString))
-tryRunProcess = (fmap . fmap . fmap) taint . try . readProcessStderr
+tryReadProcess ::
+     (MonadError Error m, MonadIO m)
+  => ProcessConfig stdout stderrIgnored stdin
+  -> m (ExitCode, Tainted LB.ByteString)
+tryReadProcess pc = over _2 taint <$> tryIO (readProcessStderr pc)
 
 -- | Run process, returning stdout and stderr as @ByteString@.
 readProcess
@@ -82,19 +91,44 @@ readProcess
   -> m (ExitCode, Tainted LB.ByteString, Tainted LB.ByteString)
 readProcess = (fmap . fmap) (bimap taint taint) System.Process.Typed.readProcess
 
+runEntityCommand ::
+     (MonadMask m, MonadError Error m, MonadIO m)
+  => EntityCommand m a
+  -> AppState
+  -> m AppState
+runEntityCommand cmd s =
+  let acquire = view (ccResource . rsAcquire) cmd
+      update = view (ccResource . rsUpdate) cmd
+      free = view (ccResource . rsFree) cmd
+   in bracket
+        (acquire >>= \tmpfile ->
+           update tmpfile (view ccEntity cmd) $> tmpfile)
+        free
+        (\tmpfile ->
+           tryReadProcess (view ccProcessConfig cmd (view ccEntity cmd) tmpfile) >>=
+           (flip (view ccAfterExit cmd) tmpfile <$> handleExitCode s))
+
+-- | "Try" a computation but return a Purebred error in the exception case
+tryIO :: (MonadError Error m, MonadIO m) => IO a -> m a
+tryIO m = liftIO (try m) >>= either (throwError . exceptionToError) pure
 
 tmpfileResource ::
-  Bool -- ^ removeFile upon cleanup?
-  -> ResourceSpec FilePath
+     (MonadIO m, MonadError Error m)
+  => Bool -- ^ removeFile upon cleanup?
+  -> ResourceSpec m FilePath
 tmpfileResource keepTempfile =
   let cleanUp =
         if keepTempfile
           then mempty
           else removeFile
-   in ResourceSpec (emptySystemTempFile "purebred") cleanUp B.writeFile
+   in ResourceSpec
+        (tryIO $ emptySystemTempFile "purebred")
+        (tryIO . cleanUp)
+        (\fp -> tryIO . B.writeFile fp)
 
-emptyResource :: ResourceSpec ()
-emptyResource = ResourceSpec mempty (const mempty) (const mempty)
+emptyResource :: (MonadIO m, MonadError Error m) => ResourceSpec m ()
+emptyResource =
+  ResourceSpec (pure mempty) (\_ -> pure mempty) (\_ _ -> pure mempty)
 
 toProcessConfigWithTempfile :: MakeProcess -> FilePath -> ProcessConfig () () ()
 toProcessConfigWithTempfile (Shell cmd) fp = shell (toList cmd <> " " <> fp)

--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -60,11 +60,10 @@ chooseEntity preferredContentType msg =
     -- otherwise select first entity;
   in firstOf (entities . filtered match) msg <|> firstOf entities msg
 
-entityToBytes :: WireEntity -> Either Error B.ByteString
-entityToBytes msg = either err Right (convert msg)
+entityToBytes :: (MonadError Error m) => WireEntity -> m B.ByteString
+entityToBytes msg = either err pure (convert msg)
   where
-    err :: EncodingError -> Either Error B.ByteString
-    err e = Left $ GenericError ("Decoding error: " <> show e)
+    err e = throwError $ GenericError ("Decoding error: " <> show e)
     convert :: WireEntity -> Either EncodingError B.ByteString
     convert m = view body <$> view transferDecoded m
 

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1024,7 +1024,7 @@ invokeEditor' s =
       mkEntity = maybe (pure mempty) entityToBytes maybeEntity
       entityCmd = EntityCommand updatePart (tmpfileResource True) (\_ fp -> proc cmd [fp])
   in
-    either (flip setError s) id
+    either (`setError` s) id
     <$> runExceptT (mkEntity >>= flip runEntityCommand s . entityCmd)
 
 -- | Write the serialised WireEntity to a temporary file. Pass the FilePath of
@@ -1040,7 +1040,7 @@ openCommand' s cmd =
       let con = EntityCommand (const . pure) (tmpfileResource (view mhKeepTemp cmd))
             (\_ fp -> toProcessConfigWithTempfile (view mhMakeProcess cmd) fp)
       in fmap con . entityToBytes
-  in either (flip setError s) id
+  in either (`setError` s) id
       <$> runExceptT (selectedAttachmentOrError s >>= mkConfig >>= flip runEntityCommand s)
 
 -- | Pass the serialized WireEntity to a Bytestring as STDIN to the process. No
@@ -1056,7 +1056,7 @@ pipeCommand' s cmd
         let con = EntityCommand (const . pure) emptyResource
               (\b _ -> setStdin (byteStringInput $ LB.fromStrict b) (proc cmd []))
         in fmap con . entityToBytes
-     in either (flip setError s) id
+     in either (`setError` s) id
         <$> runExceptT (selectedAttachmentOrError s >>= mkConfig >>= flip runEntityCommand s)
 
 selectedAttachmentOrError :: MonadError Error m => AppState -> m WireEntity

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1049,13 +1049,11 @@ openCommand' s cmd =
         case maybeEntity of
           Nothing -> throwError (GenericError "No attachment selected")
           Just e ->
-            either
-              throwError
-              (pure . EntityCommand
-                (const . pure)
-                (tmpfileResource (view mhKeepTemp cmd))
-                (\_ fp -> toProcessConfigWithTempfile (view mhMakeProcess cmd) fp))
-              (entityToBytes e)
+            EntityCommand
+              (const . pure)
+              (tmpfileResource (view mhKeepTemp cmd))
+              (\_ fp -> toProcessConfigWithTempfile (view mhMakeProcess cmd) fp)
+            <$> entityToBytes e
    in either (flip setError s) id <$> runExceptT (mkConfig >>= flip runEntityCommand s)
 
 -- | Pass the serialized WireEntity to a Bytestring as STDIN to the process. No
@@ -1074,13 +1072,11 @@ pipeCommand' s cmd
           case maybeEntity of
             Nothing -> throwError (GenericError "No attachment selected")
             Just e ->
-              either
-                throwError
-                (pure . EntityCommand
-                  (const . pure)
-                  emptyResource
-                  (\b _ -> setStdin (byteStringInput $ LB.fromStrict b) (proc cmd [])))
-              (entityToBytes e)
+              EntityCommand
+                (const . pure)
+                emptyResource
+                (\b _ -> setStdin (byteStringInput $ LB.fromStrict b) (proc cmd []))
+              <$> entityToBytes e
      in either (flip setError s) id <$> runExceptT (mkConfig >>= flip runEntityCommand s)
 
 editAttachment :: AppState -> IO AppState


### PR DESCRIPTION
With the refactoring for handling temporary files (see
dd8ad0d062a418c3bc09ef63c6de36b5b5af908a) we introduced a slightly
different way to handle errors. This is slightly different to the way
we've handled errors from IO computations before.

Throughout most of our code, we use MonadError in order to transform and
propagate errors in IO computations.

This patch changes the error reporting we used to be consistent to what
we have throughout the code base. Most types have changed to use
MonadError as well as functions in order to propagate the error to the
user interface.

This becomes especially important when we further make changes to the IO
code which needs extensive error handling and propagation to the user
interface.