### PR TITLE
New mail indicator

### DIFF
--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -193,6 +193,8 @@ defaultConfig =
       , _nmNewTag = "unread"
       , _nmDraftTag = "draft"
       , _nmSentTag = "sent"
+      , _nmHasNewMailSearch = "tag:inbox and tag:unread"
+      , _nmHasNewMailCheckDelay = Just (5 * 10000 * 60)  -- 3 seconds
       }
     , _confEditor = fromMaybe "vi" <$> lookupEnv "EDITOR"
     , _confMailView = MailViewSettings

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -156,6 +156,7 @@ import Paths_purebred (version, getLibDir)
 import UI.Index.Keybindings
 import UI.Mail.Keybindings
 import UI.Actions
+import UI.Status.Main (rescheduleMailcheck)
 import Storage.Notmuch (getDatabasePath)
 import Config.Main (defaultConfig, solarizedDark, solarizedLight, mailTagAttr)
 import Types
@@ -223,6 +224,12 @@ launch cfg = do
   s <- initialState cfg'
   let buildVty = Graphics.Vty.mkVty Graphics.Vty.defaultConfig
   initialVty <- buildVty
+
+  let query = view (confNotmuch . nmHasNewMailSearch) cfg'
+      delay = view (confNotmuch . nmHasNewMailCheckDelay) cfg'
+      dbpath = view (confNotmuch . nmDatabase) cfg'
+  maybe (pure ()) (rescheduleMailcheck bchan dbpath query) delay
+
   void $ customMain initialVty buildVty (Just bchan) (theApp s) s
 
 

--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -189,6 +189,12 @@ getDatabasePath = do
   where
       decode = T.unpack . sanitiseText . decodeLenient . LB.toStrict
 
+countThreads ::
+     (MonadError Error m, MonadIO m) => T.Text -> FilePath -> m Int
+countThreads query fp =
+  withDatabaseReadOnly fp $
+  flip Notmuch.query (Notmuch.Bare $ T.unpack query)
+  >=> Notmuch.queryCountMessages
 -- | creates a vector of threads from a notmuch search
 --
 getThreads

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -117,6 +117,7 @@ data MailIndex = MailIndex
     , _miSearchThreadsEditor :: E.Editor T.Text Name
     , _miMailTagsEditor :: E.Editor T.Text Name
     , _miThreadTagsEditor :: E.Editor T.Text Name
+    , _miNewMail :: Int
     }
 
 miMails :: Lens' MailIndex (ListWithLength V.Vector NotmuchMail)
@@ -143,6 +144,9 @@ miMailTagsEditor = lens _miMailTagsEditor (\m v -> m { _miMailTagsEditor = v})
 
 miThreadTagsEditor :: Lens' MailIndex (E.Editor T.Text Name)
 miThreadTagsEditor = lens _miThreadTagsEditor (\m v -> m { _miThreadTagsEditor = v})
+
+miNewMail :: Lens' MailIndex Int
+miNewMail = lens _miNewMail (\m v -> m { _miNewMail = v})
 
 data HeadersState = ShowAll | Filtered
 
@@ -211,6 +215,8 @@ data NotmuchSettings a = NotmuchSettings
     , _nmNewTag :: Tag
     , _nmDraftTag :: Tag
     , _nmSentTag :: Tag
+    , _nmHasNewMailSearch :: T.Text
+    , _nmHasNewMailCheckDelay :: Maybe Int
     }
     deriving (Generic, NFData)
 
@@ -228,6 +234,12 @@ nmDraftTag = lens _nmDraftTag (\nm x -> nm { _nmDraftTag = x })
 
 nmSentTag :: Lens' (NotmuchSettings a) Tag
 nmSentTag = lens _nmSentTag (\nm x -> nm { _nmSentTag = x })
+
+nmHasNewMailSearch :: Lens' (NotmuchSettings a) T.Text
+nmHasNewMailSearch = lens _nmHasNewMailSearch (\nm x -> nm { _nmHasNewMailSearch = x })
+
+nmHasNewMailCheckDelay :: Lens' (NotmuchSettings a) (Maybe Int)
+nmHasNewMailCheckDelay = lens _nmHasNewMailCheckDelay (\nm x -> nm { _nmHasNewMailCheckDelay = x })
 
 data FileBrowserSettings a = FileBrowserSettings
   { _fbKeybindings :: [Keybinding 'FileBrowser 'ListOfFiles]
@@ -746,5 +758,6 @@ newtype Generation = Generation Integer
 data PurebredEvent
   = NotifyNumThreads Int
                      Generation
+  | NotifyNewMailArrived Int
   | InputValidated (Lens' AppState (Maybe Error))
                    (Maybe Error)

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -114,6 +114,7 @@ appEvent s (T.AppEvent ev) = case ev of
     if gen == view (asMailIndex . miListOfThreadsGeneration) s
     then set (asMailIndex . miThreads . listLength) (Just n) s
     else s
+  NotifyNewMailArrived n -> M.continue (set (asMailIndex . miNewMail) n s)
   InputValidated l err -> M.continue (s & set l err . set (asAsync . aValidation) Nothing)
 appEvent s _ = M.continue s
 
@@ -129,6 +130,7 @@ initialState conf =
             (E.editorText SearchThreadsEditor Nothing searchterms)
             (E.editorText ManageMailTagsEditor Nothing "")
             (E.editorText ManageThreadTagsEditor Nothing "")
+            0
     mv = MailView
            Nothing
            Filtered

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -721,7 +721,7 @@ testShowsAndClearsError = purebredTmuxSession "shows and clears error" $
     startApplication
 
     testmdir <- view envMaildir
-    liftIO $ removeFile (testmdir <> "/Maildir/new/1502941827.R15455991756849358775.url")
+    liftIO $ removeFile (testmdir <> "/new/1502941827.R15455991756849358775.url")
 
     step "open thread"
     sendKeys "Enter" (Substring "Testmail")
@@ -1089,9 +1089,10 @@ mkTempDir = getCanonicalTemporaryDirectory >>= flip createTempDirectory "purebre
 -- The returned directory contains the 'Maildir' subdirectory.
 setUpTempMaildir :: IO FilePath
 setUpTempMaildir = do
-  mdir <- mkTempDir
+  basedir <- mkTempDir
   cwd <- getSourceDirectory
-  runProcess_ $ proc "cp" ["-r", cwd <> "/test/data/Maildir/", mdir]
+  runProcess_ $ proc "cp" ["-r", cwd <> "/test/data/Maildir/", basedir]
+  let mdir = basedir </> "Maildir"
   setUpNotmuchCfg mdir >>= setUpNotmuch
   pure mdir
 


### PR DESCRIPTION
This patch adds a small indicator which shows how much new mail is in
the INBOX. New mail is defined by a customizable notmuch query. The
query is rerun after a configurable delay. By default it is 5 seconds.

Fixes https://github.com/purebred-mua/purebred/issues/286