### PR TITLE
add support for charset plugins

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -99,7 +99,7 @@ library
                      , filepath
                      , mtl
                      , exceptions
-                     , purebred-email >= 0.1 && < 0.2
+                     , purebred-email >= 0.2
                      , attoparsec
                      , containers
                      , mime-types
@@ -147,7 +147,7 @@ test-suite uat
   other-modules:       UAT
   default-language:    Haskell2010
   build-depends:       base
-                     , purebred-email >= 0.1 && < 0.2
+                     , purebred-email >= 0.2
                      , tasty
                      , tasty-hunit
                      , directory

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -18,7 +18,7 @@ import Data.Maybe (fromMaybe)
 import Data.List.NonEmpty (fromList)
 import System.Exit (ExitCode(..))
 
-import Data.MIME (contentTypeTextPlain, matchContentType)
+import Data.MIME (contentTypeTextPlain, defaultCharsets, matchContentType)
 
 import UI.FileBrowser.Keybindings
        (fileBrowserKeybindings, manageSearchPathKeybindings)
@@ -214,5 +214,6 @@ defaultConfig =
       , _fbSearchPathKeybindings = manageSearchPathKeybindings
       , _fbHomePath = getHomeDirectory
       }
+    , _confCharsets = defaultCharsets
     , _confExtra = ()
     }

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -223,6 +223,7 @@ data Configuration extra a b c = Configuration
     , _confHelpView :: HelpViewSettings
     , _confDefaultView :: ViewName
     , _confFileBrowserView :: FileBrowserSettings c
+    , _confCharsets :: CharsetLookup
     , _confExtra :: extra  -- data specific to a particular "phase" of configuration
     }
     deriving (Generic, NFData)
@@ -258,6 +259,9 @@ confDefaultView = lens _confDefaultView (\conf x -> conf { _confDefaultView = x 
 
 confFileBrowserView :: Lens (Configuration z a b c) (Configuration z a b c') (FileBrowserSettings c) (FileBrowserSettings c')
 confFileBrowserView = lens _confFileBrowserView (\conf x -> conf { _confFileBrowserView = x })
+
+confCharsets :: ConfigurationLens CharsetLookup
+confCharsets = lens _confCharsets (\conf x -> conf { _confCharsets = x })
 
 confExtra :: Lens (Configuration extra a b c) (Configuration extra' a b c) extra extra'
 confExtra = lens _confExtra (\cfg x -> cfg { _confExtra = x })


### PR DESCRIPTION
Update to purebred-email >= 0.2.  Add a CharsetLookup to the
configuration, defaulting it to 'defaultCharsets' from Data.MIME.
This allows custom configurations and plugins to provide support for
additional character sets.

This requires purebred-email >= 0.2, which is not yet on hackage but is
in git: purebred-mua/purebred-email@82bc75ff878a61a21a031b155db5e380f3852788.

See also https://github.com/purebred-mua/purebred-icu, a plugin that provides
more charsets.  To try it out (cabal newstyle build), add all relevant dirs to
`cabal.project.local`, then `cabal new-install exe:purebred lib:purebred-icu`,
modify your config (see below) then run *purebred*.

Sample `cabal.project.local`:
```
packages: ., ../purebred-email, ..purebred-icu
```

Sample `~/.config/purebred/purebred.hs`:
```
import Purebred
import qualified Purebred.Plugin.ICU

main = purebred $ tweak defaultConfig
  where
  tweak =
    id  -- various config changes
    . Purebred.Plugin.ICU.enable
```