### PR TITLE
Select last mail if all mail is read

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -750,8 +750,9 @@ selectNextUnread =
            let
              -- find by unread tag...
              p = Notmuch.hasTag (view (asConfig . confNotmuch . nmNewTag) s)
-             -- but iff there is no resulting selection, move to 0
-             f l = maybe (L.listMoveTo 0 l) (const l) (view L.listSelectedL l)
+             -- but if there is no resulting selection, move to the
+             -- last element in the list
+             f l = maybe (L.listMoveTo (-1) l) (const l) (view L.listSelectedL l)
            in pure $ over (asMailIndex . miListOfMails) (f . L.listFindBy p) s
          }
 

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -342,7 +342,9 @@ testUpdatesReadState = withTmuxSession "updates read state for mail and thread" 
 
     liftIO $ step "set one mail to unread"
     sendKeys "Enter" (Literal "Beginning of large text")
-    sendKeys "q t" (Regex (buildAnsiRegex ["1"] ["37"] [] <> "\\sWIP Refactor\\s+" <> buildAnsiRegex ["0"] ["34"] ["40"]))
+    sendKeys "q t" (Regex (buildAnsiRegex ["1"] ["37"] []
+                           <> "\\sRe: WIP Refactor\\s+"
+                           <> buildAnsiRegex ["0"] ["34"] ["40"]))
 
     liftIO $ step "returning to thread list shows thread unread"
     sendKeys "q" (Regex (buildAnsiRegex ["1"] ["37"] [] <> "\\sWIP Refactor\\s"))
@@ -541,7 +543,7 @@ testManageTagsOnThreads = withTmuxSession "manage tags on threads" $
   \step -> do
     startApplication
 
-    -- setup: tag the mails in the thread with two different threads and then
+    -- setup: tag the mails in the thread with two different tags and then
     -- tag the thread as a whole with a new tag. All mails should keep their
     -- distinct tags, while having received a new tag.
     liftIO $ step "navigate to thread"
@@ -602,8 +604,7 @@ testManageTagsOnThreads = withTmuxSession "manage tags on threads" $
     liftIO $ step "show thread mails"
     sendKeys "Enter" (Literal "ViewMail")
 
-    liftIO $ step "navigate to second mail and assert shows old tag"
-    sendKeys "Down" (Literal "Item 2 of 2")
+    liftIO $ step "second mail shows old tag"
     sendKeys "Escape" (Regex ("replied"
                               <> buildAnsiRegex [] ["37"] []
                               <> "\\s"


### PR DESCRIPTION
When opening old threads, most of the email in the thread is read.
Most threads on mailing lists are discussions. The last mail in the
thread typically corresponds to the last state of the
discussion. Sometimes a consensus or sometimes just where we left of in
the discussion.

Purebred picked the first unread mail, which is important if there are
unread mails. However Purebred also picked the first read mail, if all
mails were read. This resulted that the user had to close the mail,
scroll down and open the last mail.

This patch selects the last mail by default if the entire thread is
read to avoid the additional key strokes to be made.

Fixes https://github.com/purebred-mua/purebred/issues/205