### PR TITLE
Make the search path editor consistent with other editors

### DIFF
--- a/src/UI/FileBrowser/Keybindings.hs
+++ b/src/UI/FileBrowser/Keybindings.hs
@@ -42,6 +42,7 @@ fileBrowserKeybindings =
 
 manageSearchPathKeybindings :: [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
 manageSearchPathKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
-  , Keybinding (V.EvKey V.KEnter []) (done `chain` continue)
+  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
+  , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
   ]


### PR DESCRIPTION
This adds additional key bindings to make the editor consistent with
other input widgets in Purebred.

Before using the search path editor was very confusing, since the only
way to move the focus back to the list (a.k.a file browser) was by
pressing Escape.

This patch changes the behaviour to allow the focus change to the list
with more key strokes.