### PR TITLE
Piped output (Autoview)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,21 @@ matrix:
     - compiler: "ghc-8.6.3"
       language: c
       env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"
       language: c
       env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
     - compiler: "ghc-head"
       language: c
       env: NOTMUCHVER=0.28 GHCHEAD=true
-      addons: {apt: {packages: [tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
     - compiler: "ghc863 (default)"
       language: nix
       before_install:
       install:
       script:
+       - nix-env --install elinks
        - nix-build
        - nix-shell --command 'PATH=$PATH:result/bin cabal test --show-details=streaming uat'
     - compiler: "hlint"

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -70,7 +70,7 @@ renderSendMail ::
   -> IO (Either Error ())
 renderSendMail sendmail m = do
   -- -t which extracts recipients from the mail
-  result <- runExceptT $ tryReadProcess config
+  result <- runExceptT $ tryReadProcessStderr config
   pure $ case result of
     Left e -> Left $ SendMailError (show e)
     Right (ExitFailure _, stderr) -> Left $ SendMailError (untaint decode stderr)
@@ -105,6 +105,7 @@ solarizedDark =
         , (textMatchHighlightAttr, V.white `on` V.green)
         , (currentTextMatchHighlightAttr, V.green `on` V.white)
         , (defaultAttr, V.defAttr)
+        , (mailbodySourceAttr, fg V.blue)
         ]
 
 -- * Attributes
@@ -177,11 +178,19 @@ helpTitleAttr = helpAttr <> "title"
 helpKeybindingAttr :: A.AttrName
 helpKeybindingAttr = helpAttr <> "keybinding"
 
+
 textMatchHighlightAttr :: A.AttrName
 textMatchHighlightAttr = "match"
 
 currentTextMatchHighlightAttr :: A.AttrName
 currentTextMatchHighlightAttr = textMatchHighlightAttr <> "current"
+
+mailbodyAttr :: A.AttrName
+mailbodyAttr = "mailbody"
+
+mailbodySourceAttr :: A.AttrName
+mailbodySourceAttr = mailbodyAttr <> "source"
+
 
 -- * Purebred's Configuration
 -- The default configuration used in Purebred.
@@ -213,9 +222,9 @@ defaultConfig =
       , _mvFindWordEditorKeybindings = findWordEditorKeybindings
       , _mvMailcap =
           [ ( matchContentType "text" (Just "html")
-            , MailcapHandler (Shell (fromList "elinks -force-html")) False)
+            , MailcapHandler (Shell (fromList "elinks -force-html")) True False)
           , ( const True
-            , MailcapHandler (Process (fromList "xdg-open") []) True)
+            , MailcapHandler (Process (fromList "xdg-open") []) False True)
           ]
       }
     , _confIndexView = IndexViewSettings

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -222,9 +222,9 @@ defaultConfig =
       , _mvFindWordEditorKeybindings = findWordEditorKeybindings
       , _mvMailcap =
           [ ( matchContentType "text" (Just "html")
-            , MailcapHandler (Shell (fromList "elinks -force-html")) True False)
+            , MailcapHandler (Shell (fromList "elinks -force-html")) CopiousOutput DiscardTempfile)
           , ( const True
-            , MailcapHandler (Process (fromList "xdg-open") []) False True)
+            , MailcapHandler (Process (fromList "xdg-open") []) IgnoreOutput KeepTempfile)
           ]
       }
     , _confIndexView = IndexViewSettings

--- a/src/Purebred/Parsing/Text.hs
+++ b/src/Purebred/Parsing/Text.hs
@@ -44,12 +44,13 @@ offset = AT.Parser $ \t pos more _lose suc -> suc t pos more (AT.fromPos pos)
 
 parseMailbody ::
      Int -- ^ text width
+  -> Source
   -> T.Text
   -> MailBody
-parseMailbody tw =
+parseMailbody tw s =
   either
-    (\e -> MailBody [Paragraph [Line [] 0 (T.pack e)]])
-    (MailBody . setLineNumbers) . parseOnly (paragraphs tw <* niceEndOfInput)
+    (\e -> MailBody mempty [Paragraph [Line [] 0 (T.pack e)]])
+    (MailBody s . setLineNumbers) . parseOnly (paragraphs tw <* niceEndOfInput)
 
 endOfParagraph :: Parser ()
 endOfParagraph = endOfLine *> endOfLine

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -142,16 +142,14 @@ runEntityCommand cmd =
 
 tmpfileResource ::
      (MonadIO m, MonadError Error m)
-  => Bool -- ^ removeFile upon cleanup?
+  => TempfileOnExit
   -> ResourceSpec m FilePath
