### PR TITLE
Reset state of the confirm dialog

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -411,14 +411,10 @@ instance Resetable 'ViewMail 'MailAttachmentPipeToEditor where
 --
 clearMailComposition :: AppState -> AppState
 clearMailComposition s =
-    let mailboxes = AddressText.renderMailboxes $ view (asConfig . confComposeView . cvIdentities) s
+    let mailboxes = view (asConfig . confComposeView . cvIdentities) s
     in s
         -- insert default from addresses
-        & over (asCompose . cFrom . E.editContentsL) (insertMany mailboxes . clearZipper)
-        -- clear editor contents for other fields
-        . over (asCompose . cTo . E.editContentsL) clearZipper
-        . over (asCompose . cSubject . E.editContentsL) clearZipper
-        . over (asCompose . cAttachments) L.listClear
+        & set asCompose (initialCompose mailboxes)
         -- reset the UI
         -- Note: Only replace the last widget on the Threads view with the
         -- SearchThreadsEditor. This is important if we abort mail composition

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -104,7 +104,30 @@ main = defaultMain $ testTmux pre post tests
       , testKeepDraftMail
       , testDiscardsMail
       , testShowsNewMail
+      , testConfirmDialogResets
       ]
+
+testConfirmDialogResets :: PurebredTestCase
+testConfirmDialogResets = purebredTmuxSession "confirm dialog resets state" $
+  \step -> do
+    startApplication
+
+    composeNewMail step
+
+    step "abort composition"
+    sendKeys "q" (Substring "Keep draft?")
+
+    step "choose Discard"
+    sendKeys "Tab" (Substring "Discard")
+
+    step "confirm discard"
+    sendKeys "Enter" (Substring "Testmail")
+
+    composeNewMail step
+
+    step "abort composition"
+    sendKeys "q" (Regex (buildAnsiRegex [] ["30"] ["42"] <> "\\s+Keep" ))
+
 
 -- Note: The most time in this test is spend on waiting. The default
 -- time for the indicator to refresh is 5 seconds.


### PR DESCRIPTION
When aborting a composition of an e-mail, the confirmation dialog
remembered it's last choice. This can be bad, because it can lead to
accidental deletion of drafts depending on a previous choice. Always
default to 'Keep' no matter what the last choice was.

Fixes https://github.com/purebred-mua/purebred/issues/332