### PR TITLE
Pin channel to stable to avoid random breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       script:
        - nix-channel --add https://nixos.org/channels/nixos-19.09 nixpkgs
        - nix-channel --update
-       - nix-env --install elinks
+       - nix-env --install --attr nixpkgs.elinks
        - nix-build
        - nix-shell --command 'PATH=$PATH:result/bin cabal test --show-details=streaming uat'
     - compiler: "hlint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ matrix:
       before_install:
       install:
       script:
+       - nix-channel --add https://nixos.org/channels/nixos-19.09 nixpkgs
+       - nix-channel --update
        - nix-env --install elinks
        - nix-build
        - nix-shell --command 'PATH=$PATH:result/bin cabal test --show-details=streaming uat'


### PR DESCRIPTION
This pins the channel to the latest NixOS stable to avoid random
breakage introduced in the unstable channel.

The current unstable channel contains an elinks package which causes a
build failure:

      $ nix-env --install elinks

      error: attribute 'fromTOML' missing, at /nix/store/g9zk11ri9yc9anbxkfxhh5msc611j9ww-nixpkgs-20.03pre207249.7e8454fb856/nixpkgs/pkgs/development/tools/poetry2nix/poetry2nix/lib.nix:27:20

      (use '--show-trace' to show detailed location information)

      The command "nix-env --install elinks" exited with 1.

Fixes https://github.com/purebred-mua/purebred/issues/354