### PR TITLE
Remove separate list of mails view

### DIFF
--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -33,11 +33,6 @@ myBrowseThreadsKbs =
   [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
   ]
 
-myBrowseMailKeybindings :: [Keybinding 'Mails 'ListOfMails]
-myBrowseMailKeybindings =
-    [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
-    ]
-
 myMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 myMailKeybindings =
     [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
@@ -62,7 +57,6 @@ main :: IO ()
 main = purebred $ tweak defaultConfig where
   tweak =
     over (confIndexView . ivBrowseThreadsKeybindings) (`union` myBrowseThreadsKbs)
-    . over (confIndexView . ivBrowseMailsKeybindings) (`union` myBrowseMailKeybindings)
     . over (confMailView . mvKeybindings) (`union` myMailKeybindings)
     . set (confComposeView . cvSendMailCmd) writeMailtoFile
     . set (confFileBrowserView . fbHomePath) getCurrentDirectory

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -43,9 +43,7 @@ import UI.GatherHeaders.Keybindings
         gatherToKeybindings,
         gatherSubjectKeybindings)
 import UI.Index.Keybindings
-       (browseMailKeybindings, browseThreadsKeybindings,
-        searchThreadsKeybindings, manageThreadTagsKeybindings,
-        manageMailTagsKeybindings)
+       (browseThreadsKeybindings, searchThreadsKeybindings, manageThreadTagsKeybindings)
 import UI.Mail.Keybindings
        (displayMailKeybindings, mailViewManageMailTagsKeybindings,
         mailAttachmentsKeybindings, openWithKeybindings,
@@ -215,9 +213,7 @@ defaultConfig =
       }
     , _confIndexView = IndexViewSettings
       { _ivBrowseThreadsKeybindings = browseThreadsKeybindings
-      , _ivBrowseMailsKeybindings = browseMailKeybindings
       , _ivSearchThreadsKeybindings = searchThreadsKeybindings
-      , _ivManageMailTagsKeybindings = manageMailTagsKeybindings
       , _ivManageThreadTagsKeybindings = manageThreadTagsKeybindings
       , _ivFromKeybindings = gatherFromKeybindings
       , _ivToKeybindings = gatherToKeybindings

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -351,9 +351,7 @@ hvKeybindings f (HelpViewSettings a) = fmap (\a' -> HelpViewSettings a') (f a)
 
 data IndexViewSettings = IndexViewSettings
     { _ivBrowseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]
-    , _ivBrowseMailsKeybindings :: [Keybinding 'Mails 'ListOfMails]
     , _ivSearchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]
-    , _ivManageMailTagsKeybindings :: [Keybinding 'Mails 'ManageMailTagsEditor]
     , _ivManageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor]
     , _ivFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
     , _ivToKeybindings :: [Keybinding 'Threads 'ComposeTo]
@@ -364,14 +362,8 @@ data IndexViewSettings = IndexViewSettings
 ivBrowseThreadsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ListOfThreads]
 ivBrowseThreadsKeybindings = lens _ivBrowseThreadsKeybindings (\s x -> s { _ivBrowseThreadsKeybindings = x })
 
-ivBrowseMailsKeybindings :: Lens' IndexViewSettings [Keybinding 'Mails 'ListOfMails]
-ivBrowseMailsKeybindings = lens _ivBrowseMailsKeybindings (\s x -> s { _ivBrowseMailsKeybindings = x })
-
 ivSearchThreadsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'SearchThreadsEditor]
 ivSearchThreadsKeybindings = lens _ivSearchThreadsKeybindings (\s x -> s { _ivSearchThreadsKeybindings = x })
