### PR TITLE
Refactor focusing of views and widgets

### DIFF
--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -28,15 +28,15 @@ import Purebred
 
 scrollKeybindings :: ('Scrollable' w) => ['Keybinding' v w]
 scrollKeybindings =
-  [ 'Keybinding' (EvKey (KChar 'j') []) ('scrollDown' ``chain`` 'continue')
-  , Keybinding (EvKey (KChar 'k') []) ('scrollUp' \`chain\` continue)
-  , Keybinding (EvKey (KChar 'd') []) ('scrollPageDown' \`chain\` continue)
-  , Keybinding (EvKey (KChar 'u') []) ('scrollPageUp' \`chain\` continue)
+  [ 'Keybinding' (EvKey (KChar 'j') []) ('scrollDown' \`chain\` 'continue')
+  , Keybinding (EvKey (KChar 'k') []) ('scrollUp' \`chain\` 'continue')
+  , Keybinding (EvKey (KChar 'd') []) ('scrollPageDown' \`chain\` 'continue')
+  , Keybinding (EvKey (KChar 'u') []) ('scrollPageUp' \`chain\` 'continue')
   ]
 
 mailViewKeybindings =
-  [ Keybinding (EvKey (KChar 'J') []) ('listDown' ``chain'`` 'displayMail' \`chain\` continue)
-  , Keybinding (EvKey (KChar 'K') []) ('listUp' \`chain'` displayMail \`chain\` continue)
+  [ Keybinding (EvKey (KChar 'J') []) ('listDown' \`focus\` 'displayMail' \`chain\` continue)
+  , Keybinding (EvKey (KChar 'K') []) ('listUp' \`focus\` displayMail \`chain\` continue)
   , Keybinding (EvKey (KChar 'G') []) ('listJumpToEnd' \`chain\` continue)
   , Keybinding (EvKey (KChar 'g') []) ('listJumpToStart' \`chain\` continue)
   ]
@@ -48,7 +48,7 @@ main = 'purebred' $ tweak 'defaultConfig' where
     . over ('confHelpView' . 'hvKeybindings') (scrollKeybindings <>)
 @
 
-The invoke the program, just run @purebred@:
+Then invoke the program by running @purebred@.
 
 = Overriding the config directory
 

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -27,62 +27,55 @@ import Types
 
 composeSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
 composeSubjectKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
     ]
 
 composeFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
 composeFromKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
     ]
 
 composeToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
 composeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
     ]
 
 composeCcKeybindings :: [Keybinding 'ComposeView 'ComposeCc]
 composeCcKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
     ]
 
 composeBccKeybindings :: [Keybinding 'ComposeView 'ComposeBcc]
 composeBccKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
     ]
 
 confirmKeybindings :: [Keybinding 'ComposeView 'ConfirmDialog]
 confirmKeybindings =
   [ Keybinding
       (V.EvKey V.KEnter [])
-      (handleConfirm `chain'` focus @'Threads @'ListOfThreads `chain'`
-       reloadList `chain`
-       continue)
+      (handleConfirm `focus` reloadList `chain` continue)
   , Keybinding
       (V.EvKey (V.KChar 'q') [])
-      (noop `chain'`
-       focus @'ComposeView @'ComposeListOfAttachments `chain`
-       continue)
+      (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
   , Keybinding
       (V.EvKey V.KEsc [])
-      (noop `chain'`
-       focus @'ComposeView @'ComposeListOfAttachments `chain`
-       continue)
+      (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
   ]
 
 confirmAbort :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
 confirmAbort =
-  noop `chain'` focus @'ComposeView @'ConfirmDialog `chain`
-  continue
+  noop `focus` continue @'ComposeView @'ConfirmDialog
 
 listOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
 listOfAttachmentsKeybindings =
@@ -94,14 +87,14 @@ listOfAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'y') []) (done `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (noop `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'y') []) (done `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (noop `focus` continue @'Threads @'ListOfThreads)
     , Keybinding (V.EvKey (V.KChar 'e') []) edit
     , Keybinding (V.EvKey (V.KChar 'D') []) (delete `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'a') []) (noop `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 't') []) (noop `chain'` focus @'ComposeView @'ComposeTo `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'c') []) (noop `chain'` focus @'ComposeView @'ComposeCc `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'b') []) (noop `chain'` focus @'ComposeView @'ComposeBcc `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 's') []) (noop `chain'` focus @'ComposeView @'ComposeSubject `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'f') []) (noop `chain'` focus @'ComposeView @'ComposeFrom `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'a') []) (noop `focus` continue @'FileBrowser @'ListOfFiles)
