### PR TITLE
Add generic build instructions (Cabal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ and `nix-env` to install the application:
 $ nix-env --file default.nix --install
 ```
 
+### Arch Linux
+
+We officially don't support Arch Linux, but will support any packaging
+efforts.  Please see
+[#352](https://github.com/purebred-mua/purebred/issues/352#issuecomment-567873060)
+for links to help building Purebred.
+
 ### Cabal
 
 Install development packages for system library dependencies

--- a/README.md
+++ b/README.md
@@ -69,3 +69,33 @@ and `nix-env` to install the application:
 ```
 $ nix-env --file default.nix --install
 ```
+
+### Cabal
+
+Install development packages for system library dependencies
+first. They are needed to compile the Haskell notmuch
+bindings. Note that package names may vary between different distributions.
+
+* libtalloc-devel
+* notmuch-devel
+
+Make sure you have one of our supported GHC versions and
+Cabal-install >= 2.2 installed. From a cloned checkout you then go:
+
+```
+# Updates the package list needed for cabal to download dependencies
+$ cabal new-update
+
+# Builds all dependencies, the purebred library and executable and
+# installs it to ~/.cabal/bin
+$ cabal new-build
+Resolving dependencies...
+Build profile: ...
+In order, the following will be built (use -v for more details):
+ - ...
+ - ...
+$ cabal new-install exe:purebred
+
+# start purebred
+$ ~/.cabal/bin/purebred
+```


### PR DESCRIPTION
This patch adds build instructions to use with cabal.

This is mainly targeting users who don't have access to nix or use a
Fedora distro. Cabal is somewhat universal to Haskell so theoretically
using Cabal should work everywhere. However, these instructions don't
give any help in regards problems users could face like:

* missing system dependencies
* GHC problems
* version mismatches
* etc

Fixes https://github.com/purebred-mua/purebred/issues/352