### PR TITLE
curry sendmail effect with executable

### DIFF
--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -38,8 +38,8 @@ myMailKeybindings =
     [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
     ]
 
-writeMailtoFile :: FilePath -> B.ByteString -> IO (Either Error ())
-writeMailtoFile _ m = do
+writeMailtoFile :: B.ByteString -> IO (Either Error ())
+writeMailtoFile m = do
   confdir <- lookupEnv "PUREBRED_CONFIG_DIR"
   currentdir <- getCurrentDirectory
   let fname = fromMaybe currentdir confdir </> "sentMail"

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -429,8 +429,7 @@ data ComposeViewSettings = ComposeViewSettings
     { _cvFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
     , _cvToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
     , _cvSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
-    , _cvSendMailCmd :: FilePath -> B.ByteString -> IO (Either Error ())
-    , _cvSendMailPath :: FilePath
+    , _cvSendMailCmd :: B.ByteString -> IO (Either Error ())
     , _cvListOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
     , _cvIdentities :: [Mailbox]
     , _cvConfirmKeybindings :: [Keybinding 'ComposeView 'ConfirmDialog]
@@ -446,11 +445,8 @@ cvToKeybindings = lens _cvToKeybindings (\cv x -> cv { _cvToKeybindings = x })
 cvSubjectKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeSubject]
 cvSubjectKeybindings = lens _cvSubjectKeybindings (\cv x -> cv { _cvSubjectKeybindings = x })
 
-cvSendMailCmd :: Lens' ComposeViewSettings (FilePath -> B.ByteString -> IO (Either Error ()))
+cvSendMailCmd :: Lens' ComposeViewSettings (B.ByteString -> IO (Either Error ()))
 cvSendMailCmd = lens _cvSendMailCmd (\cv x -> cv { _cvSendMailCmd = x })
-
-cvSendMailPath :: Lens' ComposeViewSettings FilePath
-cvSendMailPath = lens _cvSendMailPath (\cv x -> cv { _cvSendMailPath = x })
 
 cvListOfAttachmentsKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeListOfAttachments]
 cvListOfAttachmentsKeybindings = lens _cvListOfAttachmentsKeybindings (\cv x -> cv { _cvListOfAttachmentsKeybindings = x })

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1384,10 +1384,9 @@ buildMail s = do
 trySendAndCatch :: String -> B.ByteString -> AppState -> IO AppState
 trySendAndCatch l' m s = do
     let cmd = view (asConfig . confComposeView . cvSendMailCmd) s
-        sendmail = view (asConfig . confComposeView . cvSendMailPath) s
         defMailboxes = view (asConfig . confComposeView . cvIdentities) s
     catch
-        (cmd sendmail m $> (s
+        (cmd m $> (s
          & set asCompose (initialCompose defMailboxes)
          . set (asConfig . confBoundary) l'))
         (\e ->


### PR DESCRIPTION
We have a sendmail executable path field in the config.  But this
isn't really needed, and indeed makes no sense for alternative
implementations (such as the "write to file" implementation we use
for the test suite, evident in that the argument is ignored).

So remove the field, and partially apply the sendmail function to
the executable path in the cvSendMailPath field.