### PR TITLE
refactor Actions to use MonadState

### DIFF
--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -330,7 +330,7 @@ unhide = setViewState Visible
 
 setViewState :: (MonadState AppState m) => ViewState -> ViewName -> Int -> Name -> m ()
 setViewState v n i m =
-  assign (asViews . vsViews . at n . _Just . vLayers . ix i . ix m . veState) v
+  assign (asViews . vsViews . ix n . vLayers . ix i . ix m . veState) v
 
 instance Completable 'ComposeTo where
   complete _ = do
@@ -523,33 +523,33 @@ instance Focusable 'Threads 'ListOfThreads where
 instance Focusable 'ViewMail 'ManageMailTagsEditor where
   switchFocus _ _ = do
     unhide ViewMail 0 ManageMailTagsEditor
-    assign (asViews . vsViews . at ViewMail . _Just . vFocus) ManageMailTagsEditor
+    assign (asViews . vsViews . ix ViewMail . vFocus) ManageMailTagsEditor
 
 instance Focusable 'ViewMail 'ScrollingMailView where
-  switchFocus _ _ = assign (asViews. vsViews . at ViewMail . _Just . vFocus) ScrollingMailView
+  switchFocus _ _ = assign (asViews . vsViews . ix ViewMail . vFocus) ScrollingMailView
 
 instance Focusable 'ViewMail 'ScrollingMailViewFindWordEditor where
   switchFocus _ _ = do
     modifying (asMailView . mvFindWordEditor . E.editContentsL) clearZipper
-    assign (asViews. vsViews . at ViewMail . _Just . vFocus) ScrollingMailViewFindWordEditor
+    assign (asViews. vsViews . ix ViewMail . vFocus) ScrollingMailViewFindWordEditor
     unhide ViewMail 0 ScrollingMailViewFindWordEditor
 
 instance Focusable 'ViewMail 'ListOfMails where
-  switchFocus _ _ = assign (asViews . vsViews . at ViewMail . _Just . vFocus) ListOfMails
+  switchFocus _ _ = assign (asViews . vsViews . ix ViewMail . vFocus) ListOfMails
 
 instance Focusable 'ViewMail 'MailListOfAttachments where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ViewMail . _Just . vFocus) MailListOfAttachments
+    assign (asViews . vsViews . ix ViewMail . vFocus) MailListOfAttachments
     unhide ViewMail 0 MailListOfAttachments
 
 instance Focusable 'ViewMail 'MailAttachmentOpenWithEditor where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ViewMail . _Just . vFocus) MailAttachmentOpenWithEditor
+    assign (asViews . vsViews . ix ViewMail . vFocus) MailAttachmentOpenWithEditor
     unhide ViewMail 0 MailAttachmentOpenWithEditor
 
 instance Focusable 'ViewMail 'MailAttachmentPipeToEditor where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ViewMail . _Just . vFocus) MailAttachmentPipeToEditor
+    assign (asViews . vsViews . ix ViewMail . vFocus) MailAttachmentPipeToEditor
     unhide ViewMail 0 MailAttachmentPipeToEditor
 
 instance Focusable 'ViewMail 'SaveToDiskPathEditor where
@@ -559,13 +559,13 @@ instance Focusable 'ViewMail 'SaveToDiskPathEditor where
     let maybeFilePath = preview (asMailView . mvAttachments . to L.listSelectedElement
                                  . _Just . _2 . contentDisposition . folded . filename charsets) s
         fname = view (non mempty) maybeFilePath
-    assign (asViews . vsViews . at ViewMail . _Just . vFocus) SaveToDiskPathEditor
+    assign (asViews . vsViews . ix ViewMail . vFocus) SaveToDiskPathEditor
     unhide ViewMail 0 SaveToDiskPathEditor
     modifying (asMailView . mvSaveToDiskPath . E.editContentsL) (insertMany fname . clearZipper)
 
 instance Focusable 'ViewMail 'ComposeTo where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ViewMail . _Just . vFocus) ComposeTo
+    assign (asViews . vsViews . ix ViewMail . vFocus) ComposeTo
     unhide ViewMail 0 ComposeTo
 
 instance Focusable 'Help 'ScrollingHelpView where
@@ -573,33 +573,33 @@ instance Focusable 'Help 'ScrollingHelpView where
 
 instance Focusable 'ComposeView 'ComposeListOfAttachments where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ComposeView . _Just . vFocus) ComposeListOfAttachments