-tmpfileResource keepTempfile =
-  let cleanUp =
-        if keepTempfile
-          then mempty
-          else removeFile
+tmpfileResource tmpOnExit =
+  let cleanUp KeepTempfile = mempty
+      cleanUp _ = removeFile
    in ResourceSpec
         (tryIO $ emptySystemTempFile "purebred")
-        (tryIO . cleanUp)
+        (tryIO . cleanUp tmpOnExit)
         (\fp -> tryIO . B.writeFile fp)
 
 emptyResource :: (MonadIO m, MonadError Error m) => ResourceSpec m ()

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -531,7 +531,7 @@ mvMailcap :: Lens' MailViewSettings [(ContentType -> Bool, MailcapHandler)]
 mvMailcap = lens _mvMailcap (\s x -> s { _mvMailcap = x })
 
 hasCopiousoutput :: Traversal' [(ContentType -> Bool, MailcapHandler)] (ContentType -> Bool, MailcapHandler)
-hasCopiousoutput = traversed . filtered (view (_2 . mhCopiousoutput))
+hasCopiousoutput = traversed . filtered (view (_2 . mhCopiousoutput . to isCopiousOutput))
 
 data ViewName
     = Threads
@@ -802,11 +802,25 @@ mpCommand :: Lens' MakeProcess (NonEmpty Char)
 mpCommand f (Shell x) = fmap (\x' -> Shell x') (f x)
 mpCommand f (Process x args) = fmap (\x' -> Process x' args) (f x)
 
+data CopiousOutput
+  = CopiousOutput
+  | IgnoreOutput
+  deriving (Generic, NFData)
+
+isCopiousOutput :: CopiousOutput -> Bool
+isCopiousOutput CopiousOutput = True
+isCopiousOutput _ = False
+
+data TempfileOnExit
+  = KeepTempfile
+  | DiscardTempfile
+  deriving (Generic, NFData)
+
 data MailcapHandler = MailcapHandler
   { _mhMakeProcess :: MakeProcess
-  , _mhCopiousoutput :: Bool
+  , _mhCopiousoutput :: CopiousOutput
   -- ^ output should be paged or made scrollable
-  , _mhKeepTemp :: Bool
+  , _mhKeepTemp :: TempfileOnExit
   -- ^ Keep the temporary file if application spawns child and parent
   -- exits immediately (e.g. Firefox)
   } deriving (Generic, NFData)
@@ -814,10 +828,10 @@ data MailcapHandler = MailcapHandler
 mhMakeProcess :: Lens' MailcapHandler MakeProcess
 mhMakeProcess = lens _mhMakeProcess (\h x -> h { _mhMakeProcess = x })
 
-mhCopiousoutput :: Lens' MailcapHandler Bool
+mhCopiousoutput :: Lens' MailcapHandler CopiousOutput
 mhCopiousoutput = lens _mhCopiousoutput (\h x -> h { _mhCopiousoutput = x })
 
-mhKeepTemp :: Lens' MailcapHandler Bool
+mhKeepTemp :: Lens' MailcapHandler TempfileOnExit
 mhKeepTemp = lens _mhKeepTemp (\h x -> h { _mhKeepTemp = x })
 
 

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -743,7 +743,9 @@ openWithCommand =
           let cmd = view (asMailView . mvOpenCommand . E.editContentsL . to (T.unpack . currentLine)) s
            in case cmd of
             [] -> Brick.continue $ setError (GenericError "Empty command") s
-            (x:xs) -> Brick.suspendAndResume $ liftIO $ openCommand' s (MailcapHandler (Process (x :| xs) []) False False)
+            (x:xs) -> Brick.suspendAndResume
+                      $ liftIO
+                      $ openCommand' s (MailcapHandler (Process (x :| xs) []) IgnoreOutput DiscardTempfile)
     }
 
 -- | Pipe the selected entity to the command given from the editor widget.

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -428,10 +428,10 @@ instance Resetable 'ViewMail 'ScrollingMailViewFindWordEditor where
   reset _ _ = pure . over (asMailView . mvFindWordEditor . E.editContentsL) clearZipper
               . set (asViews . vsViews . at ViewMail . _Just . vLayers . ix 0
                     . ix ScrollingMailViewFindWordEditor . veState) Hidden
-              . set (asMailView . mvScrollSteps) (Brick.focusRing [])
+              . resetMatchingWords
 
 instance Resetable 'ViewMail 'ScrollingMailView where
-  reset _ _ = pure . set (asMailView . mvScrollSteps) (Brick.focusRing [])
+  reset _ _ = pure . resetMatchingWords
 
 -- | Reset the composition state for a new mail
 --
