### PR TITLE
Allow stacked rendering of widgets

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -452,33 +452,36 @@ veName f (Tile a b) = fmap (\b' -> Tile a b') (f b)
 veState :: Lens' Tile ViewState
 veState f (Tile a b) = fmap (\a' -> Tile a' b) (f a)
 
+type Layers = V.Vector Layer
+
 data View = View
     { _vFocus :: Name
-    , _vWidgets :: Tiles
+    , _vLayers :: Layers
     }
 
--- A tile is a view element with a widget and it's view state
-newtype Tiles =
-  Tiles (V.Vector Tile)
-  deriving (Eq, Show)
-
-type instance Index Tiles = Name
-type instance IxValue Tiles = Tile
-
-instance Ixed Tiles where
-  ix = tile
-
-tileiso :: Iso' Tiles (V.Vector Tile)
-tileiso = iso (\(Tiles xs) -> xs) Tiles
-
-tile :: Name -> Traversal' Tiles Tile
-tile k = tileiso . traversed . filtered (\x -> k == view veName x)
-
-vWidgets :: Lens' View Tiles
-vWidgets = lens _vWidgets (\settings x -> settings { _vWidgets = x })
+vLayers :: Lens' View Layers
+vLayers = lens _vLayers (\settings x -> settings { _vLayers = x })
 
 vFocus :: Lens' View Name
 vFocus = lens _vFocus (\settings x -> settings { _vFocus = x})
+
+-- A layer is a view element with a list of widgets and their view
+-- state
+newtype Layer =
+  Layer (V.Vector Tile)
+  deriving (Eq, Show)
+
+type instance Index Layer = Name
+type instance IxValue Layer = Tile
+
+instance Ixed Layer where
+  ix = tile
+
+layeriso :: Iso' Layer (V.Vector Tile)
+layeriso = iso (\(Layer xs) -> xs) Layer
+
+tile :: Name -> Traversal' Layer Tile
+tile k = layeriso . traversed . filtered (\x -> k == view veName x)
 
 data ViewSettings = ViewSettings
     { _vsViews :: Map.Map ViewName View

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -237,16 +237,16 @@ completeMailTags s =
                       <$> selectedItemHelper (asMailIndex . miListOfMails) s (manageMailTags s ops')
 
 instance Completable 'ComposeTo where
-  complete _ = pure . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeTo . veState) Hidden
+  complete _ = pure . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 0 . ix ComposeTo . veState) Hidden
 
 instance Completable 'ComposeFrom where
-  complete _ = pure . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeFrom . veState) Hidden
+  complete _ = pure . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 0 . ix ComposeFrom . veState) Hidden
 
 instance Completable 'ComposeSubject where
-  complete _ = pure . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeSubject . veState) Hidden
+  complete _ = pure . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 0 . ix ComposeSubject . veState) Hidden
 
 instance Completable 'ConfirmDialog where
-  complete _ = pure . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ConfirmDialog . veState) Hidden
+  complete _ = pure . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 0 . ix ConfirmDialog . veState) Hidden
 
 -- | Applying tag operations on threads
 -- Note: notmuch does not support adding tags to threads themselves, instead we'll
@@ -271,11 +271,13 @@ instance Completable 'ManageFileBrowserSearchPath where
 
 instance Completable 'MailAttachmentOpenWithEditor where
   complete _ = pure
-               . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentOpenWithEditor . veState) Hidden
+               . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                      . ix MailAttachmentOpenWithEditor . veState) Hidden
 
 instance Completable 'MailAttachmentPipeToEditor where
   complete _ = pure
-               . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentPipeToEditor . veState) Hidden
+               . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                      . ix MailAttachmentPipeToEditor . veState) Hidden
 
 -- | Generalisation of reset actions, whether they reset editors back to their
 -- initial state or throw away composed, but not yet sent mails.
@@ -308,15 +310,18 @@ instance Resetable 'Threads 'ComposeTo where
 
 instance Resetable 'ComposeView 'ComposeFrom where
   reset _ _ s = pure $ s & over (asCompose . cSubject . E.editContentsL) (revertEditorContents s)
-                . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeFrom . veState) Hidden
+                . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 1
+                       . ix ComposeFrom . veState) Hidden
 
 instance Resetable 'ComposeView 'ComposeTo where
   reset _ _ s = pure $ s & over (asCompose . cTo . E.editContentsL) (revertEditorContents s)
-                . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeTo . veState) Hidden
+                . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 1
+                       . ix ComposeTo . veState) Hidden
 
 instance Resetable 'ComposeView 'ComposeSubject where
   reset _ _ s = pure $ s & over (asCompose . cSubject . E.editContentsL) (revertEditorContents s)