+    assign (asViews . vsViews . ix ComposeView . vFocus) ComposeListOfAttachments
     modify (resetView Threads indexView)
 
 instance Focusable 'ComposeView 'ComposeFrom where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ComposeView . _Just . vFocus) ComposeFrom
+    assign (asViews . vsViews . ix ComposeView . vFocus) ComposeFrom
     curLine <- uses (asCompose . cTo . E.editContentsL) currentLine
     assign (asCompose . cTemp) curLine
     unhide ComposeView 1 ComposeFrom
 
 instance Focusable 'ComposeView 'ComposeTo where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ComposeView . _Just . vFocus) ComposeTo
+    assign (asViews . vsViews . ix ComposeView . vFocus) ComposeTo
     curLine <- uses (asCompose . cTo . E.editContentsL) currentLine
     assign (asCompose . cTemp) curLine
     unhide ComposeView 1 ComposeTo
 
 instance Focusable 'ComposeView 'ComposeSubject where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ComposeView . _Just . vFocus) ComposeSubject
+    assign (asViews . vsViews . ix ComposeView . vFocus) ComposeSubject
     curLine <- uses (asCompose . cTo . E.editContentsL) currentLine
     assign (asCompose . cTemp) curLine
     unhide ComposeView 1 ComposeSubject
 
 instance Focusable 'ComposeView 'ConfirmDialog where
   switchFocus _ _ = do
-    assign (asViews . vsViews . at ComposeView . _Just . vFocus) ConfirmDialog
+    assign (asViews . vsViews . ix ComposeView . vFocus) ConfirmDialog
     unhide ComposeView 0 ConfirmDialog
 
 instance Focusable 'FileBrowser 'ListOfFiles where
@@ -1209,7 +1209,7 @@ makeAttachmentsFromSelected s = do
   parts <- traverse (\x -> createAttachmentFromFile (mimeType x) (makeFullPath x)) (selectedFiles (view (asFileBrowser . fbEntries) s))
   pure $ s & over (asCompose . cAttachments) (go parts)
     . over (asViews . vsFocusedView) (Brick.focusSetCurrent ComposeView)
