### PR TITLE
nix: add tasty-tmux

### DIFF
--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -7,6 +7,7 @@ let
       overrides = hself: hsuper: {
         purebred = hsuper.callPackage ./purebred.nix { };
         purebred-email = hsuper.callPackage ./purebred-email.nix { };
+        tasty-tmux = hsuper.callPackage ./tasty-tmux.nix { };
         brick = hsuper.callPackage ./brick.nix {};
         notmuch = hsuper.callPackage ./hs-notmuch.nix {
           notmuch = self.pkgs.notmuch;

--- a/.nix/purebred.nix
+++ b/.nix/purebred.nix
@@ -1,11 +1,11 @@
 { mkDerivation, attoparsec, base, brick, bytestring
-, case-insensitive, containers, deepseq, directory, dyre
-, exceptions, filepath, ini, lens, mime-types, mtl, notmuch
-, optparse-applicative, purebred-email, quickcheck-instances
-, random, regex-posix, stdenv, stm, tasty, tasty-hunit
-, tasty-quickcheck, temporary, text, text-zipper, time
-, typed-process, vector, vty
-, Cabal
+  , case-insensitive, containers, deepseq, directory, dyre
+  , exceptions, filepath, ini, lens, mime-types, mtl, notmuch
+  , optparse-applicative, purebred-email, quickcheck-instances
+  , random, regex-posix, stdenv, stm, tasty, tasty-hunit
+  , tasty-quickcheck, temporary, text, text-zipper, time
+  , typed-process, vector, vty
+  , Cabal, tasty-tmux
 }:
 mkDerivation {
   pname = "purebred";
@@ -26,7 +26,7 @@ mkDerivation {
     base brick bytestring directory filepath ini lens mtl notmuch
     purebred-email quickcheck-instances regex-posix stm tasty
     tasty-hunit tasty-quickcheck temporary text time typed-process
-    vector
+    vector tasty-tmux
   ];
   homepage = "https://github.com/githubuser/purebred#readme";
   description = "An mail user agent built around notmuch";

--- a/.nix/tasty-tmux.nix
+++ b/.nix/tasty-tmux.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, bytestring, mtl, regex-posix, stdenv, tasty
+, tasty-hunit, text, typed-process
+}:
+mkDerivation {
+  pname = "tasty-tmux";
+  version = "0.1.0.0";
+  sha256 = "0886b212d0e58820175fb99fac94d469d9dcb28454065a21223b4bb79d60fdcc";
+  libraryHaskellDepends = [
+    base bytestring mtl regex-posix tasty tasty-hunit text
+    typed-process
+  ];
+  homepage = "https://github.com/purebred-mua/tasty-tmux";
+  description = "Terminal user acceptance testing (UAT) via tmux";
+  license = stdenv.lib.licenses.agpl3;
+}


### PR DESCRIPTION
Add a derivation for tasty-tmux 1.0 moved into it's own package from our
user acceptance tests.