-                . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeTo . veState) Hidden
+                . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 1
+                       . ix ComposeTo . veState) Hidden
 
 revertEditorContents :: AppState -> TextZipper T.Text -> TextZipper T.Text
 revertEditorContents s z = let saved = view (asCompose . cTemp) s
@@ -330,15 +335,18 @@ instance Resetable 'FileBrowser 'ManageFileBrowserSearchPath where
   reset _ _ = pure . over (asFileBrowser . fbSearchPath . E.editContentsL) clearZipper
 
 instance Resetable 'ViewMail 'MailListOfAttachments where
-  reset _ _ = pure . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailListOfAttachments . veState) Hidden
+  reset _ _ = pure . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                          . ix MailListOfAttachments . veState) Hidden
 
 instance Resetable 'ViewMail 'MailAttachmentOpenWithEditor where
   reset _ _ = pure . over (asMailView . mvOpenCommand . E.editContentsL) clearZipper
-            . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentOpenWithEditor . veState) Hidden
+            . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                   . ix MailAttachmentOpenWithEditor . veState) Hidden
 
 instance Resetable 'ViewMail 'MailAttachmentPipeToEditor where
   reset _ _ = pure . over (asMailView . mvPipeCommand . E.editContentsL) clearZipper
-            . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentPipeToEditor . veState) Hidden
+            . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                   . ix MailAttachmentPipeToEditor . veState) Hidden
 
 clearMailComposition :: AppState -> AppState
 clearMailComposition s =
@@ -390,7 +398,8 @@ instance Focusable 'Mails 'ManageMailTagsEditor where
 
 instance Focusable 'ViewMail 'ManageMailTagsEditor where
   switchFocus _ _ s = pure $ s &
-                      set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix ManageMailTagsEditor . veState) Visible
+                      set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                           . ix ManageMailTagsEditor . veState) Visible
                       . set (asViews . vsViews . at ViewMail . _Just . vFocus) ManageMailTagsEditor
 
 instance Focusable 'ViewMail 'ScrollingMailView where
@@ -407,15 +416,18 @@ instance Focusable 'ViewMail 'ListOfMails where
 
 instance Focusable 'ViewMail 'MailListOfAttachments where
   switchFocus _ _ = pure . set (asViews . vsViews . at ViewMail . _Just . vFocus) MailListOfAttachments
-                    . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailListOfAttachments . veState) Visible
+                    . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                           . ix MailListOfAttachments . veState) Visible
 
 instance Focusable 'ViewMail 'MailAttachmentOpenWithEditor where
   switchFocus _ _ = pure . set (asViews . vsViews . at ViewMail . _Just . vFocus) MailAttachmentOpenWithEditor
-                    . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentOpenWithEditor . veState) Visible
+                    . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                           . ix MailAttachmentOpenWithEditor . veState) Visible
 
 instance Focusable 'ViewMail 'MailAttachmentPipeToEditor where
   switchFocus _ _ = pure . set (asViews . vsViews . at ViewMail . _Just . vFocus) MailAttachmentPipeToEditor
-                    . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentPipeToEditor . veState) Visible
+                    . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                           . ix MailAttachmentPipeToEditor . veState) Visible
 
 instance Focusable 'Help 'ScrollingHelpView where
   switchFocus _ _ = pure . over (asViews . vsFocusedView) (Brick.focusSetCurrent Help)
@@ -427,21 +439,25 @@ instance Focusable 'ComposeView 'ComposeListOfAttachments where
 instance Focusable 'ComposeView 'ComposeFrom where
   switchFocus _ _ s = pure $ s & set (asViews . vsViews . at ComposeView . _Just . vFocus) ComposeFrom
                       . set (asCompose . cTemp) (view (asCompose . cTo . E.editContentsL . to currentLine) s)
-                      . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeFrom . veState) Visible
+                      . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 1
+                             . ix ComposeFrom . veState) Visible
 
 instance Focusable 'ComposeView 'ComposeTo where
   switchFocus _ _ s = pure $ s & set (asViews . vsViews . at ComposeView . _Just . vFocus) ComposeTo
                       . set (asCompose . cTemp) (view (asCompose . cTo . E.editContentsL . to currentLine) s)
-                      . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeTo . veState) Visible
+                      . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 1
+                             . ix ComposeTo . veState) Visible
 
 instance Focusable 'ComposeView 'ComposeSubject where
   switchFocus _ _ s = pure $ s & set (asViews . vsViews . at ComposeView . _Just . vFocus) ComposeSubject
                       . set (asCompose . cTemp) (view (asCompose . cTo . E.editContentsL . to currentLine) s)
