### PR TITLE
Fix intermittendly failing file browser test

### DIFF
--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -144,7 +144,8 @@ testReloadsThreadListAfterReply = purebredTmuxSession "reloads list of threads" 
     sendKeys "e" (Substring "Testmail with whitespace in the subject")
 
     step "navigate to latest attachment"
-    sendKeys "Down" (Substring "Item 2 of 2")
+    sendKeys "Down" (Substring "Item 2 of 2") >>= put
+    assertSubstringS "text/html"
 
     step "Remove HTML part"
     sendKeys "D" (Not (Substring "text/html")) >>= put

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -1109,10 +1109,12 @@ testAddAttachments = purebredTmuxSession "use file browser to add attachments" $
 
     -- try removing attachments
     step "select the attachment"
-    sendKeys "Down" (Substring "Item 2 of 2")
+    sendKeys "Down" (Substring "Item 2 of 2") >>= put
+    assertRegexS (buildAnsiRegex [] ["43"] [] <> "\\sA\\s" <> lastFile)
 
     step "remove the attachment"
-    sendKeys "D" (Not (Substring "screenshot.png"))
+    sendKeys "D" (Not (Substring lastFile)) >>= put
+    assertSubstringS "Item 1 of 1"
 
     step "try to remove the last attachment"
     sendKeys "D" (Substring "You may not remove the only attachment")


### PR DESCRIPTION
The change 47c72c27a93a0098749bf970c5ac2fe4482750e2 tried to address the
intermittendly failing test, but I think made the mistake of
"hardcoding" the file we assume to be removing from the attachment list.

The problem however is, that the list of files we're adding as
attachment varies with the environment. While the `screenshot.png` is
probably the attachment in most cases, it isn't the attachment
in **all** cases. The assertion that the next screen does not show a
file which we never added is always true.

Instead, firstly, this patch asserts that the last filename is actually
listed as an attachment. Secondly, we assert that when the attachment is
removed the last file from before is gone. Furthermore we also check
whether the item count has changed.

Fixes: https://github.com/purebred-mua/purebred/issues/327