### PR TITLE
Better notification system

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -61,6 +61,7 @@ library
                      , UI.GatherHeaders.Keybindings
                      , UI.Mail.Main
                      , UI.Mail.Keybindings
+                     , UI.Notifications
                      , UI.Help.Main
                      , UI.Help.Keybindings
                      , UI.Utils

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2017-2019 Róman Joost and Fraser Tweedale
+-- Copyright (C) 2017-2021 Róman Joost and Fraser Tweedale
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -100,6 +100,8 @@ solarizedDark =
         , (editorLabelAttr, V.brightYellow `on` V.brightBlack)
         , (editorErrorAttr, fg V.red)
         , (statusbarErrorAttr, bg V.red)
+        , (statusbarInfoAttr, bg V.green)
+        , (statusbarWarningAttr, bg V.yellow)
         , (statusbarAttr, V.black `on` V.brightYellow)
         , (headerKeyAttr, fg V.cyan)
         , (headerValueAttr, fg V.brightCyan)
@@ -149,6 +151,12 @@ statusbarAttr = "statusbar"
 
 statusbarErrorAttr :: A.AttrName
 statusbarErrorAttr = statusbarAttr <> "error"
+
+statusbarInfoAttr :: A.AttrName
+statusbarInfoAttr = statusbarAttr <> "info"
+
+statusbarWarningAttr :: A.AttrName
+statusbarWarningAttr = statusbarAttr <> "warning"
 
 editorAttr :: A.AttrName
 editorAttr = E.editAttr

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -33,7 +33,6 @@ data Error
   | FileReadError FilePath IOError -- ^ failed to read a file
   | FileParseError FilePath String -- ^ failed to parse a file
   | SendMailError String
-  | GenericError String
   | ProcessError String
   | ParseError String
   deriving (Show, Eq)

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2019 Róman Joost
+-- Copyright (C) 2019-2021 Róman Joost
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -46,7 +46,7 @@ import Control.Exception (IOException)
 import Control.Monad.Catch (bracket, MonadMask)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Except (MonadError, throwError)
-import Control.Lens (_2, over, set, view)
+import Control.Lens (_2, over, view)
 import Data.Semigroup ((<>))
 import System.Process.Typed
 import System.IO.Temp (emptyTempFile, emptySystemTempFile)
@@ -67,6 +67,7 @@ import Error
 import Types
 import Purebred.System (tryIO, exceptionToError)
 import Purebred.Types.IFC
+import UI.Notifications (setUserMessage, makeError)
 
 
 -- | Handler to handle exit failures and possibly showing an error in the UI.
@@ -95,10 +96,7 @@ outputToText = untaint (sanitiseText . decodeLenient . LB.toStrict)
 
 -- | Handle only IOExceptions, everything else is fair game.
 handleIOException :: AppState -> IOException -> IO AppState
-handleIOException s = pure . flip setError s . exceptionToError
-
-setError :: Error -> AppState -> AppState
-setError = set asError . Just
+handleIOException s = pure . flip (setUserMessage . makeError StatusBar) s . exceptionToError
 
 -- | Try running a process given by the `FilePath` and catch an IOExceptions.
 -- This is to avoid a crashing process also take down the running Brick program.

--- a/src/Purebred/Tags.hs
+++ b/src/Purebred/Tags.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2017 Fraser Tweedale and Róman Joost
+-- Copyright (C) 2017-2021 Fraser Tweedale and Róman Joost
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -37,11 +37,10 @@ import Control.Lens (over, _Left)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
-import Notmuch (Tag, mkTag)
+import Notmuch (mkTag)
 
 import Types
-import Error
-
+import UI.Notifications (makeWarning)
 
 tagOp :: Parser TagOp
 tagOp =
@@ -67,8 +66,8 @@ tagOpsWithReset = do
   ops <- allTagOps
   pure $ r : ops
 
-parseTagOps :: T.Text -> Either Error [TagOp]
-parseTagOps = over _Left (GenericError . show) . parseOnly p . T.encodeUtf8
+parseTagOps :: T.Text -> Either UserMessage [TagOp]
+parseTagOps = over _Left (makeWarning StatusBar . T.pack) . parseOnly p . T.encodeUtf8
   where
   p =
     (tagOpsWithReset <|> allTagOps)

--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -61,6 +61,7 @@ import Prelude hiding (Word)
 import Data.MIME
 
 import Error
+import UI.Notifications (makeWarning)
 import Storage.Notmuch (mailFilepath)
 import Types
 import Purebred.System (tryIO)
@@ -153,7 +154,7 @@ bodyToDisplay s textwidth charsets prefCT msg =
   case chooseEntity prefCT msg of
     Nothing ->
       throwError
