### PR TITLE
Use new widget to keep the editor state

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -78,6 +78,7 @@ library
                      , Config.Main
                      , Storage.Notmuch
                      , Storage.ParsedMail
+                     , Brick.Widgets.StatefulEdit
                      , Purebred
   other-modules:       Paths_purebred
                      , Purebred.Types.IFC

--- a/src/Brick/Widgets/StatefulEdit.hs
+++ b/src/Brick/Widgets/StatefulEdit.hs
@@ -1,0 +1,62 @@
+-- This file is part of purebred
+-- Copyright (C) 2020 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-- | This module provides a text editor widget like
+-- Brick.Widgets.Edit. However it can be used to store it's state in
+-- order to roll it back. This is useful if newly changed editor state is
+-- to be canceled and to be rolled back to the previous state.
+module Brick.Widgets.StatefulEdit
+  ( StatefulEditor(..)
+  , editStateL
+  , editEditorL
+  , saveEditorState
+  , revertEditorState
+  ) where
+
+import Control.Lens (Lens', lens, view, set, to, over)
+import Data.Text.Zipper (currentLine, insertMany, clearZipper)
+import Brick.Widgets.Edit (Editor(..), editContentsL)
+
+data StatefulEditor t n =
+  StatefulEditor
+    { _editState :: t
+    , _editEditor :: Editor t n
+    }
+
+
+-- | Access to the editors state.
+-- Note: Do not rely on accessing the editor contents using this
+-- lens. Always access the editor contents directly by accessing the
+-- editor itself using 'editEditorL'.
+editStateL :: Lens' (StatefulEditor t n) t
+editStateL = lens _editState (\e v -> e { _editState = v})
+
+-- | Access to the underlying Brick Edit widget. 
+editEditorL :: Lens' (StatefulEditor t n) (Editor t n)
+editEditorL = lens _editEditor (\e v -> e { _editEditor = v})
+
+-- | Save the editor state to potentially revert the editor back to it
+-- later.
+saveEditorState :: Monoid t => StatefulEditor t n -> StatefulEditor t n
+saveEditorState editor =
+  let contents = view (editEditorL . editContentsL . to currentLine) editor
+   in set editStateL contents editor
+
+-- | Revert the editor back to it's previously saved contents.
+revertEditorState :: Monoid t => StatefulEditor t n -> StatefulEditor t n
+revertEditorState editor =
+  let saved = view editStateL editor
+   in over (editEditorL . editContentsL) (insertMany saved . clearZipper) editor

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -63,6 +63,7 @@ import System.Process.Typed (ProcessConfig)
 import Notmuch (Tag)
 import Data.MIME
 
+import Brick.Widgets.StatefulEdit (StatefulEditor(..))
 import Error
 import Purebred.LazyVector (V)
 import Purebred.Types.IFC (Tainted)
@@ -128,7 +129,7 @@ data MailIndex = MailIndex
     { _miListOfMails  :: ListWithLength V.Vector (Toggleable NotmuchMail)
     , _miListOfThreads :: ListWithLength V (Toggleable NotmuchThread)
     , _miListOfThreadsGeneration :: Generation
-    , _miSearchThreadsEditor :: E.Editor T.Text Name
+    , _miSearchThreadsEditor :: StatefulEditor T.Text Name
     , _miMailTagsEditor :: E.Editor T.Text Name
     , _miThreadTagsEditor :: E.Editor T.Text Name
     , _miNewMail :: Int
@@ -150,7 +151,7 @@ miListOfThreadsGeneration :: Lens' MailIndex Generation
 miListOfThreadsGeneration =
   lens _miListOfThreadsGeneration (\s b -> s { _miListOfThreadsGeneration = b })
 
-miSearchThreadsEditor :: Lens' MailIndex (E.Editor T.Text Name)
+miSearchThreadsEditor :: Lens' MailIndex (StatefulEditor T.Text Name)
 miSearchThreadsEditor = lens _miSearchThreadsEditor (\m v -> m { _miSearchThreadsEditor = v})
 
 miMailTagsEditor :: Lens' MailIndex (E.Editor T.Text Name)
@@ -288,33 +289,29 @@ data ConfirmDraft
   deriving (Show)
 
 data Compose = Compose
-    { _cFrom :: E.Editor T.Text Name
-    , _cTo :: E.Editor T.Text Name
-    , _cCc :: E.Editor T.Text Name
-    , _cBcc :: E.Editor T.Text Name
-    , _cSubject :: E.Editor T.Text Name
-    , _cTemp :: T.Text
+    { _cFrom :: StatefulEditor T.Text Name
+    , _cTo :: StatefulEditor T.Text Name
+    , _cCc :: StatefulEditor T.Text Name
+    , _cBcc :: StatefulEditor T.Text Name
+    , _cSubject :: StatefulEditor T.Text Name
     , _cAttachments :: L.List Name MIMEMessage
     , _cKeepDraft :: Dialog ConfirmDraft
     }
 
-cFrom :: Lens' Compose (E.Editor T.Text Name)
+cFrom :: Lens' Compose (StatefulEditor T.Text Name)
 cFrom = lens _cFrom (\c x -> c { _cFrom = x })
 
-cTo :: Lens' Compose (E.Editor T.Text Name)
+cTo :: Lens' Compose (StatefulEditor T.Text Name)
 cTo = lens _cTo (\c x -> c { _cTo = x })
 
-cCc :: Lens' Compose (E.Editor T.Text Name)
+cCc :: Lens' Compose (StatefulEditor T.Text Name)
 cCc = lens _cCc (\c x -> c { _cCc = x })
 
-cBcc :: Lens' Compose (E.Editor T.Text Name)
+cBcc :: Lens' Compose (StatefulEditor T.Text Name)
 cBcc = lens _cBcc (\c x -> c { _cBcc = x })
 
-cSubject :: Lens' Compose (E.Editor T.Text Name)
+cSubject :: Lens' Compose (StatefulEditor T.Text Name)
 cSubject = lens _cSubject (\c x -> c { _cSubject = x })
-
-cTemp :: Lens' Compose T.Text
-cTemp = lens _cTemp (\c x -> c { _cTemp = x })
 
 cAttachments :: Lens' Compose (L.List Name MIMEMessage)
 cAttachments = lens _cAttachments (\c x -> c { _cAttachments = x })
@@ -663,13 +660,13 @@ fsEntryName = let toName (Directory n) = n
 
 data FileBrowser = CreateFileBrowser
   { _fbEntries :: FB.FileBrowser Name
-  , _fbSearchPath :: E.Editor FilePath Name
+  , _fbSearchPath :: StatefulEditor FilePath Name
   }
 
 fbEntries :: Lens' FileBrowser (FB.FileBrowser Name)
 fbEntries = lens _fbEntries (\cv x -> cv { _fbEntries = x })
 
-fbSearchPath :: Lens' FileBrowser (E.Editor FilePath Name)
+fbSearchPath :: Lens' FileBrowser (StatefulEditor FilePath Name)
 fbSearchPath = lens _fbSearchPath (\c x -> c { _fbSearchPath = x})
 
 -- | State needed to be kept for keeping track of

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -52,6 +52,7 @@ import UI.ComposeEditor.Main (attachmentsEditor, drawHeaders, renderConfirm)
 import UI.Draw.Main (renderEditorWithLabel)
 import Purebred.Events (firstGeneration)
 import Types
+import Brick.Widgets.StatefulEdit (StatefulEditor(..))
 
 -- * Synopsis
 --
@@ -170,7 +171,7 @@ initialState conf = do
             (ListWithLength (L.list ListOfMails mempty 1) (Just 0))
             (ListWithLength (L.list ListOfThreads mempty 1) (Just 0))
             firstGeneration
-            (E.editorText SearchThreadsEditor Nothing searchterms)
+            (StatefulEditor mempty $ E.editorText SearchThreadsEditor Nothing searchterms)
             (E.editorText ManageMailTagsEditor Nothing "")
             (E.editorText ManageThreadTagsEditor Nothing "")
             0
@@ -197,7 +198,7 @@ initialState conf = do
     path = view (confFileBrowserView . fbHomePath) conf
     fb = CreateFileBrowser
          fb'
-         (E.editor ManageFileBrowserSearchPath Nothing path)
+         (StatefulEditor mempty $ E.editor ManageFileBrowserSearchPath Nothing path)
     mailboxes = view (confComposeView . cvIdentities) conf
     epoch = UTCTime (fromGregorian 2018 07 18) 1
     async = Async Nothing

--- a/src/UI/ComposeEditor/Main.hs
+++ b/src/UI/ComposeEditor/Main.hs
@@ -41,6 +41,7 @@ import UI.Views (focusedViewWidget)
 import UI.Draw.Main (attachmentsHeader)
 import UI.Mail.Main (renderPart)
 import Types
+import Brick.Widgets.StatefulEdit (editEditorL)
 
 attachmentsEditor :: AppState -> Widget Name
 attachmentsEditor s =
@@ -74,12 +75,12 @@ makeLabel ComposeBcc = txt "Bcc:"
 makeLabel _ = txt "Subject:"
 
 widgetValue :: Name -> AppState -> T.Text
-widgetValue ComposeFrom = view (asCompose . cFrom . E.editContentsL . to currentLine)
-widgetValue ComposeTo = view (asCompose . cTo . E.editContentsL . to currentLine)
-widgetValue ComposeCc = view (asCompose . cCc . E.editContentsL . to currentLine)
-widgetValue ComposeBcc = view (asCompose . cBcc . E.editContentsL . to currentLine)
-widgetValue ComposeSubject = view (asCompose . cSubject . E.editContentsL . to currentLine)
-widgetValue _ = const T.empty
+widgetValue ComposeFrom = view (asCompose . cFrom . editEditorL . E.editContentsL . to currentLine)
+widgetValue ComposeTo = view (asCompose . cTo . editEditorL .  E.editContentsL . to currentLine)
+widgetValue ComposeCc = view (asCompose . cCc . editEditorL . E.editContentsL . to currentLine)
+widgetValue ComposeBcc = view (asCompose . cBcc . editEditorL . E.editContentsL . to currentLine)
+widgetValue ComposeSubject = view (asCompose . cSubject . editEditorL . E.editContentsL . to currentLine)
+widgetValue _ = mempty
 
 renderConfirm :: AppState -> Widget Name
 renderConfirm s = renderDialog (view (asCompose . cKeepDraft) s) $ hCenter emptyWidget

--- a/src/UI/FileBrowser/Main.hs
+++ b/src/UI/FileBrowser/Main.hs
@@ -24,6 +24,7 @@ import qualified Brick.Widgets.FileBrowser as FB
 import Control.Lens.Getter (view)
 import UI.Views (focusedViewWidget)
 import Types
+import Brick.Widgets.StatefulEdit (editEditorL)
 
 renderFileBrowser :: AppState -> Widget Name
 renderFileBrowser s = FB.renderFileBrowser True $ view (asFileBrowser . fbEntries) s
@@ -32,6 +33,6 @@ renderFileBrowserSearchPathEditor :: AppState -> Widget Name
 renderFileBrowserSearchPathEditor s =
   let hasFocus = ManageFileBrowserSearchPath == focusedViewWidget s
       editorDrawContent = str . unlines
-      inputW = E.renderEditor editorDrawContent hasFocus (view (asFileBrowser . fbSearchPath) s)
+      inputW = E.renderEditor editorDrawContent hasFocus (view (asFileBrowser . fbSearchPath . editEditorL) s)
       labelW = txt "Path: "
   in labelW <+> vLimit 1 inputW

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -71,6 +71,7 @@ import Types
 import Purebred.Tags (parseTagOps)
 import Purebred.Parsing.Text (niceEndOfInput)
 import UI.Validation (dispatchValidation)
+import Brick.Widgets.StatefulEdit (editEditorL)
 
 
 -- | Purebreds event handler. Either we can look up a function
@@ -114,30 +115,31 @@ composeFromHandler, composeToHandler, composeCcHandler, composeBccHandler, manag
      AppState -> Event -> Brick.EventM Name (Brick.Next AppState)
 
 composeFromHandler s e =
-  Brick.handleEventLensed s (asCompose . cFrom) E.handleEditorEvent e
+  Brick.handleEventLensed s (asCompose . cFrom . editEditorL) E.handleEditorEvent e
   >>= liftIO . runValidation
-  (preview (_Left . to GenericError) . parseOnly (mailboxList <* niceEndOfInput)) (asCompose . cFrom)
+  (preview (_Left . to GenericError) . parseOnly (mailboxList <* niceEndOfInput))
+  (asCompose . cFrom . editEditorL)
   >>= Brick.continue
 
 composeToHandler s e =
-  Brick.handleEventLensed s (asCompose . cTo) E.handleEditorEvent e
+  Brick.handleEventLensed s (asCompose . cTo . editEditorL) E.handleEditorEvent e
   >>= liftIO . runValidation
   (preview (_Left . to GenericError) . parseOnly (addressList <* niceEndOfInput))
-  (asCompose . cTo)
+  (asCompose . cTo . editEditorL)
   >>= Brick.continue
 
 composeCcHandler s e =
-  Brick.handleEventLensed s (asCompose . cCc) E.handleEditorEvent e
+  Brick.handleEventLensed s (asCompose . cCc . editEditorL) E.handleEditorEvent e
   >>= liftIO . runValidation
   (preview (_Left . to GenericError) . parseOnly (addressList <* niceEndOfInput))
-  (asCompose . cCc)
+  (asCompose . cCc . editEditorL)
   >>= Brick.continue
 
 composeBccHandler s e =
-  Brick.handleEventLensed s (asCompose . cBcc) E.handleEditorEvent e
+  Brick.handleEventLensed s (asCompose . cBcc . editEditorL) E.handleEditorEvent e
   >>= liftIO . runValidation
   (preview (_Left . to GenericError) . parseOnly (addressList <* niceEndOfInput))
-  (asCompose . cBcc)
+  (asCompose . cBcc . editEditorL)
   >>= Brick.continue
 
 manageMailTagHandler s e =
@@ -160,7 +162,9 @@ eventHandlerListOfThreads = EventHandler
 eventHandlerSearchThreadsEditor :: EventHandler 'Threads 'SearchThreadsEditor
 eventHandlerSearchThreadsEditor = EventHandler
   (asConfig . confIndexView . ivSearchThreadsKeybindings)
-  (\s -> Brick.continue <=< Brick.handleEventLensed s (asMailIndex . miSearchThreadsEditor) E.handleEditorEvent)
+  (\s ->
+     Brick.continue
+     <=< Brick.handleEventLensed s (asMailIndex . miSearchThreadsEditor . editEditorL) E.handleEditorEvent)
 
 eventHandlerViewMailManageMailTagsEditor :: EventHandler 'ViewMail 'ManageMailTagsEditor
 eventHandlerViewMailManageMailTagsEditor = EventHandler
@@ -224,7 +228,7 @@ eventHandlerThreadComposeTo = EventHandler
 eventHandlerThreadComposeSubject :: EventHandler 'Threads 'ComposeSubject
 eventHandlerThreadComposeSubject = EventHandler
   (asConfig . confIndexView . ivSubjectKeybindings)
-  (\s -> Brick.continue <=< Brick.handleEventLensed s (asCompose . cSubject) E.handleEditorEvent)
+  (\s -> Brick.continue <=< Brick.handleEventLensed s (asCompose . cSubject . editEditorL) E.handleEditorEvent)
 
 eventHandlerComposeFrom :: EventHandler 'ComposeView 'ComposeFrom
 eventHandlerComposeFrom = EventHandler
@@ -249,7 +253,7 @@ eventHandlerComposeBcc = EventHandler
 eventHandlerComposeSubject :: EventHandler 'ComposeView 'ComposeSubject
 eventHandlerComposeSubject = EventHandler
   (asConfig . confComposeView . cvSubjectKeybindings)
-  (\s -> Brick.continue <=< Brick.handleEventLensed s (asCompose . cSubject) E.handleEditorEvent)
+  (\s -> Brick.continue <=< Brick.handleEventLensed s (asCompose . cSubject . editEditorL) E.handleEditorEvent)
 
 eventHandlerConfirm :: EventHandler 'ComposeView 'ConfirmDialog
 eventHandlerConfirm = EventHandler
@@ -269,7 +273,9 @@ eventHandlerComposeFileBrowser = EventHandler
 eventHandlerManageFileBrowserSearchPath :: EventHandler 'FileBrowser 'ManageFileBrowserSearchPath
 eventHandlerManageFileBrowserSearchPath = EventHandler
   (asConfig . confFileBrowserView . fbSearchPathKeybindings)
-  (\s -> Brick.continue <=< Brick.handleEventLensed s (asFileBrowser . fbSearchPath) E.handleEditorEvent)
+  (\s ->
+     Brick.continue
+     <=< Brick.handleEventLensed s (asFileBrowser . fbSearchPath . editEditorL) E.handleEditorEvent)
 
 eventHandlerViewMailComposeTo :: EventHandler 'ViewMail 'ComposeTo
 eventHandlerViewMailComposeTo = EventHandler

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -43,6 +43,7 @@ import Types
 import Error
 import Config.Main (statusbarAttr, statusbarErrorAttr)
 import qualified Storage.Notmuch as Notmuch
+import Brick.Widgets.StatefulEdit (editEditorL)
 
 checkForNewMail :: BChan PurebredEvent -> FilePath -> Text -> Delay -> IO ()
 checkForNewMail chan dbpath query delay = do
@@ -78,7 +79,7 @@ statusbar s =
         Just e -> renderError e
         Nothing ->
             case focusedViewWidget s of
-                SearchThreadsEditor -> renderStatusbar (view (asMailIndex . miSearchThreadsEditor) s) s
+                SearchThreadsEditor -> renderStatusbar (view (asMailIndex . miSearchThreadsEditor . editEditorL) s) s
                 ManageMailTagsEditor -> renderStatusbar (view (asMailIndex . miMailTagsEditor) s) s
                 ManageThreadTagsEditor -> renderStatusbar (view (asMailIndex . miThreadTagsEditor) s) s
                 MailAttachmentOpenWithEditor -> renderStatusbar (view (asMailView . mvOpenCommand) s) s
@@ -91,9 +92,9 @@ statusbar s =
                 ComposeListOfAttachments -> renderStatusbar (views (asCompose . cAttachments) lwl s) s
                 MailListOfAttachments -> renderStatusbar (views (asMailView . mvAttachments) lwl s) s
                 ListOfFiles -> renderStatusbar (view (asFileBrowser . fbEntries) s) s
-                ComposeTo -> renderStatusbar (view (asCompose . cTo) s) s
-                ComposeFrom -> renderStatusbar (view (asCompose . cFrom) s) s
-                ComposeSubject -> renderStatusbar (view (asCompose . cSubject) s) s
+                ComposeTo -> renderStatusbar (view (asCompose . cTo . editEditorL) s) s
+                ComposeFrom -> renderStatusbar (view (asCompose . cFrom . editEditorL) s) s
+                ComposeSubject -> renderStatusbar (view (asCompose . cSubject . editEditorL) s) s
                 _ -> withAttr statusbarAttr $ str "Purebred: " <+> fillLine
 
 class WithContext a where


### PR DESCRIPTION
This adds a new editor widget in the Brick namespace. The widget is a
simple wrapper around the edit widget from Brick. However it can save
it's state and revert back to it. This is especially useful, if we want
to cancel input and not commit it to Purebred.

Note though, that some editors have not been changed to StatefulEditor
widgets. Reason being is that those don't really need to keep state. For
example the editors which change the tags on threads or mails. User's
supply operations. If they're empty, no tag operations are
performed. The editor contents are reset with every focus change.

Fixes https://github.com/purebred-mua/purebred/issues/396