@@ -851,9 +851,7 @@ removeHighlights :: Action 'ViewMail 'ScrollingMailView AppState
 removeHighlights =
   Action
     { _aDescription = ["remove search results highlights"]
-    , _aAction = pure . over (asMailView . mvBody) removeMatchingWords
-                 . over (asMailView . mvFindWordEditor . E.editContentsL) clearZipper
-                 . set (asMailView . mvScrollSteps) (Brick.focusRing [])
+    , _aAction = pure . resetMatchingWords
     }
 
 displayMail :: Action 'ViewMail 'ScrollingMailView AppState
@@ -1510,3 +1508,9 @@ keepDraft s maildir =
     fp <- createDraftFilePath maildir
     Notmuch.indexMail bs maildir fp draftTag
     pure s
+
+resetMatchingWords :: AppState -> AppState
+resetMatchingWords =
+  over (asMailView . mvBody) removeMatchingWords
+  . over (asMailView . mvFindWordEditor . E.editContentsL) clearZipper
+  . set (asMailView . mvScrollSteps) (Brick.focusRing [])

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -160,7 +160,7 @@ initialState conf =
             0
     mv = MailView
            Nothing
-           (MailBody [])
+           (MailBody mempty [])
            Filtered
            (L.list MailListOfAttachments mempty 1)
            (E.editorText MailAttachmentOpenWithEditor Nothing "")

--- a/src/UI/Mail/Main.hs
+++ b/src/UI/Mail/Main.hs
@@ -26,8 +26,8 @@ import qualified Brick.AttrMap as A
 import Brick.Types (Padding(..), ViewportType(..), Widget)
 import qualified Brick.Widgets.List as L
 import Brick.Widgets.Core
-  (padTop, txt, txtWrap, viewport, (<+>), (<=>), withAttr, vBox,
-   hBox, padLeftRight, padRight)
+  (padTop, padBottom, txt, txtWrap, viewport, (<+>), (<=>), withAttr,
+   vBox, hBox, padLeftRight, padRight)
 import Brick.Markup (markup, (@?))
 import Brick.Focus (focusGetCurrent)
 import Data.Text.Markup (Markup, markupSet)
@@ -45,7 +45,7 @@ import UI.Views (focusedViewWidget)
 import Config.Main
   (headerKeyAttr, headerValueAttr, mailViewAttr, listSelectedAttr,
    listAttr, textMatchHighlightAttr, currentTextMatchHighlightAttr,
-   defaultAttr)
+   defaultAttr, mailbodySourceAttr)
 import Storage.ParsedMail (takeFileName)
 
 -- | Instead of using the entire rendering area to show the email, we still show
@@ -113,7 +113,14 @@ renderPart charsets selected hds =
 --
 renderMarkup ::  Maybe ScrollStep -> MailBody -> Widget Name
 renderMarkup st b =
-  vBox $ toListOf (mbParagraph . pLine . to (markup . buildWordMarkup st)) b
+  let source =
+        withAttr mailbodySourceAttr $
+        padBottom (Pad 1) $ txt ("Showing output from: " <> view mbSource b)
+      bodyMarkup = toListOf (mbParagraph . to (padBottom (Pad 1) . buildParagraph st)) b
+   in source <=> vBox bodyMarkup
+
+buildParagraph :: Maybe ScrollStep -> Paragraph -> Widget Name
+buildParagraph st = vBox . toListOf (pLine . to (markup . buildWordMarkup st))
 
 -- | Render the line by inserting markup if we have a match *and* a
 -- scroll step matching

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -30,7 +30,7 @@ import qualified Brick.Widgets.List  as L
 import qualified Brick.Widgets.Edit  as E
 import Control.Monad.Except (runExceptT)
 import Control.Monad (void)
-import Control.Lens (view, views, to, has, _Just, preview, non)
+import Control.Lens (view, views, to, _Just, preview, non)
 import Control.Concurrent (forkIO, threadDelay)
 import Data.Text (Text)
 import Data.Text.Zipper (cursorPosition)
@@ -118,7 +118,7 @@ renderMatches s =
   let showCount = show $ matchCount $ view (asMailView . mvBody) s
       currentItem = view (non "0")
         $ preview (asMailView . mvScrollSteps . to focusGetCurrent . _Just . stNumber . to show) s
-   in if has (asMailView . mvScrollSteps) s
+   in if view (asMailView . mvBody . to matchCount) s > 0
         then str (currentItem <> " of " <> showCount <> " matches")
         else emptyWidget
 

--- a/test/TestMail.hs
+++ b/test/TestMail.hs
@@ -85,8 +85,8 @@ testFindsMatchingWords :: TestTree
 testFindsMatchingWords = testCase "finds matching words" $ expected @=? actual
   where
     expected =
