### PR TITLE
implement debug log

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -83,6 +83,7 @@ library
                      , Purebred.Types.IFC
   autogen-modules:     Paths_purebred
   build-depends:       base >= 4.11 && < 5
+                     , stm >= 2.4
                      , deepseq >= 1.4.2
                      , dyre >= 0.8.12
                      , lens

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -354,6 +354,11 @@ fbSearchPathKeybindings = lens _fbSearchPathKeybindings (\cv x -> cv { _fbSearch
 fbHomePath :: Lens (FileBrowserSettings a) (FileBrowserSettings a') a a'
 fbHomePath = lens _fbHomePath (\s a -> s { _fbHomePath = a })
 
+data Delay
+  = Seconds Int
+  | Minutes Int
+  deriving (Generic, NFData)
+
 data Configuration extra a b c = Configuration
     { _confTheme :: AttrMap
     , _confNotmuch :: NotmuchSettings a
@@ -369,13 +374,10 @@ data Configuration extra a b c = Configuration
     }
     deriving (Generic, NFData)
 
-data Delay 
-  = Seconds Int 
-  | Minutes Int
-  deriving (Generic, NFData)
+type InternalConfigurationFields = (BChan PurebredEvent, String, T.Text -> IO ())
 
 type UserConfiguration = Configuration () (IO FilePath) (IO String) (IO FilePath)
-type InternalConfiguration = Configuration (BChan PurebredEvent, String) FilePath String FilePath
+type InternalConfiguration = Configuration InternalConfigurationFields FilePath String FilePath
 
 type ConfigurationLens v = forall z a b c. Lens' (Configuration z a b c) v
 
@@ -417,6 +419,9 @@ confBChan = confExtra . _1
 
 confBoundary :: Lens' InternalConfiguration String
 confBoundary = confExtra . _2
+
+confLogSink :: Lens' InternalConfiguration (T.Text -> IO ())
+confLogSink = confExtra . _3
 
 
 data ComposeViewSettings = ComposeViewSettings


### PR DESCRIPTION
```
0a2e7b3 (Fraser Tweedale, 4 minutes ago)
   log mode and focus changes

   This is what the log system was born to do.  Reveal the deep mysteries of
   how purebred's UI works at runtime, because I can't understand the code :)

d4fc29a (Fraser Tweedale, 9 minutes ago)
   add --debug=FILE option

   Add an option to write debug output to a file.  No logging is actually done
   (yet).  No timestamps, levels or other formatting
   (yet).  This was just hacked up in a jiffy and if we want something more
   sophisticated, we should evaluate established solutions e.g. co-log.

   The log is stored as a sink action (Text -> IO ()) in the AppState. If no
   log file is specified via the --debug=FILE option, this is a no-op. 
   Otherwise we create a TQueue, the sink puts messages in the queue, and we
   spawn a thread to read from the queue and write the messages to a file.  We
   don't have any special handling of IO exceptions and in fact, I don't even
   know what happens if e.g. the file isn't writable, it's a normal file,
   disappears during use, etc. I guess I'll cross those bridges later.
```