### PR TITLE
ci: add 8.8 and 8.10 to matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,18 @@ apt_sources: &apt_sources
 
 matrix:
   include:
-    - compiler: "ghc-8.6.3"
+    - compiler: "ghc-8.10.1"
+      language: c
+      env: NOTMUCHVER=0.28 GHCHEAD=true
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-3.2,ghc-8.10.1], sources: *apt_sources}}
+    - compiler: "ghc-8.8.3"
       language: c
       env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: *apt_sources}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-3.0,ghc-8.8.3], sources: *apt_sources}}
+    - compiler: "ghc-8.6.5"
+      language: c
+      env: NOTMUCHVER=0.28
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.6.5], sources: *apt_sources}}
     - compiler: "ghc-8.4.4"
       language: c
       env: NOTMUCHVER=0.28

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_install:
   - unset CC
   - ROOTDIR=$(pwd)
   - mkdir -p $HOME/.local/bin
-  - "PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$HOME/.local/bin:$PATH"
+  - "PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$HOME/.cabal/bin:$HOME/.local/bin:$PATH"
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
 
@@ -151,7 +151,7 @@ script:
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
 
   # install the program (required for UAT)
-  - cabal new-install -w ${HC} --symlink-bindir=$HOME/.local/bin exe:purebred
+  - cabal new-install -w ${HC} exe:purebred
   # trick the UAT into looking for configs / data in the right place
   - export SRCDIR=$(find ${PWD} -maxdepth 1 -type d -name 'purebred-*')
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,20 +25,25 @@ before_cache:
 
   - rm -rfv $HOME/.cabal/packages/head.hackage
 
+apt_sources: &apt_sources
+  - hvr-ghc
+  - sourceline: "ppa:jamesw05/tmux"
+    key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51a89e9c35f79436"
+
 matrix:
   include:
     - compiler: "ghc-8.6.3"
       language: c
       env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc,{sourceline: "ppa:jamesw05/tmux", key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51a89e9c35f79436"}]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: *apt_sources}}
     - compiler: "ghc-8.4.4"
       language: c
       env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc,{sourceline: "ppa:jamesw05/tmux", key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51a89e9c35f79436"}]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: *apt_sources}}
     - compiler: "ghc-head"
       language: c
       env: NOTMUCHVER=0.28 GHCHEAD=true
-      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc,{sourceline: "ppa:jamesw05/tmux", key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51a89e9c35f79436"}]}}
+      addons: {apt: {packages: [elinks,tmux,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev,ghc-ppa-tools,cabal-install-head,ghc-head], sources: *apt_sources}}
     - compiler: "ghc865 (default)"
       language: nix
       before_install:

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -37,7 +37,7 @@ extra-source-files:
   configs/purebred.hs
 
 tested-with:
-  GHC==8.4.4, GHC==8.6.3
+  GHC==8.4.4, GHC==8.6.5, GHC==8.8.3, GHC==8.10.1
 
 source-repository head
   type: git


### PR DESCRIPTION
Fixes: https://github.com/purebred-mua/purebred/issues/367

```
3babb53 (Fraser Tweedale, 4 hours ago)
   ci: cabal-install >= 3.0 does not know --symlink-bindir

   Fixes: https://github.com/purebred-mua/purebred/issues/367

2f4db4c (Fraser Tweedale, 5 hours ago)
   ci: add ghc 8.8 and 8.10 to matrix

5344f26 (Fraser Tweedale, 5 hours ago)
   ci: extract apt sources to common def

   We can use YAML anchor to define the APT sources only once. Unfortunately,
   YAML has no array merge or extend capability so we cannot do similar for
   the package list (because the versions of cabal and ghc vary).
```