### PR TITLE
Allows to save attachments

### DIFF
--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -47,7 +47,7 @@ import UI.Index.Keybindings
 import UI.Mail.Keybindings
        (displayMailKeybindings, mailViewManageMailTagsKeybindings,
         mailAttachmentsKeybindings, openWithKeybindings,
-        pipeToKeybindings, findWordEditorKeybindings)
+        pipeToKeybindings, findWordEditorKeybindings, saveToDiskKeybindings)
 import UI.Help.Keybindings (helpKeybindings)
 import UI.ComposeEditor.Keybindings
        (listOfAttachmentsKeybindings, composeFromKeybindings,
@@ -220,6 +220,7 @@ defaultConfig =
       , _mvOpenWithKeybindings = openWithKeybindings
       , _mvPipeToKeybindings = pipeToKeybindings
       , _mvFindWordEditorKeybindings = findWordEditorKeybindings
+      , _mvSaveToDiskKeybindings = saveToDiskKeybindings
       , _mvMailcap =
           [ ( matchContentType "text" (Just "html")
             , MailcapHandler (Shell (fromList "elinks -force-html")) CopiousOutput DiscardTempfile)

--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -40,6 +40,7 @@ module Storage.ParsedMail (
   , chooseEntity
   , entityToText
   , entityToBytes
+  , writeEntityToPath
   ) where
 
 import Control.Applicative ((<|>))
@@ -61,6 +62,7 @@ import Data.MIME
 import Error
 import Storage.Notmuch (mailFilepath)
 import Types
+import Purebred.System (tryIO)
 import Purebred.Types.IFC (sanitiseText)
 import Purebred.Parsing.Text (parseMailbody)
 import Purebred.System.Process
@@ -263,3 +265,11 @@ toMIMEMessage charsets m@(Message _ bs) =
 --
 takeFileName :: T.Text -> T.Text
 takeFileName = T.pack . FP.takeFileName . T.unpack
+
+-- | Low-level function to save the 'WireEntity' to disk.
+--
+writeEntityToPath ::
+     (MonadError Error m, MonadIO m) => FilePath -> WireEntity -> m FilePath
+writeEntityToPath filepath entity = do
+  entityToBytes entity >>= tryIO . B.writeFile filepath
+  pure filepath

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -87,6 +87,7 @@ data Name =
     | MailAttachmentPipeToEditor
     | StatusBar
     | ConfirmDialog
+    | SaveToDiskPathEditor
     deriving (Eq,Show,Ord)
 
 -- | A brick list, with a field that optionally contains its length.
@@ -239,6 +240,7 @@ data MailView = MailView
     , _mvBody:: MailBody
     , _mvHeadersState :: HeadersState
     , _mvAttachments :: L.List Name WireEntity
+    , _mvSaveToDiskPath :: E.Editor T.Text Name
     , _mvOpenCommand:: E.Editor T.Text Name
     , _mvPipeCommand :: E.Editor T.Text Name
     , _mvFindWordEditor :: E.Editor T.Text Name
@@ -253,6 +255,9 @@ mvHeadersState = lens _mvHeadersState (\mv hs -> mv { _mvHeadersState = hs })
 
 mvAttachments :: Lens' MailView (L.List Name WireEntity)
 mvAttachments = lens _mvAttachments (\mv hs -> mv { _mvAttachments = hs })
+
+mvSaveToDiskPath :: Lens' MailView (E.Editor T.Text Name)
+mvSaveToDiskPath = lens _mvSaveToDiskPath (\mv hs -> mv { _mvSaveToDiskPath = hs })
 
 mvOpenCommand :: Lens' MailView (E.Editor T.Text Name)
 mvOpenCommand = lens _mvOpenCommand (\mv hs -> mv { _mvOpenCommand = hs })
@@ -494,6 +499,7 @@ data MailViewSettings = MailViewSettings
     , _mvPipeToKeybindings :: [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
     , _mvFindWordEditorKeybindings :: [Keybinding 'ViewMail 'ScrollingMailViewFindWordEditor]
     , _mvMailcap :: [(ContentType -> Bool, MailcapHandler)]
+    , _mvSaveToDiskKeybindings :: [Keybinding 'ViewMail 'SaveToDiskPathEditor]
     }
     deriving (Generic, NFData)
 
@@ -529,6 +535,9 @@ mvFindWordEditorKeybindings = lens _mvFindWordEditorKeybindings (\s x -> s { _mv
 
 mvMailcap :: Lens' MailViewSettings [(ContentType -> Bool, MailcapHandler)]
 mvMailcap = lens _mvMailcap (\s x -> s { _mvMailcap = x })
+
+mvSaveToDiskKeybindings :: Lens' MailViewSettings [Keybinding 'ViewMail 'SaveToDiskPathEditor]
+mvSaveToDiskKeybindings = lens _mvSaveToDiskKeybindings (\s x -> s { _mvSaveToDiskKeybindings = x })
 
 hasCopiousoutput :: Traversal' [(ContentType -> Bool, MailcapHandler)] (ContentType -> Bool, MailcapHandler)
 hasCopiousoutput = traversed . filtered (view (_2 . mhCopiousoutput . to isCopiousOutput))

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -84,6 +84,8 @@ renderWidget s _ ComposeListOfAttachments = attachmentsEditor s
 renderWidget s _ MailListOfAttachments = renderAttachmentsList s
 renderWidget s _ ListOfFiles = renderFileBrowser s
 renderWidget s _ ManageFileBrowserSearchPath = renderFileBrowserSearchPathEditor s
+renderWidget s _ SaveToDiskPathEditor =
+  renderEditorWithLabel (Proxy :: Proxy 'SaveToDiskPathEditor) "Save to file:" s
 renderWidget s _ SearchThreadsEditor =
   renderEditorWithLabel (Proxy :: Proxy 'SearchThreadsEditor) "Query:" s
 renderWidget s _ ManageMailTagsEditor =
@@ -120,6 +122,7 @@ handleViewEvent = f where
   f ViewMail MailAttachmentOpenWithEditor = dispatch eventHandlerMailAttachmentOpenWithEditor
   f ViewMail MailAttachmentPipeToEditor = dispatch eventHandlerMailAttachmentPipeToEditor
   f ViewMail ScrollingMailViewFindWordEditor = dispatch eventHandlerScrollingMailViewFind
+  f ViewMail SaveToDiskPathEditor = dispatch eventHandlerSaveToDiskEditor
   f ViewMail _ = dispatch eventHandlerScrollingMailView
   f _ ScrollingHelpView = dispatch eventHandlerScrollingHelpView
   f _ ListOfFiles = dispatch eventHandlerComposeFileBrowser
@@ -163,6 +166,7 @@ initialState conf =
            (MailBody mempty [])
            Filtered
            (L.list MailListOfAttachments mempty 1)
+           (E.editorText SaveToDiskPathEditor Nothing "")
            (E.editorText MailAttachmentOpenWithEditor Nothing "")
            (E.editorText MailAttachmentPipeToEditor Nothing "")
            (E.editorText ScrollingMailViewFindWordEditor Nothing "")

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -42,6 +42,7 @@ module UI.Keybindings (
   , eventHandlerScrollingHelpView
   , eventHandlerComposeFileBrowser
   , eventHandlerScrollingMailViewFind
+  , eventHandlerSaveToDiskEditor
   ) where
 
 import Control.Monad ((<=<))
@@ -161,6 +162,11 @@ eventHandlerMailAttachmentPipeToEditor :: EventHandler 'ViewMail 'MailAttachment
 eventHandlerMailAttachmentPipeToEditor = EventHandler
   (asConfig . confMailView . mvPipeToKeybindings)
   (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailView . mvPipeCommand) E.handleEditorEvent)
+
+eventHandlerSaveToDiskEditor :: EventHandler 'ViewMail 'SaveToDiskPathEditor
+eventHandlerSaveToDiskEditor = EventHandler
+  (asConfig . confMailView . mvSaveToDiskKeybindings)
+  (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailView . mvSaveToDiskPath) E.handleEditorEvent)
 
 eventHandlerManageThreadTagsEditor :: EventHandler 'Threads 'ManageThreadTagsEditor
 eventHandlerManageThreadTagsEditor =

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -72,6 +72,7 @@ mailAttachmentsKeybindings =
     , Keybinding (V.EvKey V.KEnter []) openAttachment
     , Keybinding (V.EvKey (V.KChar 'o') []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentOpenWithEditor AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar '|') []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentPipeToEditor AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 's') []) (noop `chain'` (focus :: Action 'ViewMail 'SaveToDiskPathEditor AppState) `chain` continue)
     ]
 
 openWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
@@ -96,3 +97,10 @@ mailViewManageMailTagsKeybindings =
     , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
     ]