-    . set (asViews . vsViews . at ComposeView . _Just . vFocus) ComposeListOfAttachments
+    . set (asViews . vsViews . ix ComposeView . vFocus) ComposeListOfAttachments
   where
     go :: [MIMEMessage] -> L.List Name MIMEMessage -> L.List Name MIMEMessage
     go parts l = foldr upsertPart l parts

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1153,7 +1153,7 @@ enterDirectory =
   { _aDescription = ["enter directory"]
   , _aAction =
       selectedItemHelper (asFileBrowser . fbEntries) $ \(_, entry) -> do
-        -- | Construct the full path to the attachment. The file browser only
+        -- Construct the full path to the attachment. The file browser only
         -- lists the file names (otherwise we wouldn't have the ability to
         -- display the full paths for deeper file hirarchies). However when
         -- attaching the file, we need the full paths so we can find, edit and

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -875,7 +875,7 @@ abort = Action ["cancel"] (reset (Proxy :: Proxy v) (Proxy :: Proxy a))
 
 -- | Used to switch the focus from one widget to another on the same view.
 --
-focus :: forall a v. (HasViewName v, HasName a, Focusable v a) => Action v a AppState  --FIXME ()
+focus :: forall v a. (HasViewName v, HasName a, Focusable v a) => Action v a ()
 focus = Action
   ["switch mode to " <> T.pack (show (name (Proxy :: Proxy a)))] $ do
     sink <- use (asConfig . confLogSink)
@@ -883,7 +883,7 @@ focus = Action
       "switchFocus "
         <> show (viewname (Proxy :: Proxy v)) <> " "
         <> show (name (Proxy :: Proxy a))
-    switchFocus (Proxy :: Proxy v) (Proxy :: Proxy a) *> get
+    switchFocus (Proxy :: Proxy v) (Proxy :: Proxy a)
 
 -- | A no-op action can
 -- be used at the start of a sequence with an immediate switch of

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -507,16 +507,9 @@ instance Focusable 'Threads 'ManageThreadTagsEditor where
     modify (toggleLastVisibleWidget ManageThreadTagsEditor)
 
 instance Focusable 'Threads 'ComposeFrom where
-  -- In case the user is already composing a new mail, go back to the compose
-  -- editor, otherwise focus the editor to input the from address.
   switchFocus _ _ = do
-    l <- use (asCompose . cAttachments)
-    if null l
-      then
-        modifying (asViews . vsFocusedView) (Brick.focusSetCurrent ComposeView)
-      else do
-        modify (toggleLastVisibleWidget ComposeFrom)
-        modifying (asCompose . cFrom) (E.applyEdit gotoEOL)
+    modify (toggleLastVisibleWidget ComposeFrom)
+    modifying (asCompose . cFrom) (E.applyEdit gotoEOL)
 
 instance Focusable 'Threads 'ComposeTo where
   switchFocus _ _ = modify (toggleLastVisibleWidget ComposeTo)

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -27,6 +27,7 @@ import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
 import qualified Graphics.Vty.Input.Events as Vty
 import Control.Lens ((&), set, view)
+import Control.Monad.State (execStateT)
 import qualified Data.Map as Map
 import Data.Time.Clock (UTCTime(..))
 import Data.Time.Calendar (fromGregorian)
@@ -190,7 +191,7 @@ initialState conf =
     epoch = UTCTime (fromGregorian 2018 07 18) 1
     async = Async Nothing
     s = AppState conf mi mv (initialCompose mailboxes) Nothing viewsettings fb epoch async
-  in applySearch s
+  in execStateT applySearch s
 
 -- | Application event loop.
 theApp ::

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -15,6 +15,7 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 
 module UI.ComposeEditor.Keybindings where
 
@@ -26,47 +27,47 @@ import Types
 
 composeSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
 composeSubjectKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
     ]
 
 composeFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
 composeFromKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
     ]
 
 composeToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
 composeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
     ]
 
 confirmKeybindings :: [Keybinding 'ComposeView 'ConfirmDialog]
 confirmKeybindings =
   [ Keybinding
       (V.EvKey V.KEnter [])
-      (handleConfirm `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain'`
+      (handleConfirm `chain'` focus @'Threads @'ListOfThreads `chain'`
        reloadList `chain`
        continue)
   , Keybinding
       (V.EvKey (V.KChar 'q') [])
       (noop `chain'`
-       (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain`
+       focus @'ComposeView @'ComposeListOfAttachments `chain`
        continue)
   , Keybinding
       (V.EvKey V.KEsc [])
       (noop `chain'`
-       (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain`
+       focus @'ComposeView @'ComposeListOfAttachments `chain`
        continue)
   ]
 
 confirmAbort :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
 confirmAbort =
-  noop `chain'` (focus :: Action 'ComposeView 'ConfirmDialog AppState) `chain`
+  noop `chain'` focus @'ComposeView @'ConfirmDialog `chain`
   continue
 
 listOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
@@ -79,12 +80,12 @@ listOfAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` focus @'Threads @'ListOfThreads `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'e') []) edit
     , Keybinding (V.EvKey (V.KChar 'D') []) (delete `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'a') []) (noop `chain'` (focus :: Action 'FileBrowser 'ListOfFiles AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 't') []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeTo AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 's') []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeSubject AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'f') []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeFrom AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'a') []) (noop `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 't') []) (noop `chain'` focus @'ComposeView @'ComposeTo `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 's') []) (noop `chain'` focus @'ComposeView @'ComposeSubject `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'f') []) (noop `chain'` focus @'ComposeView @'ComposeFrom `chain` continue)
     ]

--- a/src/UI/FileBrowser/Keybindings.hs
+++ b/src/UI/FileBrowser/Keybindings.hs
@@ -13,7 +13,10 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
 module UI.FileBrowser.Keybindings where
 
 import qualified Graphics.Vty as V
@@ -23,8 +26,8 @@ import Types
 -- | Default Keybindings
 fileBrowserKeybindings :: [Keybinding 'FileBrowser 'ListOfFiles]
 fileBrowserKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
     , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
@@ -32,13 +35,13 @@ fileBrowserKeybindings =
     , Keybinding (V.EvKey (V.KChar ' ') []) (toggleListItem `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'u') [V.MCtrl]) (parentDirectory `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (enterDirectory `chain` createAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` (focus :: Action 'FileBrowser 'ManageFileBrowserSearchPath AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` focus @'FileBrowser @'ManageFileBrowserSearchPath `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     ]
 
 manageSearchPathKeybindings :: [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
 manageSearchPathKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` (focus :: Action 'FileBrowser 'ListOfFiles AppState) `chain` continue)
+  [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
   , Keybinding (V.EvKey V.KEnter []) (done `chain` continue)
   ]

--- a/src/UI/GatherHeaders/Keybindings.hs
+++ b/src/UI/GatherHeaders/Keybindings.hs
@@ -13,7 +13,10 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
 module UI.GatherHeaders.Keybindings where
 
 import qualified Graphics.Vty as V
@@ -22,21 +25,21 @@ import UI.Actions
 
 gatherFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
 gatherFromKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'Threads 'ComposeTo AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` focus @'Threads @'ComposeTo `chain` continue)
     ]
 
 gatherToKeybindings :: [Keybinding 'Threads 'ComposeTo]
 gatherToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'Threads 'ComposeSubject AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` focus @'Threads @'ComposeSubject `chain` continue)
     ]
 
 gatherSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]
 gatherSubjectKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` invokeEditor)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` invokeEditor)
     ]

