### PR TITLE
remove redundant (<>) imports

### DIFF
--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -21,7 +21,6 @@ Example configuration, currently used for testing which demonstrates various
 ways to overwrite the configuration.
 -}
 import Purebred
-import Data.Semigroup ((<>))
 import qualified Data.ByteString as B
 import System.Environment (lookupEnv)
 import System.Directory (getCurrentDirectory)

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -81,7 +81,7 @@ library
   other-modules:       Paths_purebred
                      , Purebred.Types.IFC
   autogen-modules:     Paths_purebred
-  build-depends:       base >= 4.9 && < 5
+  build-depends:       base >= 4.11 && < 5
                      , deepseq >= 1.4.2
                      , dyre >= 0.8.12
                      , lens
@@ -113,7 +113,7 @@ executable purebred
   ghc-options:         -Wall -threaded
   main-is:             Main.hs
   default-language:    Haskell2010
-  build-depends:       base >= 4.9 && < 5
+  build-depends:       base >= 4.11 && < 5
                      , purebred
 
 test-suite unit

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -24,7 +24,6 @@ your liking.  For example, the following configuration adds some
 custom keybindings:
 
 @
-import Data.Semigroup ((<>))
 import Purebred
 
 scrollKeybindings :: ('Scrollable' w) => ['Keybinding' v w]
@@ -147,7 +146,6 @@ import Control.Monad ((>=>), void)
 import Options.Applicative hiding (str)
 import qualified Options.Applicative.Builder as Builder
 import Data.List (elemIndex, isInfixOf, isPrefixOf)
-import Data.Semigroup ((<>))
 import System.Environment (lookupEnv)
 import System.FilePath (dropTrailingPathSeparator, joinPath, splitPath)
 import System.FilePath.Posix ((</>))

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -46,7 +46,6 @@ import qualified Data.ByteString as B
 import System.IO.Temp (emptySystemTempFile)
 import System.Directory (removeFile)
 import Control.Lens ((&), _2, over, set, view)
-import Data.Semigroup ((<>))
 import Data.Foldable (toList)
 
 import qualified Data.Text as T

--- a/src/Purebred/Tags.hs
+++ b/src/Purebred/Tags.hs
@@ -23,7 +23,6 @@ import Data.Attoparsec.ByteString.Char8
   , skipMany1, takeWhile1, endOfInput, peekChar' )
 import qualified Data.ByteString as B
 import Data.Functor (($>))
-import Data.Semigroup ((<>))
 import Control.Lens (over, _Left)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T

--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -12,7 +12,6 @@ import Control.Lens
 import Data.Text.Lens (packed)
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Semigroup ((<>))
 import qualified Data.ByteString as B
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as T

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -76,7 +76,6 @@ import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
 import Network.Mime (defaultMimeLookup)
 import Data.Proxy
-import Data.Semigroup ((<>))
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Encoding as T

--- a/src/UI/Help/Main.hs
+++ b/src/UI/Help/Main.hs
@@ -10,7 +10,6 @@ import Brick.Widgets.Core
         (<+>), vBox, withAttr)
 import Graphics.Vty.Input.Events (Event(..), Key(..), Modifier(..))
 import Control.Lens (view, views)
-import Data.Semigroup ((<>))
 import Data.Text (Text, singleton, intercalate, pack)
 import Config.Main (helpTitleAttr, helpKeybindingAttr)
 import Types

--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -28,7 +28,6 @@ import Control.Lens.Getter (view)
 import Data.Time.Clock
        (UTCTime(..), NominalDiffTime, nominalDay, diffUTCTime)
 import Data.Time.Format (formatTime, defaultTimeLocale)
-import Data.Semigroup ((<>))
 import Data.Text as T (Text, pack, unpack, unwords)
 
 import Notmuch (getTag)

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -14,7 +14,6 @@ import Brick.Widgets.Core
 import Control.Lens (filtered, folded, toListOf, view, preview, has)
 import qualified Data.ByteString as B
 import qualified Data.CaseInsensitive as CI
-import Data.Semigroup ((<>))
 import Data.Maybe (fromMaybe)
 
 import Data.MIME

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -24,7 +24,6 @@ import Brick.Widgets.Center (hCenter)
 import qualified Brick.Widgets.List  as L
 import qualified Brick.Widgets.Edit  as E
 import Control.Lens (view, views)
-import Data.Semigroup ((<>))
 import Data.Text (Text)
 import Data.Text.Zipper (cursorPosition)
 

--- a/test/LazyVector.hs
+++ b/test/LazyVector.hs
@@ -19,7 +19,6 @@ module LazyVector where
 import Prelude hiding (splitAt)
 
 import Data.Foldable (toList)
-import Data.Semigroup ((<>))
 
 import Test.Tasty
 import Test.Tasty.QuickCheck

--- a/test/TestTagParser.hs
+++ b/test/TestTagParser.hs
@@ -19,7 +19,6 @@
 module TestTagParser where
 
 import Data.List (isInfixOf)
-import Data.Semigroup ((<>))
 
 import Purebred.Tags
 import Types (TagOp(..))

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -23,7 +23,6 @@ module Main where
 
 import Data.Char (chr)
 import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
-import Data.Semigroup ((<>))
 import Data.Either (isRight)
 import Data.Foldable (traverse_)
 import Data.Functor (($>))


### PR DESCRIPTION
We now require GHC 8.4.  Bump base min dep and remove explicit
imports of Data.Semigroup.<>, which is in prelude as of base-4.11
and GHC 8.4.