+
+saveToDiskKeybindings :: [Keybinding 'ViewMail 'SaveToDiskPathEditor]
+saveToDiskKeybindings =
+  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
+  , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` saveAttachmentToPath `chain` continue)
+  ]

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -80,6 +80,7 @@ statusbar s =
                 MailAttachmentOpenWithEditor -> renderStatusbar (view (asMailView . mvOpenCommand) s) s
                 MailAttachmentPipeToEditor -> renderStatusbar (view (asMailView . mvPipeCommand) s) s
                 ScrollingMailViewFindWordEditor -> renderStatusbar (view (asMailView . mvFindWordEditor) s) s
+                SaveToDiskPathEditor -> renderStatusbar (view (asMailView . mvSaveToDiskPath) s) s
                 ListOfThreads -> renderStatusbar (view (asMailIndex . miThreads) s) s
                 ListOfMails -> renderStatusbar (view (asMailIndex . miMails) s) s
                 ScrollingMailView -> renderStatusbar (view (asMailIndex . miMails) s) s

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -115,6 +115,7 @@ mailView =
               , Tile Hidden MailAttachmentOpenWithEditor
               , Tile Hidden MailAttachmentPipeToEditor
               , Tile Hidden ScrollingMailViewFindWordEditor
+              , Tile Hidden SaveToDiskPathEditor
               ]
           ]
     , _vFocus = ListOfMails


### PR DESCRIPTION
This implements the ability to save mail attachments to disk. The editor
isn't very fancy. This is the bare minimum to be able to save any type
of attachment. Errors are simply propagated.

Fixes: https://github.com/purebred-mua/purebred/issues/313