--- a/src/UI/Help/Keybindings.hs
+++ b/src/UI/Help/Keybindings.hs
@@ -13,7 +13,9 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 
 module UI.Help.Keybindings where
 
@@ -24,8 +26,8 @@ import Types
 -- | Default Keybindings
 helpKeybindings :: [Keybinding 'Help 'ScrollingHelpView]
 helpKeybindings =
-    [ Keybinding (EvKey KEsc []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (EvKey (KChar 'q') []) (noop `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    [ Keybinding (EvKey KEsc []) (noop `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (EvKey (KChar 'q') []) (noop `chain'` focus @'Threads @'ListOfThreads `chain` continue)
     , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)
     , Keybinding (EvKey (KChar ' ') []) (scrollPageDown `chain` continue)
     , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -13,7 +13,9 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 
 module UI.Index.Keybindings where
 
@@ -25,12 +27,12 @@ browseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]
 browseThreadsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) quit
     , Keybinding (V.EvKey (V.KChar 'q') []) quit
-    , Keybinding (V.EvKey V.KEnter []) (displayThreadMails `chain'` (focus :: Action 'ViewMail 'ListOfMails AppState) `chain'` selectNextUnread `chain'` displayMail `chain` continue)
-    , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` (focus :: Action 'Threads 'SearchThreadsEditor AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'm') []) (noop `chain'` (focus :: Action 'Threads 'ComposeFrom AppState) `chain`continue)
-    , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'Threads 'ManageThreadTagsEditor AppState) `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (displayThreadMails `chain'` focus @'ViewMail @'ListOfMails `chain'` selectNextUnread `chain'` displayMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` focus @'Threads @'SearchThreadsEditor `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'm') []) (noop `chain'` focus @'Threads @'ComposeFrom `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` focus @'Threads @'ManageThreadTagsEditor `chain` continue)
     , Keybinding (V.EvKey (V.KChar '\t') []) (switchComposeEditor `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` focus @'Help @'ScrollingHelpView `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
@@ -41,14 +43,14 @@ browseThreadsKeybindings =
 
 searchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]
 searchThreadsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'Threads @'ListOfThreads `chain` continue)
     ]
 
 manageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor]
 manageThreadTagsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'Threads @'ListOfThreads `chain` continue)
     ]

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -53,8 +53,9 @@ import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L
 import Brick.Widgets.Dialog (handleDialogEvent)
 import Graphics.Vty (Event (..))
-import Control.Lens (Getter, (&), _Left, preview, set, to, view)
+import Control.Lens (Getter, _Left, preview, set, to, view)
 import Control.Monad.IO.Class (liftIO)
+import Control.Monad.State
 import Data.Attoparsec.Text (parseOnly)
 import Data.List (find)
 import Data.Text.Zipper (currentLine)
@@ -85,7 +86,7 @@ lookupKeybinding e = find (\x -> view kbEvent x == e)
 dispatch :: EventHandler v m -> AppState -> Event -> Brick.EventM Name (Brick.Next AppState)
 dispatch (EventHandler l fallback) s ev =
   case lookupKeybinding ev (view l s) of
-    Just kb -> s & view (kbAction . aAction) kb . set asError Nothing
+    Just kb -> evalStateT (view (kbAction . aAction) kb) (set asError Nothing s)
     Nothing -> fallback s ev
 
 

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -25,16 +25,16 @@ import Types
 
 displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 displayMailKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` (focus :: Action 'Threads 'ListOfThreads AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
     , Keybinding (V.EvKey V.KBS []) (scrollPageUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar ' ') []) (scrollPageDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'h') []) (toggleHeaders `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` (focus :: Action 'ViewMail 'ManageMailTagsEditor AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` focus @'ViewMail @'ManageMailTagsEditor `chain` continue)
 
