### PR TITLE
Fix replying to an individual

### DIFF
--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -233,16 +233,17 @@ quoteText = ("> " <>)
 -- b) the text entity can be successfully decoded
 -- otherwise an empty plain text body is created
 toQuotedMail
-  :: MailBody
+  :: [Mailbox]
+  -> MailBody
   -> MIMEMessage
   -> MIMEMessage
-toQuotedMail mbody msg =
+toQuotedMail mailboxes mbody msg =
     let contents = T.unlines $ toListOf (mbParagraph . pLine . lText . to quoteText) mbody
         replyToAddress m =
             firstOf (headers . header "reply-to") m
             <|> firstOf (headers . header "from") m
     in createTextPlainMessage contents
-                 & set (headers . at "from") (view (headers . at "to") msg)
+                 & set (headers . at "from") (Just $ renderMailboxes mailboxes)
                  . set (headers . at "to") (replyToAddress msg)
                  . set (headers . at "references") (view (headers . replyHeaderReferences) msg)
                  . set (headers . at "subject") (("Re: " <>) <$> view (headers . at "subject") msg)

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1259,7 +1259,8 @@ replyToMail s =
       over (asViews . vsFocusedView) (Brick.focusSetCurrent Threads) .
       setError (GenericError "No mail selected for replying")
     Just pmail ->
-      let quoted = toQuotedMail mbody pmail
+      let mailboxes = view (asConfig . confComposeView . cvIdentities) s
+          quoted = toQuotedMail mailboxes mbody pmail
           mbody = view (asMailView . mvBody) s
           charsets = view (asConfig . confCharsets) s
        in s &

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -218,15 +218,15 @@ testCursorPositionedEndOnReply = purebredTmuxSession "cursor positioned on EOL w
     sendKeys ": x\r" (Substring "Attachments")
 
     step "focus from field"
-    sendKeys "f" (Regex $ "From: " <> buildAnsiRegex [] ["37"] [] <> "<frase@host.example>")
+    sendKeys "f" (Regex $ "From: " <> buildAnsiRegex [] ["37"] [] <> "\"Joe Bloggs\" <joe@foo.test>")
     sendKeys ", fromuser@foo.test\r" (Substring $ "From: "
-                                      <> "<frase@host.example>, fromuser@foo.test")
+                                      <> "\"Joe Bloggs\" <joe@foo.test>, fromuser@foo.test")
 
     step "user can change to header"
-    sendKeys "t" (Regex $ "To: " <> buildAnsiRegex [] ["37"] [] <> "<roman@host.example>")
+    sendKeys "t" (Regex $ "To: " <> buildAnsiRegex [] ["37"] [] <> "<frase@host.example>")
 
     step "append an additional from email"
-    sendKeys ", touser@foo.test\r" (Substring "To: <roman@host.example>, touser@foo.test")
+    sendKeys ", touser@foo.test\r" (Substring "To: <frase@host.example>, touser@foo.test")
 
     step "change subject"
     sendKeys "s" (Regex $ "Subject: " <> buildAnsiRegex [] ["37"] [] <> ".*subject\\s+$")
@@ -595,8 +595,8 @@ testRepliesToMailSuccessfully = purebredTmuxSession "replies to mail successfull
     step "pick first mail"
     sendKeys "Enter" (Substring "This is a test mail for purebred") >>= put
 
-    assertSubstringS "From: <roman@host.example>"
-    assertSubstringS "To: <frase@host.example>"
+    assertSubstringS "From: <frase@host.example>"
+    assertSubstringS "To: <roman@host.example>"
     assertSubstringS ("Subject: " <> subject)
 
     step "start replying"
@@ -605,8 +605,8 @@ testRepliesToMailSuccessfully = purebredTmuxSession "replies to mail successfull
     step "exit vim"
     sendKeys ": x\r" (Substring "Attachments") >>= put
 
-    assertSubstringS "From: <frase@host.example>"
-    assertSubstringS "To: <roman@host.example>"
+    assertRegexS "From: \"Joe Bloggs\" <joe@foo.test>\\s+$"
+    assertSubstringS "To: <frase@host.example>"
     assertSubstringS ("Subject: Re: " <> subject)
 
     step "send mail"
@@ -616,8 +616,8 @@ testRepliesToMailSuccessfully = purebredTmuxSession "replies to mail successfull
     contents <- liftIO $ B.readFile fpath
     let decoded = chr . fromEnum <$> B.unpack contents
     assertSubstr ("Subject: Re: " <> subject) decoded
-    assertSubstr "From: frase@host.example" decoded
-    assertSubstr "To: roman@host.example" decoded
+    assertSubstr "From: \"Joe Bloggs\" <joe@foo.test>" decoded
+    assertSubstr "To: frase@host.example" decoded
     assertSubstr "> This is a test mail for purebred" decoded
 
 testFromAddressIsProperlyReset :: PurebredTestCase

--- a/test/data/Maildir/new/1502941827.R15455991756849358775.url
+++ b/test/data/Maildir/new/1502941827.R15455991756849358775.url
@@ -3,8 +3,8 @@ X-Original-To: rjoost
 Delivered-To: rjoost@host.example
 Received: by host.example (Postfix, from userid 20845)
 	id 55C4580B8F; Thu, 17 Aug 2017 13:50:04 +1000 (AEST)
-From: <roman@host.example>
-To: <frase@host.example>
+From: <frase@host.example>
+To: <roman@host.example>, <frase@host.example>, <joe@host.example>
 Subject: Testmail with whitespace in the
 	subject
 MIME-Version: 1.0


### PR DESCRIPTION
This fixes a wrong implementation of replying to individuals. The To:
and From: fields were swapped in the reply. But replying is taking the
From: field and use the configured identity as the author of the new
mail.

Fixes: https://github.com/purebred-mua/purebred/issues/358