-
-ivManageMailTagsKeybindings :: Lens' IndexViewSettings [Keybinding 'Mails 'ManageMailTagsEditor]
-ivManageMailTagsKeybindings = lens _ivManageMailTagsKeybindings (\s x -> s { _ivManageMailTagsKeybindings = x })
 
 ivManageThreadTagsKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ManageThreadTagsEditor]
 ivManageThreadTagsKeybindings = lens _ivManageThreadTagsKeybindings (\s x -> s { _ivManageThreadTagsKeybindings = x })

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -42,7 +42,7 @@ import UI.Mail.Main (renderAttachmentsList, renderMailView)
 import UI.Help.Main (renderHelp)
 import UI.Status.Main (statusbar)
 import UI.Views
-       (indexView, mailView, composeView, helpView, listOfMailsView,
+       (indexView, mailView, composeView, helpView,
         filebrowserView, focusedViewWidget, focusedViewWidgets,
         focusedViewName)
 import UI.ComposeEditor.Main (attachmentsEditor, drawHeaders, renderConfirm)
@@ -86,8 +86,6 @@ handleViewEvent = f where
   f ComposeView ComposeSubject = dispatch eventHandlerComposeSubject
   f ComposeView ComposeTo = dispatch eventHandlerComposeTo
   f ComposeView ComposeListOfAttachments = dispatch eventHandlerComposeListOfAttachments
-  f Mails ListOfMails = dispatch eventHandlerListOfMails
-  f Mails ManageMailTagsEditor = dispatch eventHandlerManageMailTagsEditor
   f Threads ComposeFrom =  dispatch eventHandlerThreadComposeFrom
   f Threads ComposeSubject = dispatch eventHandlerThreadComposeSubject
   f Threads ComposeTo = dispatch eventHandlerThreadComposeTo
@@ -141,7 +139,6 @@ initialState conf =
         ViewSettings
         { _vsViews = Map.fromList
               [ (Threads, indexView)
-              , (Mails, listOfMailsView)
               , (ViewMail, mailView)
               , (Help, helpView)
               , (ComposeView, composeView)

--- a/src/UI/Help/Main.hs
+++ b/src/UI/Help/Main.hs
@@ -17,10 +17,8 @@ import UI.Utils (titleize, Titleize)
 
 renderHelp :: AppState -> Widget Name
 renderHelp s = viewport ScrollingHelpView T.Vertical $ vBox
-  [ views (asConfig . confIndexView . ivBrowseMailsKeybindings) (renderKbGroup ListOfMails) s
-  , views (asConfig . confIndexView . ivBrowseThreadsKeybindings) (renderKbGroup ListOfThreads) s
+  [ views (asConfig . confIndexView . ivBrowseThreadsKeybindings) (renderKbGroup ListOfThreads) s
   , views (asConfig . confIndexView . ivSearchThreadsKeybindings) (renderKbGroup SearchThreadsEditor) s
-  , views (asConfig . confIndexView . ivManageMailTagsKeybindings) (renderKbGroup ManageMailTagsEditor) s
   , views (asConfig . confIndexView . ivManageThreadTagsKeybindings) (renderKbGroup ManageThreadTagsEditor) s
   , views (asConfig . confMailView . mvKeybindings) (renderKbGroup ScrollingMailView) s
   , views (asConfig . confHelpView . hvKeybindings) (renderKbGroup ScrollingHelpView) s

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -6,30 +6,11 @@ import qualified Graphics.Vty as V
 import UI.Actions
 import Types
 
--- | Default Keybindings
-browseMailKeybindings :: [Keybinding 'Mails 'ListOfMails]
-browseMailKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` displayMail `chain` continue)
-    , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
-    , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
-    , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
-    , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'Mails 'ManageMailTagsEditor AppState) `chain` continue)
-    ]
-
 browseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]
 browseThreadsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) quit
     , Keybinding (V.EvKey (V.KChar 'q') []) quit
-    , Keybinding (V.EvKey V.KEnter []) (displayThreadMails `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain'` selectNextUnread `chain'` displayMail `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (displayThreadMails `chain'` (focus :: Action 'ViewMail 'ListOfMails AppState) `chain'` selectNextUnread `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` (focus :: Action 'Threads 'SearchThreadsEditor AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'm') []) (noop `chain'` (focus :: Action 'Threads 'ComposeFrom AppState) `chain`continue)
     , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'Threads 'ManageThreadTagsEditor AppState) `chain` continue)
@@ -48,13 +29,6 @@ searchThreadsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    ]
-
-manageMailTagsKeybindings :: [Keybinding 'Mails 'ManageMailTagsEditor]
-manageMailTagsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
     ]
 
 manageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor]

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -82,11 +82,6 @@ nullEventHandler :: EventHandler v m
 nullEventHandler = EventHandler (\f s -> s <$ f []) (const . Brick.continue)
 
 