-      MailBody
+      MailBody mempty
         [Paragraph [Line [Match 9 3 1] 1 "Purebred finds matching words"]]
     actual =
       findMatchingWords "fin" $
-      MailBody [Paragraph [Line [] 1 "Purebred finds matching words"]]
+      MailBody mempty [Paragraph [Line [] 1 "Purebred finds matching words"]]

--- a/test/TestTextParser.hs
+++ b/test/TestTextParser.hs
@@ -30,10 +30,11 @@ textparserTests = testParsesParagraphs
 
 testParsesParagraphs :: TestTree
 testParsesParagraphs =
-  testCase "parses paragraphs" $ expected @=? parseMailbody 72 paragraph
+  testCase "parses paragraphs" $ expected @=? parseMailbody 72 mempty paragraph
   where
     expected =
       MailBody
+        mempty
         [ Paragraph
             [ Line [] 0 "This is a"
             , Line [] 1 "Paragraph"

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -107,6 +107,7 @@ main = defaultMain $ testTmux pre post tests
       , testConfirmDialogResets
       , testCursorPositionedEndOnReply
       , testSubstringSearchInMailBody
+      , testSubstringMatchesAreCleared
       , testAutoview
       ]
 
@@ -123,6 +124,35 @@ testAutoview = purebredTmuxSession "automatically copies output for display" $
 
     step "use as reply"
     sendKeys "r" (Regex ">\\s+This is a HTML mail for purebred")
+
+
+testSubstringMatchesAreCleared :: PurebredTestCase
+testSubstringMatchesAreCleared = purebredTmuxSession "substring match indicator only shown on mail" $
+  \step -> do
+    startApplication
+
+    step "No match indicator is shown"
+    snapshot
+    assertRegexS "New:\\s[0-9]\\]\\s+Threads"
+
+    step "search for Lorem mail"
+    sendKeys ":" (Regex ("Query: " <> buildAnsiRegex [] ["37"] [] <> "tag:inbox"))
+    sendKeys "C-u" (Regex ("Query: " <> buildAnsiRegex [] ["37"] [] <> "\\s+"))
+
+    step "enter free text search"
+    sendLine "Lorem ipsum" (Substring "Item 1 of 1")
+
+    step "show mail contents"
+    sendKeys "Enter" (Substring "Lorem ipsum dolor sit amet, consectetur")
+
+    step "show substring search editor"
+    sendKeys "/" (Substring "Search for")
+
+    step "enter needle and show results"
+    sendKeys "et\r" (Substring "1 of 20 matches")
+
+    step "go back to threads"
+    sendKeys "Escape" (Regex "New:\\s[0-9]\\]\\s+Threads")
 
 
 testSubstringSearchInMailBody :: PurebredTestCase

--- a/test/data/Maildir/new/1234567.RHTMLMail.url
+++ b/test/data/Maildir/new/1234567.RHTMLMail.url
@@ -1,0 +1,20 @@
+Return-Path: <frase@host.example>
+X-Original-To: rjoost
+Delivered-To: rjoost@host.example
+Received: by host.example (Postfix, from userid 20845)
+	id 55C4580B8F; Thu, 07 Nov 2016 13:50:04 +1000 (AEST)
+From: <frase@host.example>
+To: <roman@host.example>
+Subject: HTML mail
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+Message-Id: <20191107035004.55C4580B8F@host.example>
+Date: Thu, 07 Nov 2016 13:50:04 +1000 (AEST)
+
+<div dir=3D"ltr">This is a HTML mail for purebred in which the HTML part co=
+ntains more crazy content than the text plain part and w &quot;linebreaks&q=
+uot; basically blah foo bar :<div><br></div><div><a href=3D"https://github.=
+purebred.com/purebred-mua/this/link/doesn/exist/really/bla/f" target=3D"_bl=
+ank">https://thislinkdoesnotexist/foo/bar/baz/just/to/fill/the/line/really/=
+XV3IJ</a> and this is were it ends.=C2=A0</div>


### PR DESCRIPTION
This adds functionality to pipe output through an external program and
capture it's output for display. This allows searching and/or viewing
mails with non-text entities like... HTML.

While it has "Autoview" in the name, this patch isn't delivering what
mutt or any other mail provides. Namely showing the content of all
attachments if they can be piped through an external program. For this,
there are several outstanding things to be implemented like:

a) Extend the AST to actually represent attachments
b) Try to traverse these attachments in order to produce text output
c) Extend the search functionality, most specifically the `ScrollSteps`
   to allow searching through the AST body including the output of the
   attachments.

The entire reason why this is put up for a pull request is the fact that
it already provides some relieve to show non-text mails, especially in
an environment using heavily HTML mails for example.