### PR TITLE
Fall back to previous view in case of an editor error

### DIFF
--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -6,8 +6,8 @@
 }:
 mkDerivation {
   pname = "brick";
-  version = "0.54";
-  sha256 = "1bce8104859986a3f871751de34f1876a3ece7632fe981d0cb267a1e00074281";
+  version = "0.55";
+  sha256 = "de09e03e8223ed10d0bddcbb836726b5849b7f9a092ab7b05942952311dca158";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -9,11 +9,12 @@ let
         purebred-email = hsuper.callPackage ./purebred-email.nix { };
         purebred-icu = hsuper.callPackage ./purebred-icu.nix { };
         tasty-tmux = hsuper.callPackage ./tasty-tmux.nix { };
-        brick = hsuper.callPackage ./brick.nix {};
         notmuch = hsuper.callPackage ./hs-notmuch.nix {
           notmuch = self.pkgs.notmuch;
           talloc = self.pkgs.talloc;
         };
+        brick = hsuper.callPackage ./brick.nix {};
+        vty = hsuper.callPackage ./vty.nix {};
       };
     };
   };

--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,7 +1,7 @@
 { compiler ? null, nixpkgs ? null}:
 
 let
-  compilerVersion = if isNull compiler then "ghc865" else compiler;
+  compilerVersion = if isNull compiler then "ghc884" else compiler;
   haskellPackagesOverlay = self: super: with super.haskell.lib; {
     haskellPackages = super.haskell.packages.${compilerVersion}.override {
       overrides = hself: hsuper: {
@@ -21,11 +21,12 @@ let
   pkgSrc =
     if isNull nixpkgs
     then
+    # nixpkgs master - 2020-07-31
     builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/b9cb3b2fb2f45ac8f3a8f670c90739eb34207b0e.tar.gz";
-      sha256 = "1cpjmsa2lwfxg55ac02w9arbd3y5617d19x91sd1fq521jqbnnpc";
+      url = "https://github.com/NixOS/nixpkgs/archive/b5613e78fd8431af680a00c0cdd42a0637601c3a.tar.gz";
+      sha256 = "1fn8j4r7hx3bl1amdwmw9lyccjci891igrf9pz3vgkfq1bpmqd65";
     }
     else
     nixpkgs;
 in
-  import pkgSrc { overlays = [ haskellPackagesOverlay ]; }
+import pkgSrc { overlays = [ haskellPackagesOverlay ]; }

--- a/.nix/purebred-email.nix
+++ b/.nix/purebred-email.nix
@@ -6,8 +6,8 @@
 }:
 mkDerivation {
   pname = "purebred-email";
-  version = "0.4.1";
-  sha256 = "e94e0696d6d92727a837519dfe1d9684bb650d54a35ef77d13175dfa40ab6d3a";
+  version = "0.4.2";
+  sha256 = "7e611e912d7fbaa482eb059481f4074a4053bcda7bbfd9fb602476cbac8b92a1";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/.nix/vty.nix
+++ b/.nix/vty.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, ansi-terminal, base, binary, blaze-builder
+, bytestring, Cabal, containers, deepseq, directory, filepath
+, hashable, HUnit, microlens, microlens-mtl, microlens-th, mtl
+, parallel, parsec, QuickCheck, quickcheck-assertions, random
+, smallcheck, stdenv, stm, string-qq, terminfo, test-framework
+, test-framework-hunit, test-framework-smallcheck, text
+, transformers, unix, utf8-string, vector
+}:
+mkDerivation {
+  pname = "vty";
+  version = "5.29";
+  sha256 = "eab7107cf3a0c56356aa75b2b7f98874b5725d9ac2031fad3695bf8c77404bbe";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    ansi-terminal base binary blaze-builder bytestring containers
+    deepseq directory filepath hashable microlens microlens-mtl
+    microlens-th mtl parallel parsec stm terminfo text transformers
+    unix utf8-string vector
+  ];
+  executableHaskellDepends = [
+    base containers directory filepath microlens microlens-mtl mtl
+  ];
+  testHaskellDepends = [
+    base blaze-builder bytestring Cabal containers deepseq HUnit
+    microlens microlens-mtl mtl QuickCheck quickcheck-assertions random
+    smallcheck stm string-qq terminfo test-framework
+    test-framework-hunit test-framework-smallcheck text unix
+    utf8-string vector
+  ];
+  homepage = "https://github.com/jtdaugherty/vty";
+  description = "A simple terminal UI library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/default.nix
+++ b/default.nix
@@ -43,7 +43,7 @@ let
     cabal-install
     cabal2nix
     ghcid
-    hindent
+    # hindent - currently broken
     hlint
     pkgs.notmuch
     pkgs.tmux

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -88,7 +88,7 @@ library
                      , deepseq >= 1.4.2
                      , dyre >= 0.8.12
                      , lens
-                     , brick >= 0.54
+                     , brick >= 0.55
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -35,6 +35,7 @@ module Purebred.System.Process
   , proc
   , shell
   , setStdin
+  , closed
   , byteStringInput
   ) where
 

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -861,7 +861,7 @@ openWithCommand =
       case cmd of
         [] -> lift . Brick.continue . setError (GenericError "Empty command") =<< get
         (x:xs) -> stateSuspendAndResume $
