### PR TITLE
Feature/279 uses focus ring length for matches

### DIFF
--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -1,20 +1,20 @@
-{ mkDerivation, base, config-ini, containers, contravariant
-, data-clist, deepseq, directory, dlist, filepath, microlens
-, microlens-mtl, microlens-th, QuickCheck, stdenv, stm
+{ mkDerivation, base, bytestring, config-ini, containers
+, contravariant, data-clist, deepseq, directory, dlist, filepath
+, microlens, microlens-mtl, microlens-th, QuickCheck, stdenv, stm
 , template-haskell, text, text-zipper, transformers, unix, vector
 , vty, word-wrap
 }:
 mkDerivation {
   pname = "brick";
-  version = "0.47";
-  sha256 = "47ce722f7a5f0457c97222823e863e455fe8b30710c2a9926d5930a9703892be";
+  version = "0.50.1";
+  sha256 = "fe9c6e3fcd71fa4a97bf12411256970dc10a3174623c95386e0e77a2d74d6673";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base config-ini containers contravariant data-clist deepseq
-    directory dlist filepath microlens microlens-mtl microlens-th stm
-    template-haskell text text-zipper transformers unix vector vty
-    word-wrap
+    base bytestring config-ini containers contravariant data-clist
+    deepseq directory dlist filepath microlens microlens-mtl
+    microlens-th stm template-haskell text text-zipper transformers
+    unix vector vty word-wrap
   ];
   testHaskellDepends = [
     base containers microlens QuickCheck vector

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -86,7 +86,7 @@ library
                      , deepseq >= 1.4.2
                      , dyre >= 0.8.12
                      , lens
-                     , brick >= 0.47
+                     , brick >= 0.50.1
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -21,7 +21,7 @@ module UI.Status.Main where
 
 import Brick.BChan (BChan, writeBChan)
 import Brick.Types (Widget)
-import Brick.Focus (focusGetCurrent)
+import Brick.Focus (focusGetCurrent, focusRingLength)
 import Brick.Widgets.Core
   (hBox, txt, str, withAttr, (<+>), strWrap, padLeftRight,
   emptyWidget)
@@ -115,7 +115,8 @@ renderStatusbar w s = withAttr statusbarAttr $ hBox
 
 renderMatches :: AppState -> Widget n
 renderMatches s =
-  let showCount = show $ matchCount $ view (asMailView . mvBody) s
+  let showCount = view (non "0")
+        $ preview (asMailView . mvScrollSteps . to (show . focusRingLength)) s
       currentItem = view (non "0")
         $ preview (asMailView . mvScrollSteps . to focusGetCurrent . _Just . stNumber . to show) s
    in if has (asMailView . mvScrollSteps) s


### PR DESCRIPTION
This is a fixup commit for the feature added by #338 but needs the latest brick release (> 50).