### PR TITLE
Also export the 'sendmail' function

### DIFF
--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -135,7 +135,8 @@ module Purebred (
   Mailbox(..),
   AddrSpec(..),
   Domain(..),
-  purebred) where
+  purebred,
+  sendmail) where
 
 import UI.App (theApp, initialState)
 
@@ -162,7 +163,7 @@ import UI.Mail.Keybindings
 import UI.Actions
 import UI.Status.Main (rescheduleMailcheck)
 import Storage.Notmuch (getDatabasePath)
-import Config.Main (defaultConfig, solarizedDark, mailTagAttr)
+import Config.Main (defaultConfig, solarizedDark, mailTagAttr, sendmail)
 import Types
 import Error
 


### PR DESCRIPTION
In 83be34759cd09ffcfe9b0ee1a03b027dcf5e7312 we removed the
`cvSendMailPath` because the partially applied function is much more
flexible and makes an extra path in the state kind of superfluous.
However that also took away any form to customize the path to sendmail.
While typical MTA's will always disguise themself as /usr/bin/sendmail,
there are circumstances where user based MTA's such as 'esmtp' or
'msmtp' are preferable.

Export the 'sendmail' partial so users can point to whatever sendmail
binary they prefer.