### PR TITLE
Remove marked list item status from status bar

### DIFF
--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -117,7 +117,6 @@ renderStatusbar w s = withAttr statusbarAttr $ hBox
   , padLeftRight 1 (str "[")
   , renderNewMailIndicator s
   , renderMatches s
-  , renderToggled s
   , padLeft (Pad 1) (str "]")
   , fillLine
   , txt (
@@ -125,14 +124,6 @@ renderStatusbar w s = withAttr statusbarAttr $ hBox
       <> titleize (focusedViewWidget s) <> " "
       )
   ]
-
-renderToggled :: AppState -> Widget n
-renderToggled s =
-  let currentL = case focusedViewWidget s of
-        ListOfThreads -> length $ toListOf (asThreadsView . miListOfThreads . traversed . filtered fst) s
-        ListOfFiles -> length $ view (asFileBrowser . fbEntries . to FB.fileBrowserSelection) s
-        _ -> length $ toListOf (asThreadsView . miListOfMails . traversed . filtered fst) s
-  in if currentL > 0 then str $ "Marked: " <> show currentL else emptyWidget
 
 renderMatches :: AppState -> Widget n
 renderMatches s =


### PR DESCRIPTION
With the implementation in bulk actions in
e72afdb6827d4bde10dce97ce8f6fe4c4146d1f9 the status bar was showing how
many items were marked. However in order to figure this out, we actually
have to force the entire list items in order to find out how many are
marked. The list item itself only knows whether it's marked or not,
since it's hold this specific state.

This removes this code for now, since it's more important to be more
performant loading a lot of possible threads instead of showing how many
items the user marked. The amount of marked items is currently not done
programmatically and not know how many items there is most likely not a
feature what makes Purebred indistinguishable from the rest of mailers.

Fixes https://github.com/purebred-mua/purebred/issues/406