### PR TITLE
send mail / save draft: cleanup and perf improvement

### DIFF
--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -21,7 +21,8 @@ Example configuration, currently used for testing which demonstrates various
 ways to overwrite the configuration.
 -}
 import Purebred
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Lazy as L
 import System.Environment (lookupEnv)
 import System.Directory (getCurrentDirectory)
 import Data.Maybe (fromMaybe)
@@ -38,12 +39,12 @@ myMailKeybindings =
     [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
     ]
 
-writeMailtoFile :: B.ByteString -> IO (Either Error ())
+writeMailtoFile :: B.Builder -> IO (Either Error ())
 writeMailtoFile m = do
   confdir <- lookupEnv "PUREBRED_CONFIG_DIR"
   currentdir <- getCurrentDirectory
   let fname = fromMaybe currentdir confdir </> "sentMail"
-  B.writeFile fname m
+  L.writeFile fname (B.toLazyByteString m)
   pure (Right ())
 
 fromMail :: [Mailbox]

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -24,8 +24,8 @@ import Data.Monoid ((<>))
 import Brick.Util (fg, on, bg)
 import qualified Brick.Widgets.Edit as E
 import qualified Graphics.Vty as V
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as LB
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Lazy as L
 import qualified Data.Text as T
 import Control.Monad.Except (runExceptT)
 import System.Environment (lookupEnv)
@@ -65,7 +65,7 @@ import Storage.Notmuch (getDatabasePath)
 --
 sendmail ::
      FilePath
-  -> B.ByteString -- ^ the rendered mail
+  -> B.Builder -- ^ the rendered mail
   -> IO (Either Error ())
 sendmail bin m = do
   -- -t which extracts recipients from the mail
@@ -75,8 +75,8 @@ sendmail bin m = do
     Right (ExitFailure _, stderr) -> Left $ SendMailError (untaint decode stderr)
     Right (ExitSuccess, _) -> Right ()
   where
-    config = setStdin (byteStringInput (LB.fromStrict m)) $ proc bin ["-t", "-v"]
-    decode = T.unpack . sanitiseText . decodeLenient . LB.toStrict
+    config = setStdin (byteStringInput (B.toLazyByteString m)) $ proc bin ["-t", "-v"]
+    decode = T.unpack . sanitiseText . decodeLenient . L.toStrict
 
 -- | Default theme
 solarizedDark :: A.AttrMap

--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -31,7 +31,7 @@ module Storage.Notmuch (
     -- ** Messages
   , messageTagModify
   , mailFilepath
-  , indexMail
+  , indexFilePath
   , unindexFilePath
 
     -- ** Tagging (Labels)
@@ -292,19 +292,6 @@ indexFilePath dbpath fp tgs =
   withDatabase
     dbpath
     (\db -> Notmuch.indexFile db fp >>= Notmuch.messageSetTags tgs)
-
--- | Writes given mail as ByteString to a file and indexes it
---
-indexMail ::
-     (MonadError Error m, MonadIO m)
-  => B.ByteString -- ^ rendered mail
-  -> FilePath -- ^ path to the maildir
-  -> FilePath -- ^ path to file under which the mail is stored
-  -> Tag -- ^ tag to attach the mail
-  -> m ()
-indexMail bs maildir fp tag = do
-    tryIO $ B.writeFile fp bs
-    indexFilePath maildir fp [tag]
 
 unindexFilePath ::
      (MonadError Error m, MonadIO m)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -45,6 +45,7 @@ import Control.Monad.Except (MonadError)
 import Control.Monad.Reader (MonadIO)
 import Control.Concurrent (ThreadId)
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -441,7 +442,7 @@ data ComposeViewSettings = ComposeViewSettings
     , _cvCcKeybindings :: [Keybinding 'ComposeView 'ComposeCc]
     , _cvBccKeybindings :: [Keybinding 'ComposeView 'ComposeBcc]
     , _cvSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
-    , _cvSendMailCmd :: B.ByteString -> IO (Either Error ())
+    , _cvSendMailCmd :: B.Builder -> IO (Either Error ())
     , _cvListOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
     , _cvIdentities :: [Mailbox]
     , _cvConfirmKeybindings :: [Keybinding 'ComposeView 'ConfirmDialog]
@@ -463,7 +464,7 @@ cvBccKeybindings = lens _cvBccKeybindings (\cv x -> cv { _cvBccKeybindings = x }
 cvSubjectKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeSubject]
 cvSubjectKeybindings = lens _cvSubjectKeybindings (\cv x -> cv { _cvSubjectKeybindings = x })
 
-cvSendMailCmd :: Lens' ComposeViewSettings (B.ByteString -> IO (Either Error ()))
+cvSendMailCmd :: Lens' ComposeViewSettings (B.Builder -> IO (Either Error ()))
 cvSendMailCmd = lens _cvSendMailCmd (\cv x -> cv { _cvSendMailCmd = x })
 
 cvListOfAttachmentsKeybindings :: Lens' ComposeViewSettings [Keybinding 'ComposeView 'ComposeListOfAttachments]


### PR DESCRIPTION
```
aa18c96 (Fraser Tweedale, 3 hours ago)
   avoid construction of strict ByteStrings

   When sending or saving mail, we currently render the mail into a strict
   ByteString.  This could be quite an expensive operation when all we really
   need to do is send it to sendmail(1) stdin or to a file.  Change the
   cvSendMailCommand to accept a Builder instead of a strict ByteString,
   allowing a more efficient implementation, and chase the changes.

   Also remove the indexMail function.  It should not be the responsibility of
   the Notmuch subroutines to actually write the mail to disk (and pushing
   that responsibility to the caller allows the caller to use the most
   efficient means of writing the file).

c874068 (Fraser Tweedale, 3 hours ago)
   refactor send mail and safe draft actions

   Refactor the send mail and save draft actions to use MonadState.
```