+    , Keybinding (V.EvKey (V.KChar 't') []) (noop `focus` continue @'ComposeView @'ComposeTo)
+    , Keybinding (V.EvKey (V.KChar 'c') []) (noop `focus` continue @'ComposeView @'ComposeCc)
+    , Keybinding (V.EvKey (V.KChar 'b') []) (noop `focus` continue @'ComposeView @'ComposeBcc)
+    , Keybinding (V.EvKey (V.KChar 's') []) (noop `focus` continue @'ComposeView @'ComposeSubject)
+    , Keybinding (V.EvKey (V.KChar 'f') []) (noop `focus` continue @'ComposeView @'ComposeFrom)
     ]

--- a/src/UI/FileBrowser/Keybindings.hs
+++ b/src/UI/FileBrowser/Keybindings.hs
@@ -26,16 +26,16 @@ import Types
 -- | Default Keybindings
 fileBrowserKeybindings :: [Keybinding 'FileBrowser 'ListOfFiles]
 fileBrowserKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (noop `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` focus @'FileBrowser @'ManageFileBrowserSearchPath `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar ':') []) (noop `focus` continue @'FileBrowser @'ManageFileBrowserSearchPath)
     , Keybinding (V.EvKey V.KEnter []) (createAttachments `chain` continue)
     , Keybinding (V.EvKey (V.KChar '*') []) (fileBrowserToggleFile `chain` continue)
     ]
 
 manageSearchPathKeybindings :: [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
 manageSearchPathKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
-  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
-  , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'FileBrowser @'ListOfFiles `chain` continue)
+  [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'FileBrowser @'ListOfFiles)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'FileBrowser @'ListOfFiles)
+  , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'FileBrowser @'ListOfFiles)
   ]

--- a/src/UI/GatherHeaders/Keybindings.hs
+++ b/src/UI/GatherHeaders/Keybindings.hs
@@ -25,21 +25,21 @@ import UI.Actions
 
 gatherFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
 gatherFromKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` focus @'Threads @'ComposeTo `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (noop `focus` continue @'Threads @'ComposeTo)
     ]
 
 gatherToKeybindings :: [Keybinding 'Threads 'ComposeTo]
 gatherToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` focus @'Threads @'ComposeSubject `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (noop `focus` continue @'Threads @'ComposeSubject)
     ]
 
 gatherSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]
 gatherSubjectKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (noop `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` invokeEditor)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (noop `focus` invokeEditor @'ComposeView @'ComposeListOfAttachments)
     ]

--- a/src/UI/Help/Keybindings.hs
+++ b/src/UI/Help/Keybindings.hs
@@ -26,8 +26,8 @@ import Types
 -- | Default Keybindings
 helpKeybindings :: [Keybinding 'Help 'ScrollingHelpView]
 helpKeybindings =
-    [ Keybinding (EvKey KEsc []) (noop `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (EvKey (KChar 'q') []) (noop `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    [ Keybinding (EvKey KEsc []) (noop `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (EvKey (KChar 'q') []) (noop `focus` continue @'Threads @'ListOfThreads)
     , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)
     , Keybinding (EvKey (KChar ' ') []) (scrollPageDown `chain` continue)
     , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -27,12 +27,12 @@ browseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]
 browseThreadsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) quit
     , Keybinding (V.EvKey (V.KChar 'q') []) quit