-    , Keybinding (V.EvKey V.KUp []) (noop `chain'` (focus :: Action 'ViewMail 'ListOfMails AppState) `chain` listUp `chain'` displayMail `chain` continue)
-    , Keybinding (V.EvKey V.KDown []) (noop `chain'` (focus :: Action 'ViewMail 'ListOfMails AppState) `chain` listDown `chain'` displayMail `chain` continue)
+    , Keybinding (V.EvKey V.KUp []) (noop `chain'` focus @'ViewMail @'ListOfMails `chain` listUp `chain'` displayMail `chain` continue)
+    , Keybinding (V.EvKey V.KDown []) (noop `chain'` focus @'ViewMail @'ListOfMails `chain` listDown `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'J') []) (noop
                                              `chain'` listDown @'Threads @'ListOfThreads
@@ -49,24 +49,24 @@ displayMailKeybindings =
                                              `chain'` selectNextUnread
                                              `chain'` displayMail
                                              `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` (focus :: Action 'Help 'ScrollingHelpView AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` invokeEditor)
-    , Keybinding (V.EvKey (V.KChar 'v') []) (noop `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'e') []) (composeAsNew `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '/') []) (noop `chain'` (focus :: Action 'ViewMail 'ScrollingMailViewFindWordEditor AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` focus @'Help @'ScrollingHelpView `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` invokeEditor)
+    , Keybinding (V.EvKey (V.KChar 'v') []) (noop `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'e') []) (composeAsNew `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '/') []) (noop `chain'` focus @'ViewMail @'ScrollingMailViewFindWordEditor `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'n') []) (scrollNextWord `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'f') []) (noop
                                              `chain` encapsulateMail
-                                             `chain'` (focus :: Action 'ViewMail 'ComposeTo AppState)
+                                             `chain'` focus @'ViewMail @'ComposeTo
                                              `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) (removeHighlights `chain` continue)
     ]
 
 findWordEditorKeybindings :: [Keybinding 'ViewMail 'ScrollingMailViewFindWordEditor]
 findWordEditorKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
-  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
-  , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
+  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+  , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
   ]
 
 
@@ -74,46 +74,46 @@ mailAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
 mailAttachmentsKeybindings =
     [ Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
     , Keybinding (V.EvKey V.KEnter []) openAttachment
-    , Keybinding (V.EvKey (V.KChar 'o') []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentOpenWithEditor AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '|') []) (noop `chain'` (focus :: Action 'ViewMail 'MailAttachmentPipeToEditor AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 's') []) (noop `chain'` (focus :: Action 'ViewMail 'SaveToDiskPathEditor AppState) `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'o') []) (noop `chain'` focus @'ViewMail @'MailAttachmentOpenWithEditor `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '|') []) (noop `chain'` focus @'ViewMail @'MailAttachmentPipeToEditor `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 's') []) (noop `chain'` focus @'ViewMail @'SaveToDiskPathEditor `chain` continue)
     ]
 
 openWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
 openWithKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `chain'` (focus :: Action 'ViewMail 'MailAttachmentPipeToEditor AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` openWithCommand)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `chain'` focus @'ViewMail @'MailAttachmentPipeToEditor `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'MailListOfAttachments `chain` openWithCommand)
     ]
 
 pipeToKeybindings :: [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
 pipeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `chain'` (focus :: Action 'ViewMail 'MailAttachmentOpenWithEditor AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` pipeToCommand)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `chain'` focus @'ViewMail @'MailAttachmentOpenWithEditor `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'MailListOfAttachments `chain` pipeToCommand)
     ]
 
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
 mailViewManageMailTagsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
     ]
 
 saveToDiskKeybindings :: [Keybinding 'ViewMail 'SaveToDiskPathEditor]
 saveToDiskKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
-  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` continue)
-  , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ViewMail 'MailListOfAttachments AppState) `chain` saveAttachmentToPath `chain` continue)
+  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
+  , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'MailListOfAttachments `chain` saveAttachmentToPath `chain` continue)
   ]
 
 mailviewComposeToKeybindings :: [Keybinding 'ViewMail 'ComposeTo]
 mailviewComposeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` (focus :: Action 'ViewMail 'ScrollingMailView AppState) `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` (focus :: Action 'ComposeView 'ComposeListOfAttachments AppState) `chain` invokeEditor)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` invokeEditor)
     ]

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -13,7 +13,9 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 
 module UI.Mail.Keybindings where
 
@@ -35,14 +37,14 @@ displayMailKeybindings =
     , Keybinding (V.EvKey V.KDown []) (noop `chain'` (focus :: Action 'ViewMail 'ListOfMails AppState) `chain` listDown `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'J') []) (noop
