### PR TITLE
Also display the confirm dialog when using Esc

### DIFF
--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -18,6 +18,7 @@
 
 module UI.ComposeEditor.Keybindings where
 
+import qualified Brick.Types as T
 import qualified Graphics.Vty as V
 import UI.Actions
 import Types
@@ -63,10 +64,15 @@ confirmKeybindings =
        continue)
   ]
 
+confirmAbort :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
+confirmAbort =
+  noop `chain'` (focus :: Action 'ComposeView 'ConfirmDialog AppState) `chain`
+  continue
+
 listOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
 listOfAttachmentsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'ComposeView 'ConfirmDialog AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) confirmAbort
+    , Keybinding (V.EvKey (V.KChar 'q') []) confirmAbort
     , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -287,7 +287,7 @@ testDiscardsMail = purebredTmuxSession "discards draft mail" $
     composeNewMail step
 
     step "abort composition"
-    sendKeys "q" (Substring "Keep draft?")
+    sendKeys "Escape" (Substring "Keep draft?")
 
     step "choose Discard"
     sendKeys "Tab" (Substring "Discard")


### PR DESCRIPTION
This was a forgotten binding. When the user presses ESC he looses his
entire Draft instantly.

Avoid this by binding the same Action to the two different keys.