### PR TITLE
Sent mails should be copied to send folder

### DIFF
--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -69,7 +69,7 @@ import qualified Notmuch
 import Error
 import Types
 import Purebred.LazyVector
-import Purebred.System.Process (readProcess, proc, createDraftFilePath)
+import Purebred.System.Process (readProcess, proc)
 import Purebred.System (tryIO)
 import Purebred.Types.IFC (sanitiseText, untaint)
 
@@ -298,11 +298,11 @@ indexFilePath dbpath fp tgs =
 indexMail ::
      (MonadError Error m, MonadIO m)
   => B.ByteString -- ^ rendered mail
-  -> FilePath -- ^ maildir under which we store the mail
+  -> FilePath -- ^ path to the maildir
+  -> FilePath -- ^ path to file under which the mail is stored
   -> Tag -- ^ tag to attach the mail
   -> m ()
-indexMail bs maildir tag = do
-    fp <- createDraftFilePath maildir
+indexMail bs maildir fp tag = do
     tryIO $ B.writeFile fp bs
     indexFilePath maildir fp [tag]
 

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1273,7 +1273,8 @@ sendMail s =
       send = do
         (bs, randomg) <- over _1 (renderMessage . sanitizeMail charsets) <$> buildMail s
         s' <- liftIO $ trySendAndCatch randomg bs s
-        Notmuch.indexMail bs maildir sentTag
+        sentFP <- createSentFilePath maildir
+        Notmuch.indexMail bs maildir sentFP sentTag
         pure s'
    in either (`setError` s) id <$> runExceptT send
 
@@ -1498,5 +1499,6 @@ keepDraft s maildir =
   let draftTag = view (asConfig . confNotmuch . nmDraftTag) s
   in do
     bs <- renderMessage . fst <$> buildMail s
-    Notmuch.indexMail bs maildir draftTag
+    fp <- createDraftFilePath maildir
+    Notmuch.indexMail bs maildir fp draftTag
     pure s


### PR DESCRIPTION
This patch fixes a small bug which left sent mails in the "Drafts"
folder. Instead they're written to the "Sent" folder if sending mail was
successful.

Fixes https://github.com/purebred-mua/purebred/issues/349