-eventHandlerListOfMails :: EventHandler 'Mails 'ListOfMails
-eventHandlerListOfMails = EventHandler
-  (asConfig . confIndexView . ivBrowseMailsKeybindings)
-  (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailIndex . miListOfMails) L.handleListEvent)
-
 eventHandlerListOfThreads :: EventHandler 'Threads 'ListOfThreads
 eventHandlerListOfThreads = EventHandler
   (asConfig . confIndexView . ivBrowseThreadsKeybindings)
@@ -96,12 +91,6 @@ eventHandlerSearchThreadsEditor :: EventHandler 'Threads 'SearchThreadsEditor
 eventHandlerSearchThreadsEditor = EventHandler
   (asConfig . confIndexView . ivSearchThreadsKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailIndex . miSearchThreadsEditor) E.handleEditorEvent)
-
-eventHandlerManageMailTagsEditor :: EventHandler 'Mails 'ManageMailTagsEditor
-eventHandlerManageMailTagsEditor =
-  EventHandler
-    (asConfig . confIndexView . ivManageMailTagsKeybindings)
-    manageMailTagHandler
 
 eventHandlerViewMailManageMailTagsEditor :: EventHandler 'ViewMail 'ManageMailTagsEditor
 eventHandlerViewMailManageMailTagsEditor = EventHandler

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -8,9 +8,10 @@ import Types
 
 displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 displayMailKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'Mails 'ListOfMails AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
     , Keybinding (V.EvKey V.KBS []) (scrollPageUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar ' ') []) (scrollPageDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'h') []) (toggleHeaders `chain` continue)
     , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'ViewMail 'ManageMailTagsEditor AppState) `chain` continue)

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -1,6 +1,5 @@
 module UI.Views
   ( indexView
-  , listOfMailsView
   , mailView
   , composeView
   , helpView
@@ -84,21 +83,6 @@ indexView =
               ]
           ]
     , _vFocus = ListOfThreads
-    }
-
-listOfMailsView :: View
-listOfMailsView =
-  View
-    { _vLayers =
-        fromList
-          [ Layer $
-            fromList
-              [ Tile Visible ListOfMails
-              , Tile Visible StatusBar
-              , Tile Visible ManageMailTagsEditor
-              ]
-          ]
-    , _vFocus = ListOfMails
     }
 
 mailView :: View

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -44,7 +44,7 @@ testModeDescription :: TestTree
 testModeDescription = testCase "mode present in the switch action"
                       $ view aDescription a @?= ["switch mode to ManageMailTagsEditor"]
   where
-    a = focus :: Action 'Mails 'ManageMailTagsEditor AppState
+    a = focus :: Action 'ViewMail 'ManageMailTagsEditor AppState
 
 testNoDupes :: TestTree
 testNoDupes =

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -464,16 +464,16 @@ testUpdatesReadState = purebredTmuxSession "updates read state for mail and thre
     step "view next unread in thread"
     sendKeys "Down" (Substring "2 of 2")
 
