### PR TITLE
Deprecate mail field which is not used

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -264,17 +264,13 @@ data ConfirmDraft
   deriving (Show)
 
 data Compose = Compose
-    { _cMail :: B.ByteString
-    , _cFrom :: E.Editor T.Text Name
+    { _cFrom :: E.Editor T.Text Name
     , _cTo :: E.Editor T.Text Name
     , _cSubject :: E.Editor T.Text Name
     , _cTemp :: T.Text
     , _cAttachments :: L.List Name MIMEMessage
     , _cKeepDraft :: Dialog ConfirmDraft
     }
-
-cMail :: Lens' Compose B.ByteString
-cMail = lens _cMail (\c x -> c { _cMail = x })
 
 cFrom :: Lens' Compose (E.Editor T.Text Name)
 cFrom = lens _cFrom (\c x -> c { _cFrom = x })

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -562,7 +562,7 @@ focusComposeFrom
     -> AppState
     -> f AppState
 focusComposeFrom _ _ s =
-    if nullOf (asCompose . cMail) s
+    if nullOf (asCompose . cAttachments) s
         then pure $
              over
                  (asViews . vsFocusedView)
@@ -1327,15 +1327,13 @@ sanitizeMail charsets =
 
 initialCompose :: [Mailbox] -> Compose
 initialCompose mailboxes =
-  let mail = B.empty
-  in Compose
-        mail
-        (E.editorText ComposeFrom (Just 1) (AddressText.renderMailboxes mailboxes))
-        (E.editorText ComposeTo (Just 1) "")
-        (E.editorText ComposeSubject (Just 1) "")
-        T.empty
-        (L.list ComposeListOfAttachments mempty 1)
-        initialDraftConfirmDialog
+  Compose
+    (E.editorText ComposeFrom (Just 1) (AddressText.renderMailboxes mailboxes))
+    (E.editorText ComposeTo (Just 1) "")
+    (E.editorText ComposeSubject (Just 1) "")
+    T.empty
+    (L.list ComposeListOfAttachments mempty 1)
+    initialDraftConfirmDialog
 
 -- | Set the compose state from an existing mail. This is typically
 -- used for re-editing draft mails.
@@ -1349,7 +1347,6 @@ newComposeFromMail charsets m =
         view vector $ toMIMEMessage charsets <$> toListOf (_Just . entities) m
       orEmpty = view (non "")
    in Compose
-        B.empty
         (E.editorText ComposeFrom (Just 1) (orEmpty from))
         (E.editorText ComposeTo (Just 1) (orEmpty to'))
         (E.editorText ComposeSubject (Just 1) (orEmpty subject))


### PR DESCRIPTION
This field is a left over from the previous mail parser which we've used
until purebred-email was incorporated. For whatever reason we never
removed this field until now.