-                                             `chain'` (listDown :: Action 'Threads 'ListOfThreads AppState)
+                                             `chain'` listDown @'Threads @'ListOfThreads
                                              `chain'` displayThreadMails
                                              `chain'` selectNextUnread
                                              `chain'` displayMail
                                              `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain'` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'K') []) (noop
-                                             `chain'` (listUp :: Action 'Threads 'ListOfThreads AppState)
+                                             `chain'` listUp @'Threads @'ListOfThreads
                                              `chain'` displayThreadMails
                                              `chain'` selectNextUnread
                                              `chain'` displayMail

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -45,7 +45,7 @@ focusedViewWidgets :: AppState -> [[Name]]
 focusedViewWidgets s =
   let defaultV = view (asConfig . confDefaultView) s
       focused = fromMaybe defaultV $ focusGetCurrent $ view (asViews . vsFocusedView) s
-      allLayers = view (asViews . vsViews . at focused . _Just . vLayers) s
+      allLayers = view (asViews . vsViews . ix focused . vLayers) s
    in toList $ toListOf
         (layeriso . traversed . filtered (\t -> view veState t == Visible) . veName)
         <$> allLayers

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -13,8 +13,11 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
 module TestActions where
 
 import qualified Brick.Widgets.List as L
@@ -44,7 +47,7 @@ testModeDescription :: TestTree
 testModeDescription = testCase "mode present in the switch action"
                       $ view aDescription a @?= ["switch mode to ManageMailTagsEditor"]
   where
-    a = focus :: Action 'ViewMail 'ManageMailTagsEditor AppState
+    a = focus @'ViewMail @'ManageMailTagsEditor
 
 testNoDupes :: TestTree
 testNoDupes =


### PR DESCRIPTION
"Make the whole country seethe with a high-pitched campaign for producing greenhouse vegetables!"

```
f87f82e (Fraser Tweedale, 33 minutes ago)
   use -XTypeApplications for 'focus' in keybindings

   Wanting to relax the return type of the 'focus' action from
   'AppState' to '()' revealed an opportunity to improve usability.  In 
   keybindings, when 'focus' is used we currently use an explicit, fully
   saturated type signature to determine the Focusable instance. This includes
   the 'Action' constructor and the 'AppState' return type, which are both
   redundant (`chain` and `chain'` both ignore the Action return type as a
   result of the StateT refactor).

   Therefore we can simplify the definition of keybindings that use
   'focus' by using -XTypeApplications, available in GHC since 8.0.

654f2c8 (Fraser Tweedale, 54 minutes ago)
   refactor invokeEditor' and editAttachment

   Refactor these functions to use 'MonadState'.  In the case of
   'editAttachment', a lot of the behaviour was subsumed by an application of
   'selectedItemHelper'.

e58e41d (Fraser Tweedale, 75 minutes ago)
   fix instance Focusable 'Threads 'ComposeFrom

   The old implementation (which was factored out to a top-level function
   'focusComposeFrom' contained the expression:

     if nullOf (asCompose . cAttachments) s
        then ...

   This was erroneously refacted as:

     l <- use (asCompose . cAttachments)
    if null l
      then ...

   The latter is testing whether the attachment list is empty, whereas the
   former is testing whether the optic (asCompose . cAttachments) has zero
   targets.  In the case of an Iso, Lens or Getter, there is always exactly
   one target, hence 'nullOf' always returns 'False'! The true branch of the
   old implementation is unreachable, but I introduced a bug (that made it
   reachable) during the refactor.

   To fix, remove the conditional and replace the whole conditional with the
   false branch.

c278f3d (Fraser Tweedale, 75 minutes ago)
   refactor Action to use StateT

   Using 'StateT AppState (EventM n)' for 'Action' definitions improves the
   readability (and writeability) of actions.  It also increases the
   flexibility (or abstractness) of what data types actions return.

   To get all this to work we had to add some orphan 'MonadThrow',
   'MonadCatch' and 'MonadMask' instances for '(EventM n)'.  I hope to land
   these upstream in brick.