-          openCommand' (MailcapHandler (Process (x :| xs) []) IgnoreOutput DiscardTempfile)
+          openCommand' (MailcapHandler (Process (x :| xs) []) IgnoreOutput KeepTempfile)
     }
 
 -- | Wrapper for 'Brick.suspendAndResume' that reads state from

--- a/src/UI/GatherHeaders/Keybindings.hs
+++ b/src/UI/GatherHeaders/Keybindings.hs
@@ -22,6 +22,7 @@ module UI.GatherHeaders.Keybindings where
 import qualified Graphics.Vty as V
 import Types
 import UI.Actions
+import qualified Brick.Types as T
 
 gatherFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
 gatherFromKeybindings =
@@ -41,5 +42,10 @@ gatherSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]
 gatherSubjectKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey V.KEnter []) (noop `focus` invokeEditor @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter []) (
+        noop
+        `focus` (
+            invokeEditor Threads ListOfThreads
+            :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState))
+        )
     ]

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -22,6 +22,7 @@ module UI.Mail.Keybindings where
 import qualified Graphics.Vty as V
 import UI.Actions
 import Types
+import qualified Brick.Types as T
 
 displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 displayMailKeybindings =
@@ -53,7 +54,13 @@ displayMailKeybindings =
                                              `focus` displayMail
                                              `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `focus` continue @'Help @'ScrollingHelpView)
-    , Keybinding (V.EvKey (V.KChar 'r') []) (replyMail `focus` invokeEditor @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'r') []) (
+        replyMail
+        `focus` (
+            invokeEditor ViewMail ScrollingMailView
+            :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
+            )
+        )
     , Keybinding (V.EvKey (V.KChar 'v') []) (noop `focus` continue @'ViewMail @'MailListOfAttachments)
     , Keybinding (V.EvKey (V.KChar 'e') []) (composeAsNew `focus` continue @'ComposeView @'ComposeListOfAttachments)
     , Keybinding (V.EvKey (V.KChar '/') []) (noop `focus` continue @'ViewMail @'ScrollingMailViewFindWordEditor)
@@ -118,5 +125,10 @@ mailviewComposeToKeybindings :: [Keybinding 'ViewMail 'ComposeTo]
 mailviewComposeToKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'ScrollingMailView)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` invokeEditor @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter []) (
+        done `focus` (
+            invokeEditor ViewMail ScrollingMailView
+            :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
+            )
+        )
     ]


### PR DESCRIPTION
```
30d9d60 Bump purebred-email to latest 0.4.2 release

Apart from the fixes, we also need the higher package boundaries,
otherwise the nix builds will fail.

eb59fd9 nix: use new release and GHC 8.8.4

This pin's to a new nix release to avoid CI mostly fetching cached
packages instead of rebuilding the (Nix) world.

With bumping minimum versions for vty and brick, the minimum boundaries
of all transitive packages has shifted upwards, causing a lot of
derivations to be rebuilt due to the fact that they are not included in
the package closure of the former pinned versions.

a3b32ce Fall back to previous view in case of editor error

When Purebred is suspended and we hand control over to our editor, it is
possible that the editor errors (crashes, doesn't start, wrong editor,
yadda yadda).

Currently Purebred would simply go to the compose editor with an empty
attachment. That means that we could possibly send an email with an
empty body.

Instead, parameterize the `invokeEditor` function in which we give a
fallback view and widget. In cases of an error, we fall back to this
view and the focused widget.

Fixes: https://github.com/purebred-mua/purebred/issues/336
```