### PR TITLE
Use a more explicit way to update the attachment list

### DIFF
--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -834,11 +834,22 @@ testRepliesToMailSuccessfully = purebredTmuxSession "replies to mail successfull
     sendKeys "r" (Substring "> This is a test mail for purebred")
 
     step "exit vim"
-    sendKeys ": x\r" (Substring "Attachments") >>= put
+    sendLine ": x" (Substring "Attachments") >>= put
 
     assertRegexS "From: \"Joe Bloggs\" <joe@foo.test>\\s+$"
     assertSubstringS "To: <frase@host.example>"
     assertSubstringS ("Subject: Re: " <> subject)
+
+    -- https://github.com/purebred-mua/purebred/issues/379
+    step "edit the mail one more time"
+    sendKeys "e" (Substring "> This is a test mail for purebred")
+
+    step "insert body"
+    sendKeys "oThis is more information" (Substring "This is more information")
+    sendKeys "Escape" Unconditional
+
+    step "exit vim"
+    sendLine ": x" (Substring "Item 1 of 1")
 
     step "send mail"
     sendKeys "y" (Substring "Query")


### PR DESCRIPTION
The way we updated the attachment list was by guessing the
operation. Well, if the list was empty the operation was pretty straight
forward: insert the item(s). However if the list was not empty the
guessing became harder: either replace or append. The ambiguity of this
resulted in this bug.

Instead of guessing, pass the operation we want to do after we've
invoked the operator to the function which invokes the editor. We know
exactly what we want to do with the list, after the editor has exited.

Fixes https://github.com/purebred-mua/purebred/issues/379


----

#