-        (GenericError $ "Unable to find preferred entity with: " <> show prefCT)
+        (ParseError $ "Unable to find preferred entity with: " <> show prefCT)
     Just entity ->
       let output =
             maybe
@@ -192,7 +193,7 @@ chooseEntity preferredContentType msg =
 entityToBytes :: (MonadError Error m) => WireEntity -> m B.ByteString
 entityToBytes msg = either err pure (convert msg)
   where
-    err e = throwError $ GenericError ("Decoding error: " <> show e)
+    err e = throwError $ ParseError ("Decoding error: " <> show e)
     convert :: WireEntity -> Either EncodingError B.ByteString
     convert m = view body <$> view transferDecoded m
 

--- a/src/UI/App.hs
+++ b/src/UI/App.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2017-2019 Róman Joost and Fraser Tweedale
+-- Copyright (C) 2017-2021 Róman Joost and Fraser Tweedale
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -46,7 +46,7 @@ import UI.Help.Main (renderHelp)
 import UI.Status.Main (statusbar)
 import UI.Views
        (indexView, mailView, composeView, helpView,
-        filebrowserView, focusedViewWidget, focusedViewWidgets,
+        filebrowserView, focusedViewWidget, visibleViewWidgets,
         focusedViewName)
 import UI.ComposeEditor.Main (attachmentsEditor, drawHeaders, renderConfirm)
 import UI.Draw.Main (renderEditorWithLabel)
@@ -75,7 +75,7 @@ import Brick.Widgets.StatefulEdit (StatefulEditor(..))
 -- the widget.
 --
 drawUI :: AppState -> [Widget Name]
-drawUI s = vBox . fmap (renderWidget s (focusedViewName s)) <$> focusedViewWidgets s
+drawUI s = vBox . fmap (renderWidget s (focusedViewName s)) <$> visibleViewWidgets s
 
 renderWidget :: AppState -> ViewName -> Name -> Widget Name
 renderWidget s _ ListOfThreads = renderListOfThreads s

--- a/src/UI/Draw/Main.hs
+++ b/src/UI/Draw/Main.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2017-2019 Róman Joost
+-- Copyright (C) 2017-2021 Róman Joost
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -31,12 +31,13 @@ import Brick.Widgets.Core
 import qualified Brick.Widgets.Edit as E
 import qualified Data.Text as T
 import Data.Proxy
-import Control.Lens (_Just, has, view)
+import Control.Lens (view)
 import Types
 import UI.Views (focusedViewWidget)
 import UI.Actions (HasName(..), HasEditor(..))
 import Config.Main
   (editorLabelAttr, editorAttr, editorFocusedAttr, statusbarAttr, editorErrorAttr)
+import UI.Notifications (hasError)
 
 -- | Fills the entire line with spaces. This can be used to draw a
 -- visual bar when an 'AttrName' with a background colour is set.
@@ -48,16 +49,15 @@ attachmentsHeader :: Widget Name
 attachmentsHeader = withAttr statusbarAttr $ hBox [ padLeft (Pad 1) (txt "-- Attachments") , vLimit 1 (fill '-')]
 
 editorDrawContent :: Bool -> [T.Text] -> Widget Name
-editorDrawContent hasError st = let widget = txt $ T.unlines st
-                                in if hasError then withAttr editorErrorAttr widget else widget
+editorDrawContent showError st = let widget = txt $ T.unlines st
+                                 in if showError then withAttr editorErrorAttr widget else widget
 
 -- | Renders editor with a label on the left restricted to one line
 renderEditorWithLabel ::
      (HasName n, HasEditor n) => Proxy n -> T.Text -> AppState -> Widget Name
 renderEditorWithLabel p label s =
   let hasFocus = name p == focusedViewWidget s
-      hasError = has (asError . _Just) s
-      inputW = E.renderEditor (editorDrawContent hasError) hasFocus (view (editorL p) s)
+      inputW = E.renderEditor (editorDrawContent (hasError s)) hasFocus (view (editorL p) s)
       labelW = withAttr editorLabelAttr $ padRight (Pad 1) $ txt label
       eAttr =
         if hasFocus