-    , Keybinding (V.EvKey V.KEnter []) (displayThreadMails `chain'` focus @'ViewMail @'ListOfMails `chain'` selectNextUnread `chain'` displayMail `chain` continue)
-    , Keybinding (V.EvKey (V.KChar ':') []) (noop `chain'` focus @'Threads @'SearchThreadsEditor `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'm') []) (noop `chain'` focus @'Threads @'ComposeFrom `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` focus @'Threads @'ManageThreadTagsEditor `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (displayThreadMails `focus` selectNextUnread `focus` displayMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar ':') []) (noop `focus` continue @'Threads @'SearchThreadsEditor)
+    , Keybinding (V.EvKey (V.KChar 'm') []) (noop `focus` continue @'Threads @'ComposeFrom)
+    , Keybinding (V.EvKey (V.KChar '`') []) (noop `focus` continue @'Threads @'ManageThreadTagsEditor)
     , Keybinding (V.EvKey (V.KChar '\t') []) (switchComposeEditor `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` focus @'Help @'ScrollingHelpView `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '?') []) (noop `focus` continue @'Help @'ScrollingHelpView)
     , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
@@ -44,14 +44,14 @@ browseThreadsKeybindings =
 
 searchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]
 searchThreadsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'Threads @'ListOfThreads)
     ]
 
 manageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor]
 manageThreadTagsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` untoggleListItems @'Threads @'ListOfThreads `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` untoggleListItems @'Threads @'ListOfThreads `chain` continue)
     ]

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -25,49 +25,50 @@ import Types
 
 displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 displayMailKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` focus @'Threads @'ListOfThreads `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `focus` continue @'Threads @'ListOfThreads)
     , Keybinding (V.EvKey V.KBS []) (scrollPageUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem `chain` listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
     , Keybinding (V.EvKey (V.KChar ' ') []) (scrollPageDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'h') []) (toggleHeaders `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '`') []) (noop `chain'` focus @'ViewMail @'ManageMailTagsEditor `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '`') []) (noop `focus` continue @'ViewMail @'ManageMailTagsEditor)
 
-    , Keybinding (V.EvKey V.KUp []) (noop `chain'` focus @'ViewMail @'ListOfMails `chain` listUp `chain'` displayMail `chain` continue)
-    , Keybinding (V.EvKey V.KDown []) (noop `chain'` focus @'ViewMail @'ListOfMails `chain` listDown `chain'` displayMail `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain'` displayMail `chain` continue)
+    , Keybinding (V.EvKey V.KUp []) (
+        noop `focus` listUp @'ViewMail @'ListOfMails `focus` displayMail `chain` continue)
+    , Keybinding (V.EvKey V.KDown []) (
+        noop `focus` listDown @'ViewMail @'ListOfMails `focus` displayMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `focus` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'J') []) (noop
-                                             `chain'` listDown @'Threads @'ListOfThreads
-                                             `chain'` displayThreadMails
-                                             `chain'` selectNextUnread
-                                             `chain'` displayMail
+                                             `focus` listDown @'Threads @'ListOfThreads
+                                             `focus` displayThreadMails
+                                             `focus` selectNextUnread
+                                             `focus` displayMail
                                              `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain'` displayMail `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `focus` displayMail `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'K') []) (noop
-                                             `chain'` listUp @'Threads @'ListOfThreads
-                                             `chain'` displayThreadMails
-                                             `chain'` selectNextUnread
-                                             `chain'` displayMail
+                                             `focus` listUp @'Threads @'ListOfThreads
+                                             `focus` displayThreadMails
+                                             `focus` selectNextUnread
+                                             `focus` displayMail
                                              `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '?') []) (noop `chain'` focus @'Help @'ScrollingHelpView `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` invokeEditor)
-    , Keybinding (V.EvKey (V.KChar 'v') []) (noop `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'e') []) (composeAsNew `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '/') []) (noop `chain'` focus @'ViewMail @'ScrollingMailViewFindWordEditor `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '?') []) (noop `focus` continue @'Help @'ScrollingHelpView)
+    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `focus` invokeEditor @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'v') []) (noop `focus` continue @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'e') []) (composeAsNew `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '/') []) (noop `focus` continue @'ViewMail @'ScrollingMailViewFindWordEditor)
     , Keybinding (V.EvKey (V.KChar 'n') []) (scrollNextWord `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'f') []) (noop
                                              `chain` encapsulateMail
-                                             `chain'` focus @'ViewMail @'ComposeTo
-                                             `chain` continue)
+                                             `focus` continue @'ViewMail @'ComposeTo)
     , Keybinding (V.EvKey V.KEnter []) (removeHighlights `chain` continue)
     ]
 
 findWordEditorKeybindings :: [Keybinding 'ViewMail 'ScrollingMailViewFindWordEditor]
 findWordEditorKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
-  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
-  , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+  [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'ScrollingMailView)
+  , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ViewMail @'ScrollingMailView)
   ]
 
 