-    step "go back to thread list which is read"
-    sendKeys "q q" (Regex (buildAnsiRegex [] ["37"] ["43"] <> T.encodeUtf8 " Feb'17\\sRóman\\sJoost\\s+\\(2\\)"))
+    step "go back to thread list which is now read"
+    sendKeys "q" (Regex (buildAnsiRegex [] ["37"] ["43"] <> T.encodeUtf8 " Feb'17\\sRóman\\sJoost\\s+\\(2\\)"))
 
     step "set one mail to unread"
     sendKeys "Enter" (Substring "Beginning of large text")
-    sendKeys "q t" (Regex (buildAnsiRegex ["1"] ["37"] []
+    sendKeys "t" (Regex (buildAnsiRegex ["1"] ["37"] []
                            <> "\\sRe: WIP Refactor\\s+"
                            <> buildAnsiRegex ["0"] ["34"] ["40"]))
 
-    step "returning to thread list shows thread unread"
+    step "returning to thread list shows entire thread as unread"
     sendKeys "q" (Regex (buildAnsiRegex ["1"] ["37"] [] <> "\\sWIP Refactor\\s"))
 
 testConfig :: PurebredTestCase
@@ -614,9 +614,6 @@ testManageTagsOnMails = purebredTmuxSession "manage tags on mails" $
                              <> "bar"))
       >>= assertSubstring "This is a test mail"
 
-    step "go back to list of mails"
-    sendKeys "Escape" (Substring "List of Mails")
-
     step "go back to list of threads"
     sendKeys "Escape" (Substring "List of Threads")
 
@@ -669,9 +666,6 @@ testManageTagsOnThreads = purebredTmuxSession "manage tags on threads" $
     step "add new tag"
     sendLine "+replied -inbox" (Substring "replied")
 
-    step "go back to list of mails"
-    sendKeys "Escape" (Substring "Item 2 of 2")
-
     step "thread tags shows new tags"
     sendKeys "Escape" (Regex ("archive"
                               <> buildAnsiRegex [] ["37"] []
@@ -703,10 +697,7 @@ testManageTagsOnThreads = purebredTmuxSession "manage tags on threads" $
                               <> buildAnsiRegex [] ["36"] []
                               <> "thread"
                               <> buildAnsiRegex [] ["37"] []
-                              <> "\\sRe: WIP Refactor"))
-
-    step "go back to list of threads"
-    sendKeys "Escape" (Substring "List of Threads")
+                              <> "\\sWIP Refactor"))
 
     step "open thread tag editor"
     sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] []))
@@ -751,10 +742,13 @@ testSetsMailToRead = purebredTmuxSession "user can toggle read tag" $
     sendKeys "Enter" (Substring "This is a test mail for purebred")
 
     step "first unread mail is opened"
-    sendKeys "Escape" (Substring "List of Mails")
+    sendKeys "Escape" (Substring "List of Threads")
       >>= assertRegex (buildAnsiRegex [] ["37"] ["43"] <> ".*Testmail")
 
-    step "toggle it back to unread (bold again)"
+    step "show mail"
+    sendKeys "Enter" (Substring "This is a test mail for purebred")
+
+    step "toggle single mail back to unread (bold again)"
     sendKeys "t" (Regex (buildAnsiRegex ["1"] ["37"] ["43"] <> ".*Testmail"))
 
 testCanToggleHeaders :: PurebredTestCase
@@ -790,7 +784,7 @@ testUserViewsMailSuccessfully = purebredTmuxSession "user can view mail" $
     sendKeys "Enter" (Substring "This is a test mail")
 
     step "go back to thread list"
-    sendKeys "q q" (Substring "WIP Refactor")
+    sendKeys "q" (Substring "WIP Refactor")
 
     step "Move down to threaded mails"
     sendKeys "Down" (Substring "Purebred: Item 2 of 3")


### PR DESCRIPTION
This view was added initially with our proof-of-concept brick
application two years ago. However, upon recent reflection, this view
serves no purpose. When viewing mail, we already show a list of mails in
the current thread. Tagging is already possible from the actual mail
view. Going back to the list of threads is now quicker.

https://github.com/purebred-mua/purebred/issues/303