### PR TITLE
Feature/5 marking for bulk actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,15 @@ matrix:
     - compiler: "ghc-8.6.3"
       language: c
       env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc,{sourceline: "ppa:jamesw05/tmux", key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51a89e9c35f79436"}]}}
     - compiler: "ghc-8.4.4"
       language: c
       env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc,{sourceline: "ppa:jamesw05/tmux", key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51a89e9c35f79436"}]}}
     - compiler: "ghc-head"
       language: c
       env: NOTMUCHVER=0.28 GHCHEAD=true
-      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc,{sourceline: "ppa:jamesw05/tmux", key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51a89e9c35f79436"}]}}
     - compiler: "ghc865 (default)"
       language: nix
       before_install:

--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -31,12 +31,16 @@ import Data.List.NonEmpty (NonEmpty(..))
 
 myBrowseThreadsKbs :: [Keybinding 'Threads 'ListOfThreads]
 myBrowseThreadsKbs =
-  [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
+  [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"]
+                                       `chain` untoggleListItems
+                                       `chain` continue)
   ]
 
 myMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 myMailKeybindings =
-    [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"] `chain` continue)
+    [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"]
+                                         `chain` untoggleListItems
+                                         `chain` continue)
     ]
 
 writeMailtoFile :: B.Builder -> IO (Either Error ())

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -87,6 +87,7 @@ solarizedDark =
         , (listSelectedAttr, V.white `on` V.yellow)
         , (listNewMailAttr, fg V.white `V.withStyle` V.bold)
         , (listNewMailSelectedAttr, V.white `on` V.yellow `V.withStyle` V.bold)
+        , (listToggledAttr, V.currentAttr `V.withStyle` V.reverseVideo)
         , (mailTagAttr, fg V.cyan)
         , (mailAuthorsAttr, fg V.white)
         , (E.editFocusedAttr, V.white `on` V.brightBlack)
@@ -146,6 +147,9 @@ listNewMailAttr = L.listAttr <> "newmail"
 
 listNewMailSelectedAttr :: A.AttrName
 listNewMailSelectedAttr = listNewMailAttr <> L.listSelectedAttr
+
+listToggledAttr :: A.AttrName
+listToggledAttr = L.listAttr <> "toggled"
 
 mailAttr :: A.AttrName
 mailAttr = "mail"

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -83,13 +83,18 @@ solarizedDark :: A.AttrMap
 solarizedDark =
     A.attrMap
         V.defAttr
-        [ (listAttr, V.brightBlue `on` V.brightBlack)
-        , (listSelectedAttr, V.white `on` V.yellow)
-        , (listNewMailAttr, fg V.white `V.withStyle` V.bold)
-        , (listNewMailSelectedAttr, V.white `on` V.yellow `V.withStyle` V.bold)
-        , (listToggledAttr, V.currentAttr `V.withStyle` V.reverseVideo)
+        [ (listAttr, fg V.brightBlue)
+        , (listSelectedAttr, bg V.yellow)
+        , (listNewMailAttr, fg V.white)
+        , (listSelectedNewmailAttr, fg V.white)
+        , (listToggledAttr, bg V.yellow `V.withStyle` V.reverseVideo)
+        , (listSelectedToggledAttr, bg V.red `V.withStyle` V.reverseVideo)
         , (mailTagAttr, fg V.cyan)
-        , (mailAuthorsAttr, fg V.white)
+        , (mailTagToggledAttr, bg V.brightBlue)
+        , (mailAuthorsAttr, fg V.brightBlue)
+        , (mailNewmailAuthorsAttr, fg V.white)
+        , (mailSelectedNewmailAuthorsAttr, fg V.white)
+        , (mailToggledAuthorsAttr, V.yellow `on` V.brightBlue)
         , (E.editFocusedAttr, V.white `on` V.brightBlack)
         , (editorAttr, V.brightBlue `on` V.brightBlack)
         , (editorLabelAttr, V.brightYellow `on` V.brightBlack)
@@ -111,6 +116,27 @@ solarizedDark =
 -- * Attributes
 -- $attributes
 -- These attributes are used as keys in widgets to assign color values.
+--
+
+-- ** State Attributes used to indicate list item state
+-- List attributes are generated based on three possible states:
+--
+--   * selected (first)
+--   * toggled
+--   * new (last)
+--
+-- That means that for example, any new list items will inherit colour
+-- definitions from selected and toggled attributes.
+listStateSelectedAttr :: A.AttrName
+listStateSelectedAttr = "selected"
+
+listStateNewmailAttr :: A.AttrName
+listStateNewmailAttr = "newmail"
+
+listStateToggledAttr :: A.AttrName
+listStateToggledAttr = "toggled"
+
+-- ** Widget Attributes
 --
 defaultAttr :: A.AttrName
 defaultAttr = "default"
@@ -139,17 +165,23 @@ editorLabelAttr = editorAttr <> "label"
 listAttr :: A.AttrName
 listAttr = L.listAttr
 
+-- Note: Brick exports a L.listSelectedAttr, yet in order to make our
+-- use of our listState attributes consistent across the application
+-- we need to use our own listState attributes.
 listSelectedAttr :: A.AttrName
-listSelectedAttr = L.listSelectedAttr
+listSelectedAttr = L.listAttr <> listStateSelectedAttr
 
 listNewMailAttr :: A.AttrName
-listNewMailAttr = L.listAttr <> "newmail"
+listNewMailAttr = L.listAttr <> listStateNewmailAttr
 
-listNewMailSelectedAttr :: A.AttrName
-listNewMailSelectedAttr = listNewMailAttr <> L.listSelectedAttr
+listSelectedNewmailAttr :: A.AttrName
+listSelectedNewmailAttr = L.listSelectedAttr <> listStateNewmailAttr
 
 listToggledAttr :: A.AttrName
-listToggledAttr = L.listAttr <> "toggled"
+listToggledAttr = L.listAttr <> listStateToggledAttr
+
+listSelectedToggledAttr :: A.AttrName
+listSelectedToggledAttr = listStateSelectedAttr <> listToggledAttr
 
 mailAttr :: A.AttrName
 mailAttr = "mail"
@@ -157,11 +189,26 @@ mailAttr = "mail"
 mailTagAttr :: A.AttrName
 mailTagAttr = mailAttr <> "tag"
 
+mailTagToggledAttr :: A.AttrName
+mailTagToggledAttr = mailTagAttr <> listStateToggledAttr
+
 mailAuthorsAttr :: A.AttrName
 mailAuthorsAttr = mailAttr <> "authors"
 
+mailNewmailAuthorsAttr :: A.AttrName
+mailNewmailAuthorsAttr = mailAuthorsAttr <> listStateNewmailAttr
+
+mailToggledAuthorsAttr :: A.AttrName
+mailToggledAuthorsAttr = mailAuthorsAttr <> listStateToggledAttr
+
 mailSelectedAuthorsAttr :: A.AttrName
-mailSelectedAuthorsAttr = mailAuthorsAttr <> "selected"
+mailSelectedAuthorsAttr = mailAuthorsAttr <> listStateSelectedAttr
+
+mailSelectedNewmailAuthorsAttr :: A.AttrName
+mailSelectedNewmailAuthorsAttr = mailAuthorsAttr <> listStateSelectedAttr <> listStateNewmailAttr
+
+mailSelectedToggledAuthorsAttr :: A.AttrName
+mailSelectedToggledAuthorsAttr = mailSelectedAuthorsAttr <> listStateToggledAttr
 
 headerAttr :: A.AttrName
 headerAttr = "header"

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -129,6 +129,9 @@ module Purebred (
   defaultConfig,
   solarizedDark,
   mailTagAttr,
+  listStateSelectedAttr,
+  listStateToggledAttr,
+  listStateNewmailAttr,
   (</>),
   module Control.Lens,
   genBoundary,
@@ -160,7 +163,9 @@ import UI.Mail.Keybindings
 import UI.Actions
 import UI.Status.Main (rescheduleMailcheck)
 import Storage.Notmuch (getDatabasePath)
-import Config.Main (defaultConfig, solarizedDark, mailTagAttr, sendmail)
+import Config.Main
+    (defaultConfig, solarizedDark, mailTagAttr, sendmail,
+    listStateSelectedAttr, listStateToggledAttr, listStateNewmailAttr)
 import Types
 import Error
 

--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -230,7 +230,7 @@ getThreads
   :: (MonadError Error m, MonadIO m)
   => T.Text
   -> NotmuchSettings FilePath
-  -> m (V (SelectableItem NotmuchThread))
+  -> m (V (Toggleable NotmuchThread))
 getThreads s settings =
   withDatabaseReadOnly (view nmDatabase settings) $
     flip Notmuch.query (Notmuch.Bare $ T.unpack s)
@@ -247,7 +247,7 @@ getThreadMessages
   :: (MonadError Error m, MonadIO m, Traversable t)
   => FilePath
   -> t NotmuchThread
-  -> m (Vec.Vector (SelectableItem NotmuchMail))
+  -> m (Vec.Vector (Toggleable NotmuchMail))
 getThreadMessages fp ts = withDatabaseReadOnly fp go
   where
     go db = do

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -642,6 +642,11 @@ vsViews = lens _vsViews (\settings x -> settings { _vsViews = x })
 vsFocusedView :: Lens' ViewSettings (Brick.FocusRing ViewName)
 vsFocusedView = lens _vsFocusedView (\settings x -> settings { _vsFocusedView = x})
 
+-- | An item which carries it's selected state.
+-- Used in order to mark list items.
+--
+type SelectableItem a = (Bool, a)
+
 data FileSystemEntry
     = Directory String
     | File String
@@ -653,11 +658,11 @@ fsEntryName = let toName (Directory n) = n
               in to toName
 
 data FileBrowser = CreateFileBrowser
-  { _fbEntries :: L.List Name (Bool, FileSystemEntry)
+  { _fbEntries :: L.List Name (SelectableItem FileSystemEntry)
   , _fbSearchPath :: E.Editor FilePath Name
   }
 
-fbEntries :: Lens' FileBrowser (L.List Name (Bool, FileSystemEntry))
+fbEntries :: Lens' FileBrowser (L.List Name (SelectableItem FileSystemEntry))
 fbEntries = lens _fbEntries (\cv x -> cv { _fbEntries = x })
 
 fbSearchPath :: Lens' FileBrowser (E.Editor FilePath Name)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -123,8 +123,8 @@ search and composes e-mails from here.
 
 -}
 data MailIndex = MailIndex
-    { _miListOfMails  :: ListWithLength V.Vector (SelectableItem NotmuchMail)
-    , _miListOfThreads :: ListWithLength V (SelectableItem NotmuchThread)
+    { _miListOfMails  :: ListWithLength V.Vector (Toggleable NotmuchMail)
+    , _miListOfThreads :: ListWithLength V (Toggleable NotmuchThread)
     , _miListOfThreadsGeneration :: Generation
     , _miSearchThreadsEditor :: E.Editor T.Text Name
     , _miMailTagsEditor :: E.Editor T.Text Name
@@ -132,16 +132,16 @@ data MailIndex = MailIndex
     , _miNewMail :: Int
     }
 
-miMails :: Lens' MailIndex (ListWithLength V.Vector (SelectableItem NotmuchMail))
+miMails :: Lens' MailIndex (ListWithLength V.Vector (Toggleable NotmuchMail))
 miMails = lens _miListOfMails (\m v -> m { _miListOfMails = v })
 
-miThreads :: Lens' MailIndex (ListWithLength V (SelectableItem NotmuchThread))
+miThreads :: Lens' MailIndex (ListWithLength V (Toggleable NotmuchThread))
 miThreads = lens _miListOfThreads (\m v -> m { _miListOfThreads = v})
 
-miListOfMails :: Lens' MailIndex (L.GenericList Name V.Vector (SelectableItem NotmuchMail))
+miListOfMails :: Lens' MailIndex (L.GenericList Name V.Vector (Toggleable NotmuchMail))
 miListOfMails = miMails . listList
 
-miListOfThreads :: Lens' MailIndex (L.GenericList Name V (SelectableItem NotmuchThread))
+miListOfThreads :: Lens' MailIndex (L.GenericList Name V (Toggleable NotmuchThread))
 miListOfThreads = miThreads . listList
 
 miListOfThreadsGeneration :: Lens' MailIndex Generation
@@ -642,10 +642,10 @@ vsViews = lens _vsViews (\settings x -> settings { _vsViews = x })
 vsFocusedView :: Lens' ViewSettings (Brick.FocusRing ViewName)
 vsFocusedView = lens _vsFocusedView (\settings x -> settings { _vsFocusedView = x})
 
--- | An item which carries it's selected state.
+-- | An item carrying it's selected state.
 -- Used in order to mark list items.
 --
-type SelectableItem a = (Bool, a)
+type Toggleable a = (Bool, a)
 
 data FileSystemEntry
     = Directory String
@@ -658,11 +658,11 @@ fsEntryName = let toName (Directory n) = n
               in to toName
 
 data FileBrowser = CreateFileBrowser
-  { _fbEntries :: L.List Name (SelectableItem FileSystemEntry)
+  { _fbEntries :: L.List Name (Toggleable FileSystemEntry)
   , _fbSearchPath :: E.Editor FilePath Name
   }
 
-fbEntries :: Lens' FileBrowser (L.List Name (SelectableItem FileSystemEntry))
+fbEntries :: Lens' FileBrowser (L.List Name (Toggleable FileSystemEntry))
 fbEntries = lens _fbEntries (\cv x -> cv { _fbEntries = x })
 
 fbSearchPath :: Lens' FileBrowser (E.Editor FilePath Name)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -123,8 +123,8 @@ search and composes e-mails from here.
 
 -}
 data MailIndex = MailIndex
-    { _miListOfMails  :: ListWithLength V.Vector NotmuchMail
-    , _miListOfThreads :: ListWithLength V NotmuchThread
+    { _miListOfMails  :: ListWithLength V.Vector (SelectableItem NotmuchMail)
+    , _miListOfThreads :: ListWithLength V (SelectableItem NotmuchThread)
     , _miListOfThreadsGeneration :: Generation
     , _miSearchThreadsEditor :: E.Editor T.Text Name
     , _miMailTagsEditor :: E.Editor T.Text Name
@@ -132,16 +132,16 @@ data MailIndex = MailIndex
     , _miNewMail :: Int
     }
 
-miMails :: Lens' MailIndex (ListWithLength V.Vector NotmuchMail)
+miMails :: Lens' MailIndex (ListWithLength V.Vector (SelectableItem NotmuchMail))
 miMails = lens _miListOfMails (\m v -> m { _miListOfMails = v })
 
-miThreads :: Lens' MailIndex (ListWithLength V NotmuchThread)
+miThreads :: Lens' MailIndex (ListWithLength V (SelectableItem NotmuchThread))
 miThreads = lens _miListOfThreads (\m v -> m { _miListOfThreads = v})
 
-miListOfMails :: Lens' MailIndex (L.GenericList Name V.Vector NotmuchMail)
+miListOfMails :: Lens' MailIndex (L.GenericList Name V.Vector (SelectableItem NotmuchMail))
 miListOfMails = miMails . listList
 
-miListOfThreads :: Lens' MailIndex (L.GenericList Name V NotmuchThread)
+miListOfThreads :: Lens' MailIndex (L.GenericList Name V (SelectableItem NotmuchThread))
 miListOfThreads = miThreads . listList
 
 miListOfThreadsGeneration :: Lens' MailIndex Generation

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -297,15 +297,9 @@ instance HasList 'ListOfFiles where
 class (HasList (n :: Name), Traversable (T n)) =>
       HasSelectableItemList n
   where
-  selectE :: Proxy n -> E n -> E n
   deselectE :: Proxy n -> E n -> E n
   toggleE :: Proxy n -> E n -> E n
   isSelectedE :: Proxy n -> E n -> Bool
-
-  {-
-  selectAll :: (MonadState AppState m) => Proxy n -> m ()
-  selectAll proxy = modifying (list proxy . traversed) (selectE proxy)
-  -}
 
   deselectAll :: (MonadState AppState m) => Proxy n -> m ()
   deselectAll proxy = modifying (list proxy . traversed) (deselectE proxy)
@@ -325,7 +319,6 @@ instance
   , IxValue (T n (Bool, a)) ~ (Bool, a)
   , Ixed (T n (Bool, a))
   ) => HasSelectableItemList n where
-  selectE _ = set _1 True
   deselectE _ = set _1 False
   toggleE _ = over _1 not
   isSelectedE _ = fst

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -289,7 +289,7 @@ instance HasList 'MailListOfAttachments where
 
 instance HasList 'ListOfFiles where
   type T 'ListOfFiles = Vector.Vector
-  type E 'ListOfFiles = (Bool, FileSystemEntry)
+  type E 'ListOfFiles = SelectableItem FileSystemEntry
   list _ = asFileBrowser . fbEntries
 
 

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1144,7 +1144,7 @@ toggleHeaders = Action
 setTags :: forall v ctx. HasSelectableItemList ctx => [TagOp] -> Action v ctx ()
 setTags ops =
     Action
-    { _aDescription = ["apply given tags"]
+    { _aDescription = ["apply tag operations: " <> T.intercalate ", " (T.pack . show <$> ops) ]
     , _aAction = do
         w <- gets focusedViewWidget
         s <- get

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -1159,9 +1159,10 @@ setTags ops =
           ScrollingMailView -> do
             selected <- toListOf (selectedItemsL (Proxy @'ScrollingMailView)) <$> get
             manageMailTags ops selected
-          _ -> do
+          ListOfThreads -> do
             selected <- toListOf (selectedItemsL (Proxy @'ListOfThreads)) <$> get
             manageThreadTags ops selected
+          _ -> error "setTags called on widget without a registered handler"
 
     }
 

--- a/src/UI/FileBrowser/Main.hs
+++ b/src/UI/FileBrowser/Main.hs
@@ -32,7 +32,7 @@ renderFileBrowser :: AppState -> Widget Name
 renderFileBrowser s = L.renderList drawListItem (ListOfFiles == focusedViewWidget s)
                       $ view (asFileBrowser . fbEntries) s
 
-drawListItem :: Bool -> (Bool, FileSystemEntry) -> Widget Name
+drawListItem :: Bool -> SelectableItem FileSystemEntry -> Widget Name
 drawListItem sel (toggled, x) =
   let attr = withAttr $ if sel then listSelectedAttr else listAttr
       toggledWidget = txt $ if toggled then " ☑ " else " ☐ "

--- a/src/UI/FileBrowser/Main.hs
+++ b/src/UI/FileBrowser/Main.hs
@@ -32,7 +32,7 @@ renderFileBrowser :: AppState -> Widget Name
 renderFileBrowser s = L.renderList drawListItem (ListOfFiles == focusedViewWidget s)
                       $ view (asFileBrowser . fbEntries) s
 
-drawListItem :: Bool -> SelectableItem FileSystemEntry -> Widget Name
+drawListItem :: Bool -> Toggleable FileSystemEntry -> Widget Name
 drawListItem sel (toggled, x) =
   let attr = withAttr $ if sel then listSelectedAttr else listAttr
       toggledWidget = txt $ if toggled then " ☑ " else " ☐ "

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -39,6 +39,7 @@ browseThreadsKeybindings =
     , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem `chain` listDown `chain` continue)
     ]
 
 searchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]
@@ -52,5 +53,5 @@ manageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor]
 manageThreadTagsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` untoggleListItems @'Threads @'ListOfThreads `chain` continue)
     ]

--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -46,7 +46,7 @@ renderListOfThreads s = L.renderList (listDrawThread s) True $ view (asMailIndex
 renderListOfMails :: AppState -> Widget Name
 renderListOfMails s = L.renderList (listDrawMail s) True $ view (asMailIndex . miListOfMails) s
 
-listDrawMail :: AppState -> Bool -> SelectableItem NotmuchMail -> Widget Name
+listDrawMail :: AppState -> Bool -> Toggleable NotmuchMail -> Widget Name
 listDrawMail s sel (toggled, a) =
     let settings = view (asConfig . confNotmuch) s
         isNewMail = hasTag (view nmNewTag settings) a
@@ -61,7 +61,7 @@ listDrawMail s sel (toggled, a) =
           ]
     in withAttr (getListAttr (makeListItemState isNewMail sel toggled)) widget
 
-listDrawThread :: AppState -> Bool -> SelectableItem NotmuchThread -> Widget Name
+listDrawThread :: AppState -> Bool -> Toggleable NotmuchThread -> Widget Name
 listDrawThread s sel (toggled, a) =
     let settings = view (asConfig . confNotmuch) s
         isNewMail = hasTag (view nmNewTag settings) a

--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -45,7 +45,7 @@ renderListOfThreads s = L.renderList (listDrawThread s) True $ view (asMailIndex
 renderListOfMails :: AppState -> Widget Name
 renderListOfMails s = L.renderList (listDrawMail s) True $ view (asMailIndex . miListOfMails) s
 
-notmuchConfig :: AppState -> (NotmuchSettings FilePath)
+notmuchConfig :: AppState -> NotmuchSettings FilePath
 notmuchConfig = view (asConfig . confNotmuch)
 
 isNewMail :: ManageTags a => a -> AppState -> Bool
@@ -58,9 +58,9 @@ renderListAttr, authorsAttr, tagsAttr ::
   -> Bool -- ^ selected
   -> Bool -- ^ Toggled
   -> AttrName
-renderListAttr a s sel toggled = makeListStateAttr listAttr (isNewMail a s) sel toggled
-authorsAttr a s sel toggled = makeListStateAttr mailAuthorsAttr (isNewMail a s) sel toggled
-tagsAttr a s sel toggled = makeListStateAttr mailTagAttr (isNewMail a s) sel toggled
+renderListAttr a s = makeListStateAttr listAttr (isNewMail a s)
+authorsAttr a s = makeListStateAttr mailAuthorsAttr (isNewMail a s)
+tagsAttr a s = makeListStateAttr mailTagAttr (isNewMail a s)
 
 
 listDrawMail :: AppState -> Bool -> Toggleable NotmuchMail -> Widget Name

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -28,6 +28,7 @@ displayMailKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
     , Keybinding (V.EvKey V.KBS []) (scrollPageUp `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem `chain` listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar ' ') []) (scrollPageDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'h') []) (toggleHeaders `chain` continue)
@@ -100,7 +101,7 @@ pipeToKeybindings =
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
 mailViewManageMailTagsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (done `chain'` untoggleListItems @'ViewMail @'ScrollingMailView `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
     ]
 

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -125,7 +125,7 @@ renderToggled s =
   let currentL = case focusedViewWidget s of
         ListOfThreads -> length $ toListOf (asMailIndex . miListOfThreads . traversed . filtered fst) s
         _ -> length $ toListOf (asMailIndex . miListOfMails . traversed . filtered fst) s
-  in if currentL > 0 then str $ "Tag: " <> show currentL else emptyWidget
+  in if currentL > 0 then str $ "Marked: " <> show currentL else emptyWidget
 
 renderMatches :: AppState -> Widget n
 renderMatches s =

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -33,12 +33,12 @@ import qualified Brick.Widgets.List as L
 import Types
 
 
-toggledItems :: L.List Name (Bool, a) -> [(Bool, a)]
+toggledItems :: L.List Name (SelectableItem a) -> [SelectableItem a]
 toggledItems = toListOf (L.listElementsL . folded . filtered fst)
 
 -- | Toggle file list entries to be selected
 --
-selectedFiles :: L.List Name (Bool, FileSystemEntry) -> [FilePath]
+selectedFiles :: L.List Name (SelectableItem FileSystemEntry) -> [FilePath]
 selectedFiles l = let cur = case L.listSelectedElement l of
                         Just (_, (_, File fsname)) -> [(False, File fsname)]
                         _ -> []

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2017-2019 Fraser Tweedale and Róman Joost
+-- Copyright (C) 2017-2020 Fraser Tweedale and Róman Joost
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -20,30 +20,12 @@
 module UI.Utils
   ( titleize
   , Titleize
-  , toggledItems
-  , selectedFiles
   ) where
-import Data.List (union)
 
 import Data.Text (Text, pack)
-import Control.Lens
-       (folded, traversed, filtered, toListOf, view, _2)
-import qualified Brick.Widgets.List as L
 
 import Types
 
-
-toggledItems :: L.List Name (Toggleable a) -> [Toggleable a]
-toggledItems = toListOf (L.listElementsL . folded . filtered fst)
-
--- | Toggle file list entries to be selected
---
-selectedFiles :: L.List Name (Toggleable FileSystemEntry) -> [FilePath]
-selectedFiles l = let cur = case L.listSelectedElement l of
-                        Just (_, (_, File fsname)) -> [(False, File fsname)]
-                        _ -> []
-                      toggled = view (_2 . fsEntryName) <$> toggledItems l
-                  in toggled `union` toListOf (traversed . _2 . fsEntryName) cur
 
 -- | Show a descriptive name
 --

--- a/src/UI/Utils.hs
+++ b/src/UI/Utils.hs
@@ -33,12 +33,12 @@ import qualified Brick.Widgets.List as L
 import Types
 
 
-toggledItems :: L.List Name (SelectableItem a) -> [SelectableItem a]
+toggledItems :: L.List Name (Toggleable a) -> [Toggleable a]
 toggledItems = toListOf (L.listElementsL . folded . filtered fst)
 
 -- | Toggle file list entries to be selected
 --
-selectedFiles :: L.List Name (SelectableItem FileSystemEntry) -> [FilePath]
+selectedFiles :: L.List Name (Toggleable FileSystemEntry) -> [FilePath]
 selectedFiles l = let cur = case L.listSelectedElement l of
                         Just (_, (_, File fsname)) -> [(False, File fsname)]
                         _ -> []

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -29,7 +29,6 @@ import qualified Data.Vector as Vector
 
 import Types
 import UI.Actions
-import UI.Utils (selectedFiles)
 import UI.Views (swapWidget)
 
 
@@ -39,7 +38,6 @@ actionTests =
     testGroup
         "action tests"
         [ testModeDescription
-        , testNoDupes
         , testSwapBottom
         ]
 
@@ -48,17 +46,6 @@ testModeDescription = testCase "mode present in the switch action"
                       $ view aDescription a @?= ["switch mode to ManageMailTagsEditor"]
   where
     a = focus @'ViewMail @'ManageMailTagsEditor
-
-testNoDupes :: TestTree
-testNoDupes =
-    let vec =
-            Vector.fromList
-                [ (True, File "file 1")
-                , (True, File "file 2")
-                , (False, File "file 3")]
-        l = set L.listSelectedL (Just 1) $ L.list ListOfFiles vec 1
-    in testCase "no duplicates when multiple items are selected" $
-       selectedFiles l @?= ["file 1", "file 2"]
 
 testSwapBottom :: TestTree
 testSwapBottom = testCase "swaps last visible widget" $ swapWidget ListOfThreads ManageThreadTagsEditor tiles @?= expected

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -239,7 +239,7 @@ testSubstringMatchesAreCleared = purebredTmuxSession "substring match indicator 
 
     step "No match indicator is shown"
     snapshot
-    assertRegexS "New:\\s[0-9]\\]\\s+Threads"
+    assertRegexS "New:\\s[0-9]\\s+\\]\\s+Threads"
 
     step "search for Lorem mail"
     sendKeys ":" (Regex ("Query: " <> buildAnsiRegex [] ["37"] [] <> "tag:inbox"))
@@ -258,7 +258,7 @@ testSubstringMatchesAreCleared = purebredTmuxSession "substring match indicator 
     sendKeys "et\r" (Substring "1 of 20 matches")
 
     step "go back to threads"
-    sendKeys "Escape" (Regex "New:\\s[0-9]\\]\\s+Threads")
+    sendKeys "Escape" (Regex "New:\\s[0-9]\\s+\\]\\s+Threads")
 
 
 testSubstringSearchInMailBody :: PurebredTestCase

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -708,7 +708,7 @@ testUserCanMoveBetweenThreads = purebredTmuxSession "user can navigate between t
     -- assert that the first mail is really the one we're later navigating back
     -- to
     snapshot
-    assertRegexS (buildAnsiRegex ["1"] ["37"] ["43"] <> "\\sAug'17.*Testmail with whitespace")
+    assertRegexS (buildAnsiRegex [] ["37"] ["43"] <> "\\sAug'17.*Testmail with whitespace")
 
     step "View Mail"
     sendKeys "Enter" (Substring "This is a test mail for purebred")
@@ -793,16 +793,16 @@ testUpdatesReadState = purebredTmuxSession "updates read state for mail and thre
     sendKeys "Down" (Substring "2 of 2")
 
     step "go back to thread list which is now read"
-    sendKeys "q" (Regex (buildAnsiRegex [] ["37"] ["43"] <> T.encodeUtf8 " Feb'17\\sRóman\\sJoost\\s+\\(2\\)"))
+    sendKeys "q" (Regex (buildAnsiRegex [] ["34"] ["43"] <> T.encodeUtf8 " Feb'17\\sRóman\\sJoost\\s+\\(2\\)"))
 
     step "set one mail to unread"
     sendKeys "Enter" (Substring "Beginning of large text")
-    sendKeys "t" (Regex (buildAnsiRegex ["1"] ["37"] []
+    sendKeys "t" (Regex (buildAnsiRegex [] ["37"] []
                            <> "\\sRe: WIP Refactor\\s+"
-                           <> buildAnsiRegex ["0"] ["34"] ["40"]))
+                           <> buildAnsiRegex [] ["34"] ["49"]))
 
     step "returning to thread list shows entire thread as unread"
-    sendKeys "q" (Regex (buildAnsiRegex ["1"] ["37"] [] <> "\\sWIP Refactor\\s"))
+    sendKeys "q" (Regex (buildAnsiRegex [] ["37"] [] <> "\\sWIP Refactor\\s"))
 
 testConfig :: PurebredTestCase
 testConfig = purebredTmuxSession "test custom config" $
@@ -851,7 +851,7 @@ testAddAttachments = purebredTmuxSession "use file browser to add attachments" $
     sendKeys "a" (Regex $ "Path: " <> buildAnsiRegex [] ["34"] ["40"] <> cwd)
 
     step "jump to the end of the list"
-    sendKeys "G" (Regex $ buildAnsiRegex [] ["37"] ["43"] <> T.encodeUtf8 "\\s\9744 - " <> lastFile)
+    sendKeys "G" (Regex $ buildAnsiRegex [] [] ["43"] <> T.encodeUtf8 "\\s\9744 - " <> lastFile)
 
     step "add first selected file"
     sendKeys "Enter" (Substring lastFile)
@@ -900,13 +900,13 @@ testAddAttachments = purebredTmuxSession "use file browser to add attachments" $
     sendKeys "a" (Regex $ "Path: " <> buildAnsiRegex [] ["34"] ["40"] <> cwd)
 
     step "jump to the end of the list"
-    sendKeys "G" (Regex $ buildAnsiRegex [] ["37"] ["43"] <> T.encodeUtf8 "\\s\9744 - " <> lastFile)
+    sendKeys "G" (Regex $ buildAnsiRegex [] [] ["43"] <> T.encodeUtf8 "\\s\9744 - " <> lastFile)
 
     step "select the file"
-    sendKeys "Space" (Regex $ buildAnsiRegex [] ["37"] ["43"] <> T.encodeUtf8 "\\s\9745 - " <> lastFile)
+    sendKeys "Space" (Regex $ buildAnsiRegex [] [] ["43"] <> T.encodeUtf8 "\\s\9745 - " <> lastFile)
 
     step "move one item up"
-    sendKeys "Up" (Regex $ buildAnsiRegex [] ["37"] ["43"] <> T.encodeUtf8 "\\s\9744 - " <> secondLastFile)
+    sendKeys "Up" (Regex $ buildAnsiRegex [] [] ["43"] <> T.encodeUtf8 "\\s\9744 - " <> secondLastFile)
 
     step "add selected files"
     out <- sendKeys "Enter" (Substring "Item 3 of 3")
@@ -936,7 +936,7 @@ testManageTagsOnMails = purebredTmuxSession "manage tags on mails" $
 
     step "enter new tag"
     sendLine "+inbox +foo +bar" (Regex ("foo"
-                             <> buildAnsiRegex [] ["37"] []
+                             <> buildAnsiRegex [] ["34"] []
                              <> "\\s"
                              <> buildAnsiRegex [] ["36"] []
                              <> "bar"))
@@ -996,7 +996,7 @@ testManageTagsOnThreads = purebredTmuxSession "manage tags on threads" $
 
     step "thread tags shows new tags"
     sendKeys "Escape" (Regex ("archive"
-                              <> buildAnsiRegex [] ["37"] []
+                              <> buildAnsiRegex [] ["34"] []
                               <> "\\s"
                               <> buildAnsiRegex [] ["36"] []
                               <> "replied"))
@@ -1009,9 +1009,9 @@ testManageTagsOnThreads = purebredTmuxSession "manage tags on threads" $
     -- "-only" will fail due to tmux parsing it as an argument, but the mail is
     -- already tagged with "thread" so the additional adding won't do anything
     sendLine "+thread" (Regex ("archive"
-                             <> buildAnsiRegex [] ["37"] []
+                             <> buildAnsiRegex [] ["34"] []
                              <> "\\s"
-                             <> buildAnsiRegex [] ["36"] [] <> "replied" <> buildAnsiRegex [] ["37"] []
+                             <> buildAnsiRegex [] ["36"] [] <> "replied" <> buildAnsiRegex [] ["34"] []
                              <> "\\s"
                              <> buildAnsiRegex [] ["36"] [] <> "thread"))
 
@@ -1020,11 +1020,11 @@ testManageTagsOnThreads = purebredTmuxSession "manage tags on threads" $
 
     step "second mail shows old tag"
     sendKeys "Escape" (Regex ("replied"
-                              <> buildAnsiRegex [] ["37"] []
+                              <> buildAnsiRegex [] ["34"] []
                               <> "\\s"
                               <> buildAnsiRegex [] ["36"] []
                               <> "thread"
-                              <> buildAnsiRegex [] ["37"] []
+                              <> buildAnsiRegex [] ["34"] []
                               <> "\\sWIP Refactor"))
 
     step "open thread tag editor"
@@ -1071,13 +1071,13 @@ testSetsMailToRead = purebredTmuxSession "user can toggle read tag" $
 
     step "first unread mail is opened"
     sendKeys "Escape" (Substring "List of Threads")
-      >>= assertRegex (buildAnsiRegex [] ["37"] ["43"] <> ".*Testmail")
+      >>= assertRegex (buildAnsiRegex [] ["34"] [] <> ".*Testmail")
 
     step "show mail"
     sendKeys "Enter" (Substring "This is a test mail for purebred")
 
     step "toggle single mail back to unread (bold again)"
-    sendKeys "t" (Regex (buildAnsiRegex ["1"] ["37"] ["43"] <> ".*Testmail"))
+    sendKeys "t" (Regex (buildAnsiRegex [] ["37"] [] <> ".*Testmail"))
 
 testCanToggleHeaders :: PurebredTestCase
 testCanToggleHeaders = purebredTmuxSession "user can toggle Headers" $
@@ -1260,7 +1260,7 @@ testSendMail =
           sendKeys "Escape" (Substring "body")
 
           step "exit vim"
-          sendKeys ": x\r" (Regex ("text/plain; charset=us-ascii\\s" <> buildAnsiRegex [] ["34"] ["40"] <> "\\s+"))
+          sendKeys ": x\r" (Regex ("text/plain; charset=us-ascii\\s" <> buildAnsiRegex [] [] ["49"] <> "\\s+"))
 
           -- pre-check before we sent:
           --   * Drafts is empty before sending


### PR DESCRIPTION
Oof this has now become quite large, but worth it I guess. I'm anticipating that you might not have the time instantly to go through all of that. The way how currently toggled list items are rendered sucks a bit and I may investigate further if that can be improved.
However I feel fine to merge it as it is.
```
commit a15e987b45c7c74e5dacde5bb6067047e9789e19
Author: Róman Joost <roman@bromeco.de>
Date:   Sun Mar 29 15:42:40 2020 +1000

    Re-use HasToggleablelist functions instead of utils
    
    This is a small refactoring to re-use the HasToggleablelist functions
    instead of the utility functions only used for the file browser. This
    doesn't make the attachment creation generic, since all of this code is
    verys specific to the file browser anyways.

commit 6182328255718612f45b8ac90bf3d181d6018722
Author: Róman Joost <roman@bromeco.de>
Date:   Sun Mar 29 12:24:09 2020 +1000

    Test bulk actions with additional acceptance tests

commit 30fa4a15095eebc8be756a8ca3285a2d2ed5feb8
Author: Róman Joost <roman@bromeco.de>
Date:   Sun Mar 29 07:20:21 2020 +1000

    Use a better word than "Tagged"
    
    I had used "Tag", because mutt is using "Tag". The word tagging here has
    a different context however. In mutt it used to be to perform bulk
    actions on the tagged list items, but with the introduction of notmuch,
    tagging can also mean the labeling of mails with "tags".
    
    Instead of using "Tagged", use the word "Marked" since we're marking
    these list items for further action.

commit 43de3888192cedb6a4913e87594bc902d95e3998
Author: Róman Joost <roman@bromeco.de>
Date:   Sat Mar 28 16:47:43 2020 +1000

    Operate on toggled *or* selected list items
    
    This adds an additional helper for lists supporting toggling of it's
    items. It is similar in nature to our existing `selectedItemHelper`.
    
    It really is a workaround for Brick's List, since it can not encapsulate
    a marked/toggled state for it's list items. This function allows to
    operate on toggled or selected items.

commit 5e14cb4d43aad4fe705b934da33d873e6d26d097
Author: Róman Joost <roman@bromeco.de>
Date:   Sat Mar 28 16:29:04 2020 +1000

    Use `toggle` to indicate a selected state
    
    We currently use selected and toggled ambiguosly in the code. To make it
    clear: refer to a list item which is toggled for batch editing as
    `toggled` and a list item which is selected by the cursor as: selected.

commit 3702b535a5fed8dc79baa3986ce7d1050d0a54b9
Author: Róman Joost <roman@bromeco.de>
Date:   Sat Mar 28 10:34:19 2020 +1000

    Raise an error if setTags is called on unsupported widget
    
    If we call `setTags` on a widget we have not registered a handler for,
    Purebred would simply assume that the only widget would be the list of
    threads.
    
    However when adding new widgets, this can lead to confusing
    behaviour for new contributors since the handler is silently operating
    on the list of threads.

commit 68b2cf2f01356e0cc0c231adabb2a4dd63418675
Author: Róman Joost <roman@bromeco.de>
Date:   Sat Mar 28 10:33:39 2020 +1000

    Remove selectAll for now
    
    At this point we do not want to support toggling all items in a list due
    to performance concerns.

commit b40697fee779705b3835e1a9357fdcc990fa782d
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Sun Mar 22 17:04:59 2020 +1000

    derive HasSelectableItemList for any context with (Bool, a) element type

commit e11d7bc1fc2414aaddf4c8312074dae7afd0906b
Author: Róman Joost <roman@bromeco.de>
Date:   Sun Mar 22 13:09:27 2020 +1000

    Provide a lens to operate on toggled items

commit 15cfcf41a4d24541ecf2464ce6832a98182880aa
Author: Róman Joost <roman@bromeco.de>
Date:   Sun Feb 16 14:41:00 2020 +1000

    Improve help for setTags action
    
    The 'apply given tags' isn't very helpful, particularly when we have a
    look at our help page in the UI:
    
         a - apply given tags
         S - apply given tags
    
    Both are distinct actions and the 'what' is missing here. This adds at
    least the show instances of the tag operations to make this part of the
    UI more helpful.

commit 583054f1b13c2604588aacfa2da0b5c977f87750
Author: Róman Joost <roman@bromeco.de>
Date:   Thu Feb 6 19:41:07 2020 +1000

    Bulk actions
    
    This implements the support for bulk actions, currently limited to
    tagging only. The major part of this patch is the support for tagging
    multiple items (either mail or thread) from our Brick list widgets now
    able to hold a toggle state in the list item itself.
    
    Fixes https://github.com/purebred-mua/purebred/issues/5

commit 8c08052ac151bb59cacc6c551c270c9679ed3ef7
Author: Róman Joost <roman@bromeco.de>
Date:   Thu Jan 30 20:12:26 2020 +1000

    Type alias to reflect marked list items
    
    This is a simple type alias which reflects list items which can be
    marked for bulk actions.
```