@@ -75,46 +76,47 @@ mailAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
 mailAttachmentsKeybindings =
     [ Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
     , Keybinding (V.EvKey V.KEnter []) openAttachment
-    , Keybinding (V.EvKey (V.KChar 'o') []) (noop `chain'` focus @'ViewMail @'MailAttachmentOpenWithEditor `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '|') []) (noop `chain'` focus @'ViewMail @'MailAttachmentPipeToEditor `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 's') []) (noop `chain'` focus @'ViewMail @'SaveToDiskPathEditor `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'o') []) (noop `focus` continue @'ViewMail @'MailAttachmentOpenWithEditor)
+    , Keybinding (V.EvKey (V.KChar '|') []) (noop `focus` continue @'ViewMail @'MailAttachmentPipeToEditor)
+    , Keybinding (V.EvKey (V.KChar 's') []) (noop `focus` continue @'ViewMail @'SaveToDiskPathEditor)
     ]
 
 openWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
 openWithKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `chain'` focus @'ViewMail @'MailAttachmentPipeToEditor `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'MailListOfAttachments `chain` openWithCommand)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `focus` continue @'ViewMail @'MailAttachmentPipeToEditor)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` openWithCommand)
     ]
 
 pipeToKeybindings :: [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
 pipeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `chain'` focus @'ViewMail @'MailAttachmentOpenWithEditor `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'MailListOfAttachments `chain` pipeToCommand)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `focus` continue @'ViewMail @'MailAttachmentOpenWithEditor)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` pipeToCommand)
     ]
 
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
 mailViewManageMailTagsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` untoggleListItems @'ViewMail @'ScrollingMailView `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` untoggleListItems @'ViewMail @'ScrollingMailView `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'ScrollingMailView)
     ]
 
 saveToDiskKeybindings :: [Keybinding 'ViewMail 'SaveToDiskPathEditor]
 saveToDiskKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
-  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'MailListOfAttachments `chain` continue)
-  , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ViewMail @'MailListOfAttachments `chain` saveAttachmentToPath `chain` continue)
+  [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
+  , Keybinding (V.EvKey V.KEnter []) (
+      done `chain` saveAttachmentToPath `focus` continue @'ViewMail @'MailListOfAttachments )
   ]
 
 mailviewComposeToKeybindings :: [Keybinding 'ViewMail 'ComposeTo]
 mailviewComposeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ViewMail @'ScrollingMailView `chain` continue)
-    , Keybinding (V.EvKey V.KEnter []) (done `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` invokeEditor)
+    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'ScrollingMailView)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` invokeEditor @'ComposeView @'ComposeListOfAttachments)
     ]

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -16,11 +16,11 @@
 
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 module TestActions where
 
 import qualified Brick.Widgets.List as L
+import qualified Brick.Types as T
 
 import Control.Lens
 import Test.Tasty (TestTree, testGroup)
@@ -34,18 +34,7 @@ import UI.Views (swapWidget)
 
 actionTests ::
   TestTree
-actionTests =
-    testGroup
-        "action tests"
-        [ testModeDescription
-        , testSwapBottom
-        ]
-
-testModeDescription :: TestTree
-testModeDescription = testCase "mode present in the switch action"
-                      $ view aDescription a @?= ["switch mode to ManageMailTagsEditor"]
-  where
-    a = focus @'ViewMail @'ManageMailTagsEditor
+actionTests = testGroup "action tests" [testSwapBottom]
 
 testSwapBottom :: TestTree
 testSwapBottom = testCase "swaps last visible widget" $ swapWidget ListOfThreads ManageThreadTagsEditor tiles @?= expected


### PR DESCRIPTION
Purebred had two chain combinators:

a) `chain` for chaining Action's of the same view/widget
b) `chain'` for chaining Action's of *different* view/widget

Furthermore, we had an action called `focus` which actually didn't focus
a view/widget, but rather ran setup/teardown code when view and widgets
were changed.

This is confusing.

This patch hopes to improve how Purebred makes focus changes.

a) The `chain'` combinator becomes 'focus' in order to make clear, that
we're focusing a new widget in a potentially different view.

b) The former `focus` Action is removed instead.

c) The `switchFocus` class method has been renamed to `onFocusSwitch` to
indicate the fact that this is not actually changing the focus to a view
or widget. Rather it runs code during a switch of focus to a different
widget.

d) The explicit view/widget specifier for Actions which can be used on
multiple views/widgets is now made on the right hand side of the `focus`
combinator.

Examples:

A former keybinding like:

    Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `chain'` focus @'ComposeView @'ComposeListOfAttachments `chain` continue)

becomes:

     Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)

This former keybinding:

     Keybinding (V.EvKey V.KEnter []) (handleConfirm `chain'` focus @'Threads @'ListOfThreads `chain'` reloadList `chain` continue)

becomes:

     Keybinding (V.EvKey V.KEnter []) (handleConfirm `focus` reloadList `chain` continue)


----

#