-                      . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ComposeSubject . veState) Visible
+                      . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 1
+                             . ix ComposeSubject . veState) Visible
 
 instance Focusable 'ComposeView 'ConfirmDialog where
   switchFocus _ _ s = pure $ s & set (asViews . vsViews . at ComposeView . _Just . vFocus) ConfirmDialog
-                      . set (asViews . vsViews . at ComposeView . _Just . vWidgets . ix ConfirmDialog . veState) Visible
+                      . set (asViews . vsViews . at ComposeView . _Just . vLayers . ix 0
+                             . ix ConfirmDialog . veState) Visible
 
 instance Focusable 'FileBrowser 'ListOfFiles where
   switchFocus _ _ s = let path = view (asFileBrowser . fbSearchPath . E.editContentsL . to currentLine) s
@@ -618,7 +634,8 @@ openAttachment =
            Nothing ->
              Brick.continue
              $ s & set (asViews . vsViews . at ViewMail . _Just . vFocus) MailAttachmentOpenWithEditor
-             . set (asViews . vsViews . at ViewMail . _Just . vWidgets . ix MailAttachmentOpenWithEditor . veState) Visible
+             . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
+                    . ix MailAttachmentOpenWithEditor . veState) Visible
   }
 
 openWithCommand :: Action 'ViewMail 'MailAttachmentOpenWithEditor (T.Next AppState)

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -22,7 +22,7 @@ module UI.App where
 import qualified Brick.Main as M
 import Brick.Types (Widget)
 import Brick.Focus (focusRing)
-import Brick.Widgets.Core (vBox, vLimit, emptyWidget)
+import Brick.Widgets.Core (vBox, vLimit)
 import qualified Brick.Types as T
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
@@ -51,10 +51,7 @@ import Purebred.Events (firstGeneration)
 import Types
 
 drawUI :: AppState -> [Widget Name]
-drawUI s = let ui = vBox (renderWidget s (focusedViewName s) <$> focusedViewWidgets s)
-           in case focusedViewWidget s of
-                ConfirmDialog -> [renderConfirm s, ui]
-                _ -> [ui]
+drawUI s = vBox . fmap (renderWidget s (focusedViewName s)) <$> focusedViewWidgets s
 
 renderWidget :: AppState -> ViewName -> Name -> Widget Name
 renderWidget s _ ListOfThreads = renderListOfThreads s
@@ -81,7 +78,7 @@ renderWidget s _ ComposeTo = renderEditorWithLabel (Proxy :: Proxy 'ComposeTo) "
 renderWidget s _ ComposeSubject = renderEditorWithLabel (Proxy :: Proxy 'ComposeSubject) "Subject:" s
 renderWidget s _ ComposeHeaders = drawHeaders s
 renderWidget s _ StatusBar = statusbar s
-renderWidget _ _ ConfirmDialog = emptyWidget
+renderWidget s _ ConfirmDialog = renderConfirm s
 
 handleViewEvent :: ViewName -> Name -> AppState -> Vty.Event -> T.EventM Name (T.Next AppState)
 handleViewEvent = f where

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -61,7 +61,7 @@ testSwapBottom :: TestTree
 testSwapBottom = testCase "swaps last visible widget" $ swapWidget ListOfThreads ManageThreadTagsEditor tiles @?= expected
   where
     tiles =
-        Tiles $ Vector.fromList
+        Layer $ Vector.fromList
           [ Tile Visible ListOfThreads
           , Tile Visible StatusBar
           , Tile Visible SearchThreadsEditor
@@ -69,7 +69,7 @@ testSwapBottom = testCase "swaps last visible widget" $ swapWidget ListOfThreads
           , Tile Hidden ComposeFrom
           ]
     expected =
-        Tiles $ Vector.fromList
+        Layer $ Vector.fromList
           [ Tile Visible ListOfThreads
           , Tile Visible StatusBar
           , Tile Hidden SearchThreadsEditor


### PR DESCRIPTION
Brick supports rendering of stacked widgets. For example, Brick can
render a dialog in front of the main UI.

Before this patch, Purebred rendered widgets in a single list onto the
screen. The widgets were rendered vertically from top to
bottom. However, if we wanted to render a dialog in front of the UI it
was rendered at the top and the rest of the widgets used the remaining
height showing them a little bit squished.

This patch changes this by adding an additional abstraction. Instead of
a single list of widgets, purebred allows lists of widgets. Layers can
not be set to hidden or visible, but the containing widgets can.

Each layer renders it's visible widgets resulting in a stacked, rendered
terminal image.

Fixes https://github.com/purebred-mua/purebred/issues/297