--- a/src/UI/Notifications.hs
+++ b/src/UI/Notifications.hs
@@ -1,0 +1,85 @@
+-- This file is part of purebred
+-- Copyright (C) 2021 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+{-# LANGUAGE FlexibleContexts #-}
+module UI.Notifications (
+  -- * Overview
+  -- $overview
+
+  -- * Setters on the AppState
+  setUserMessage
+
+  -- * Utilities
+  , hasError
+
+  -- * Factory functions
+  , makeInfo
+  , makeWarning
+  , makeError
+
+  -- * State Monad Setters
+  , showError
+  , showWarning
+  , showInfo
+  , showUserMessage
+  )
+where
+
+import Control.Lens (view, set, assign)
+import qualified Data.Text as T
+import Control.Monad.State
+
+import Types
+import Error
+
+{- $overview
+Notifications are one-line messages shown to the user. That can be
+Errors, Warnings or simply acknowledgement of actions.
+
+Note: If you want to make the 'UserMessage' visible between views in
+the UI, use a context which is always displayed. At this point
+'StatusBar' serves this purpose well.
+-}
+
+setUserMessage :: UserMessage -> AppState -> AppState
+setUserMessage = set asUserMessage . Just
+
+hasError :: AppState -> Bool
+hasError = go . view asUserMessage
+  where
+    go (Just (UserMessage _ (Error _))) = True
+    go _ = False
+
+showError :: (MonadState AppState m) => Error -> m ()
+showError = showUserMessage . makeError StatusBar
+
+showWarning :: (MonadState AppState m) => T.Text -> m ()
+showWarning = showUserMessage . makeWarning StatusBar
+
+showInfo :: (MonadState AppState m) => T.Text -> m ()
+showInfo = showUserMessage . makeInfo StatusBar
+
+showUserMessage :: (MonadState AppState m) => UserMessage -> m ()
+showUserMessage = assign asUserMessage . Just
+
+
+makeInfo :: Name -> T.Text -> UserMessage
+makeInfo n = UserMessage n . Info
+
+makeWarning :: Name -> T.Text -> UserMessage
+makeWarning n = UserMessage n . Warning
+
+makeError :: Name -> Error -> UserMessage
+makeError n = UserMessage n . Error

--- a/src/UI/Status/Main.hs
+++ b/src/UI/Status/Main.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2018 Róman Joost and Fraser Tweedale
+-- Copyright (C) 2018-2021 Róman Joost and Fraser Tweedale
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -41,8 +41,7 @@ import UI.Draw.Main (fillLine)
 import UI.Utils (titleize)
 import UI.Views (focusedViewWidget, focusedViewName)
 import Types
-import Error
-import Config.Main (statusbarAttr, statusbarErrorAttr)
+import Config.Main (statusbarAttr, statusbarErrorAttr, statusbarInfoAttr, statusbarWarningAttr)
 import qualified Storage.Notmuch as Notmuch
 import Brick.Widgets.StatefulEdit (editEditorL)
 
@@ -68,16 +67,15 @@ data StatusbarContext a
     | ErrorContext a
     deriving (Show)
 
-renderError :: Error -> Widget Name
-renderError = withAttr statusbarErrorAttr . hCenter . theError
-  where
-    theError (GenericError e) = strWrap e
-    theError e = strWrap (show e)
+renderUserMessage :: UserMessage -> Widget Name
+renderUserMessage (UserMessage _ (Warning t)) = withAttr statusbarWarningAttr $ hCenter $ txt t
+renderUserMessage (UserMessage _ (Info t)) = withAttr statusbarInfoAttr $ hCenter $ txt t
+renderUserMessage (UserMessage _ (Error e)) = withAttr statusbarErrorAttr $ hCenter $ strWrap (show e)
 
 statusbar :: AppState -> Widget Name
 statusbar s =
-    case view asError s of
-        Just e -> renderError e
+    case view asUserMessage s of
+        Just m -> renderUserMessage m
         Nothing ->
             case focusedViewWidget s of
                 SearchThreadsEditor -> renderStatusbar (view (asThreadsView . miSearchThreadsEditor . editEditorL) s) s

--- a/src/UI/Validation.hs
+++ b/src/UI/Validation.hs
@@ -26,7 +26,6 @@ import Data.Functor (($>))
 import Brick.BChan (writeBChan)
 
 import Types
-import Error
 
 
 -- | Schedules validation by sending a PurebredEvent.
@@ -37,8 +36,8 @@ import Error
 -- find a thread id already set and a new thread is scheduled.
 --
 dispatchValidation ::
-     (a -> Maybe Error)  -- ^ validation function
-  -> Lens' AppState (Maybe Error)
+     (a -> Maybe UserMessage)  -- ^ validation function
+  -> Lens' AppState (Maybe UserMessage)
   -> a
   -> AppState
   -> IO AppState

--- a/src/UI/Validation.hs
+++ b/src/UI/Validation.hs
@@ -22,7 +22,6 @@ module UI.Validation
 
 import Control.Concurrent (forkIO, killThread, threadDelay)
 import Control.Lens (Lens', set, view)
-import Data.Functor (($>))
 import Brick.BChan (writeBChan)
 
 import Types
@@ -42,7 +41,7 @@ dispatchValidation ::
   -> AppState
   -> IO AppState
 dispatchValidation fx l a s =
-  let go = maybe schedule (killThread $> schedule) . view (asAsync . aValidation)
+  let go = maybe schedule (\t -> killThread t *> schedule) . view (asAsync . aValidation)
       chan = view (asConfig . confBChan) s
       schedule =
         forkIO (sleepMs 500 >> writeBChan chan (InputValidated l (fx a)))

--- a/src/UI/Views.hs
+++ b/src/UI/Views.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2018-2019 Róman Joost
+-- Copyright (C) 2018-2021 Róman Joost
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -20,7 +20,7 @@ module UI.Views
   , helpView
   , filebrowserView
   , swapWidget
-  , focusedViewWidgets
+  , visibleViewWidgets
   , focusedViewWidget
   , focusedViewName
   , focusedView
@@ -39,8 +39,8 @@ import Types
 import Data.Foldable (toList)
 
 
-focusedViewWidgets :: AppState -> [[Name]]
-focusedViewWidgets s =
+visibleViewWidgets :: AppState -> [[Name]]
+visibleViewWidgets s =
   let defaultV = view (asConfig . confDefaultView) s
       focused = fromMaybe defaultV $ focusGetCurrent $ view (asViews . vsFocusedView) s
       allLayers = view (asViews . vsViews . ix focused . vLayers) s

--- a/test/TestActions.hs
+++ b/test/TestActions.hs
@@ -19,16 +19,11 @@
 
 module TestActions where
 
-import qualified Brick.Widgets.List as L
-import qualified Brick.Types as T
-
-import Control.Lens
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 import qualified Data.Vector as Vector
 
 import Types
-import UI.Actions
 import UI.Views (swapWidget)
 
 

--- a/test/TestTagParser.hs
+++ b/test/TestTagParser.hs
@@ -20,9 +20,9 @@ module TestTagParser where
 
 import Data.List (isInfixOf)
 
+import qualified Data.Text as T
 import Purebred.Tags
-import Types (TagOp(..))
-import Error
+import Types (TagOp(..), UserMessage(..), Name(..), MessageSeverity(..))
 
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit ((@=?), testCase, assertBool, assertFailure)
@@ -47,9 +47,9 @@ testParseTags =
               )
             , ( "wrong order"
               , \case
-                  Left (GenericError msg) ->
+                  Left (UserMessage StatusBar (Warning msg)) ->
                     assertBool "message indicates bad char"
-                    $ "unexpected '='" `isInfixOf` msg
+                    $ "unexpected '='" `isInfixOf` T.unpack msg
                   Left e ->
                     assertFailure $ "parse failed with unexpected error: " <> show e
                   Right _ ->


### PR DESCRIPTION
```
commit c248c50ce861d60f21f6b278145a1f2cbf749b4b (HEAD -> feature/286-notification-system, origin/feature/286-notification-system)
Author: Róman Joost <roman@bromeco.de>
Date:   Thu Jan 14 06:10:08 2021 +1000

    Remove unused imports

commit e2e70d8c3d4cb9a6e15e811c419415458deba3b7
Author: Róman Joost <roman@bromeco.de>
Date:   Tue Jan 12 19:37:44 2021 +1000

    Use the widget name to avoid overflowing notifications
    
    Some editors use real time validation. That is, per character we fire of
    a thread to validate, but kill the thread if the next character is
    received in less than 500ms.
    
    However, when the editor widget gets input too fast (e.g. tmux driven
    tests or to a lesser extend a copy & paste[1]) and the last character
    finishes the input (e.g. `Enter` to switch to the next input) the
    validation message "overflows" into the next widget.
    
    Instead, use the context information on the user message, to only show
    user messages for widgets still visible in the UI.
    
    [1] There is specific copy & paste support (aka bracketed paste). Only
    the quick succession of receiving input is meant in this context.
    
    Fixes: https://github.com/purebred-mua/purebred/issues/412

commit 52fcb19eab1db11777baf2349072ff53b8cd4edf
Author: Róman Joost <roman@bromeco.de>
Date:   Tue Jan 12 19:36:47 2021 +1000

    Fix validation
    
    The problem here is that `$>` sequenced the two actions so that
    `schedule` was the remaining action to be evaluated. That caused a
    scheduling of a thread per character input without killing any of the
    remaining threads.

commit 1ac5c3b6bdbf7952898bfa43182f37f703bedb04
Author: Róman Joost <roman@bromeco.de>
Date:   Thu Aug 13 07:08:47 2020 +1000

    Better notification system
    
    This implements an improvement to the current notification system.
    
    The `UserMessage` differenciates three levels of severity:
    
    * Info
    * Warning
    * Error
    
    That helps to remove most of the `GenericError` messages which were
    misused before as basic feedback.
    
    Furthermore this adds a context, so we can later filter out if messages
    are relevant to be visible or not.
    
    Fixes: https://github.com/purebred-mua/purebred/issues/286

```