### PR TITLE
Fix/update nix

### DIFF
--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,7 +1,7 @@
 { compiler ? null, nixpkgs ? null}:
 
 let
-  compilerVersion = if isNull compiler then "ghc863" else compiler;
+  compilerVersion = if isNull compiler then "ghc865" else compiler;
   haskellPackagesOverlay = self: super: with super.haskell.lib; {
     haskellPackages = super.haskell.packages.${compilerVersion}.override {
       overrides = hself: hsuper: {
@@ -21,8 +21,8 @@ let
     if isNull nixpkgs
     then
     builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/e27e11480323db005ab62ef477eb1fd28b6b62f5.tar.gz";
-      sha256 = "0i64wsl20fl92bsqn900nxmmnr1v3088drbwhwpm9lvln42yf23s";
+      url = "https://github.com/NixOS/nixpkgs/archive/b9cb3b2fb2f45ac8f3a8f670c90739eb34207b0e.tar.gz";
+      sha256 = "1cpjmsa2lwfxg55ac02w9arbd3y5617d19x91sd1fq521jqbnnpc";
     }
     else
     nixpkgs;

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
        - nix-channel --add https://nixos.org/channels/nixos-19.09 nixpkgs
        - nix-channel --update
        - nix-env --install --attr nixpkgs.elinks
-       - nix-build
+       - nix-build -j 2
        - nix-shell --command 'PATH=$PATH:result/bin cabal v2-test --test-show-details=streaming uat'
     - compiler: "hlint"
       language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
        - nix-channel --update
        - nix-env --install --attr nixpkgs.elinks
        - nix-build
-       - nix-shell --command 'PATH=$PATH:result/bin cabal test --show-details=streaming uat'
+       - nix-shell --command 'PATH=$PATH:result/bin cabal v2-test --test-show-details=streaming uat'
     - compiler: "hlint"
       language: c
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       language: c
       env: NOTMUCHVER=0.28 GHCHEAD=true
       addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
-    - compiler: "ghc863 (default)"
+    - compiler: "ghc865 (default)"
       language: nix
       before_install:
       install:


### PR DESCRIPTION
```
commit 5a87183c187c4aa25ca9ac053cd68b22b60cd19e (HEAD -> fix/update-nix, origin/fix/update-nix)
Author: Róman Joost <roman@bromeco.de>
Date:   Sun Feb 16 11:56:45 2020 +1000

    nix: Minimize build time by use two concurrent jobs
    
    According to:
    
      https://docs.travis-ci.com/user/reference/overview/#virtualization-environments
    
    we have two cores available. This patch invokes nix-build to use two
    concurrent jobs in accordance to the amount of cores availabe to speed
    up building most of our dependencies.

commit 440afd0a5c3609d5eabfa768e02fed105469913f
Author: Róman Joost <roman@bromeco.de>
Date:   Sun Feb 16 13:35:14 2020 +1000

    nix: Adopt to renamed test option in cabal-install 3.0
    
    The nix release we've chosen already ships the cabal-install tool
    version 3.0.
    
    This version has renamed a test command we use to stream in-progress
    test output to the console. This patch adopts the new test command and
    furthermore uses the `v2` test API. Reason being is that locally, there
    seemed to be no difference between test and new-test, while v2-test
    seemed to be the new command.

commit 2e91ab079647b4525a320847cfbb0b14057b5948
Author: Róman Joost <roman@bromeco.de>
Date:   Sat Dec 21 20:28:44 2019 +1000

    nix: Update release
    
    The release we had pinned from an unstable branch is now very much out
    of date.
    
    This update pins the release against a latest commit of the
    nixos-19.09 branch. With this change we also change the compiler from
    GHC 8.6.3 to GHC 8.6.5

```