### PR TITLE
add plugin system

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,7 +15,7 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 module Main where
 
-import Purebred (purebred, defaultConfig)
+import Purebred (purebred)
 
 main :: IO ()
-main = purebred defaultConfig
+main = purebred []

--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -59,7 +59,10 @@ fromMail =
     ]
 
 main :: IO ()
-main = purebred $ tweak defaultConfig where
+main = purebred
+  [ usePlugin $ tweakConfig tweak
+  ]
+  where
   tweak =
     over (confIndexView . ivBrowseThreadsKeybindings) (`union` myBrowseThreadsKbs)
     . over (confMailView . mvKeybindings) (`union` myMailKeybindings)

--- a/docs/man/index.adoc
+++ b/docs/man/index.adoc
@@ -124,8 +124,11 @@ myMailKeybindings =
 
 -- Tweak the default configuration before starting Purebred
 main :: IO ()
-main = purebred $ tweak defaultConfig where
-  tweak = over (confMailView . mvKeybindings) (`union` myMailKeybindings)  -- <4>
+main = purebred
+  [ usePlugin $ tweakConfig tweak
+  ]
+  where
+  tweak = over (confMailView . mvKeybindings) (myMailKeybindings <>)  -- <4>
 
 ----
 <1> The type indicates that this list holds key bindings for the
@@ -135,10 +138,9 @@ and adding labels.
 <3> Every keybinding will have to end with a Brick event loop
 action. The `continue` action continues the event loop and therefore
 Purebred.
-<4> For the custom key bindings to take effect, register them when
-calling `purebred`. We rely heavily on the use
-of <<lens>> functions to
-overwrite the default keybindings by `union` the default list with our
+<4> Add the custom key bindings to the configuration (via the `tweakPlugin`
+plugin).  Use <<lens>> functions to prepend the custom keybindings to the
+default keybindings.
 custom list.
 
 

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -82,9 +82,11 @@ library
                      , Brick.Widgets.StatefulEdit
                      , Purebred
                      , Purebred.Plugin
+                     , Purebred.Plugin.TweakConfig
                      , Purebred.Version
   other-modules:       Paths_purebred
                      , Purebred.Types.IFC
+                     , Purebred.Plugin.Internal
                      , Purebred.Plugin.UserAgent
   autogen-modules:     Paths_purebred
   build-depends:       base >= 4.11 && < 5

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -81,8 +81,11 @@ library
                      , Storage.ParsedMail
                      , Brick.Widgets.StatefulEdit
                      , Purebred
+                     , Purebred.Plugin
+                     , Purebred.Version
   other-modules:       Paths_purebred
                      , Purebred.Types.IFC
+                     , Purebred.Plugin.UserAgent
   autogen-modules:     Paths_purebred
   build-depends:       base >= 4.11 && < 5
                      , stm >= 2.4

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -33,6 +33,8 @@ import Data.Maybe (fromMaybe)
 import Data.List.NonEmpty (fromList)
 import System.Exit (ExitCode(..))
 
+import Control.Lens (set)
+
 import Data.MIME (contentTypeTextPlain, defaultCharsets, matchContentType)
 
 import UI.FileBrowser.Keybindings
@@ -56,7 +58,7 @@ import UI.ComposeEditor.Keybindings
 
 import Error
 import Types
-import Purebred.Plugin
+import Purebred.Plugin.Internal
 import qualified Purebred.Plugin.UserAgent
 import Purebred.System.Process
 import Purebred.Types.IFC (sanitiseText, untaint)
@@ -318,7 +320,7 @@ defaultConfig =
       , _fbHomePath = getHomeDirectory
       }
     , _confCharsets = defaultCharsets
-    , _confPlugins =
+    , _confPlugins = set pluginBuiltIn True <$>
         [ usePlugin Purebred.Plugin.UserAgent.plugin
         ]
     , _confExtra = ()

--- a/src/Config/Main.hs
+++ b/src/Config/Main.hs
@@ -20,7 +20,6 @@ module Config.Main where
 import qualified Brick.AttrMap as A
 import qualified Brick.Widgets.List as L
 import qualified Brick.Widgets.Dialog as D
-import Data.Monoid ((<>))
 import Brick.Util (fg, on, bg)
 import qualified Brick.Widgets.Edit as E
 import qualified Graphics.Vty as V
@@ -57,6 +56,8 @@ import UI.ComposeEditor.Keybindings
 
 import Error
 import Types
+import Purebred.Plugin
+import qualified Purebred.Plugin.UserAgent
 import Purebred.System.Process
 import Purebred.Types.IFC (sanitiseText, untaint)
 import Storage.Notmuch (getDatabasePath)
@@ -317,5 +318,8 @@ defaultConfig =
       , _fbHomePath = getHomeDirectory
       }
     , _confCharsets = defaultCharsets
+    , _confPlugins =
+        [ usePlugin Purebred.Plugin.UserAgent.plugin
+        ]
     , _confExtra = ()
     }

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -254,7 +254,7 @@ launch ghcOpts cfg = do
   logSink <- setupLogsink (debugFile opts)
   logSink (T.pack "Compile flags: " <> T.intercalate (T.pack " ") (T.pack <$> ghcOpts))
   logSink (T.pack "Opened log file")
-  cfg' <- processConfig (bchan, b, logSink) (pre cfg)
+  cfg' <- processConfig (InternalConfigurationFields bchan b logSink) (pre cfg)
 
   s <- initialState cfg'
   let buildVty = Graphics.Vty.mkVty Graphics.Vty.defaultConfig

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -172,7 +172,7 @@ import Types
 import Error
 import Purebred.Plugin
 import Purebred.Plugin.Internal
-  ( configHook, pluginBuiltIn, pluginName )
+  ( configHook, pluginBuiltIn, pluginName, pluginVersion )
 
 -- re-exports for configuration
 import qualified Graphics.Vty
@@ -232,7 +232,14 @@ fullVersionInfo plugins = unlines $
   , ""
   , "Configured plugins: "
   , ""
-  ] <> (views pluginName ("- " <>) <$> filter (views pluginBuiltIn not) plugins)
+  ] <> (showPlugin <$> filter (views pluginBuiltIn not) plugins)
+  where
+    showPlugin plug =
+      let
+        nam = view pluginName plug
+        ver = view pluginVersion plug
+      in
+        "- " <> nam <> " " <> showVersion ver
 
 
 optParser :: String -> ParserInfo AppConfig

--- a/src/Purebred/LazyVector.hs
+++ b/src/Purebred/LazyVector.hs
@@ -41,7 +41,6 @@ import qualified Data.List as L
 import Data.Monoid (Monoid(..))
 import Data.Ord (Ord(..))
 import Data.Semigroup (Semigroup(..))
-import Data.Traversable (Traversable)
 import Prelude ((+), (-), uncurry)
 import Text.Show (Show)
 

--- a/src/Purebred/Plugin.hs
+++ b/src/Purebred/Plugin.hs
@@ -14,14 +14,6 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MonoLocalBinds #-}
-{-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 {-|
 
 Types and helpers for plugins.
@@ -35,76 +27,13 @@ module Purebred.Plugin
 
   -- * Constructing a plugin
   , Plugin(..)
-  , pluginName
-  , preSendHook
 
-  -- * Hooks
+  -- ** Hooks
   , PreSendHook(..)
+  , ConfigHook(..)
 
-  -- * Hook capabilities
+  -- ** Capabilities
   , Pure, CanIO, CanReadConfig, CanRWAppState, Unconstrained
   ) where
 
-import Control.DeepSeq
-
-import Control.Lens (Lens', lens, set)
-import Control.Monad.Reader
-import Control.Monad.State
-
-import Data.MIME (MIMEMessage)
-
-import Types (AppState, InternalConfiguration)
-
-type Pure = Applicative
-type CanIO = MonadIO
-type CanRWAppState = MonadState AppState
-type CanReadConfig = MonadReader InternalConfiguration
-
-class (CanReadConfig m, CanIO m, CanRWAppState m) => Unconstrained m where
-instance (CanReadConfig m, CanIO m, CanRWAppState m) => Unconstrained m where
-
--- | Process a message before sending.
--- Available capabilities: __all__.
-newtype PreSendHook cap =
-  PreSendHook { getPreSendHook :: forall m. (cap m) => MIMEMessage -> m MIMEMessage }
-
--- | This is the internal plugin type; a flat record of all hook functions,
--- with relaxed constraints.  Plugin modules should provide a 'Plugin' instead.
--- 'usePlugin' converts a 'Plugin' to a 'PluginDict'.
---
-data PluginDict = PluginDict
-  { _pluginName :: String
-  , _preSendHook :: PreSendHook Unconstrained
-  }
-
-instance NFData PluginDict where
-  rnf (PluginDict name _) = force name `seq` ()
-
-pluginName :: Lens' PluginDict String
-pluginName = lens _pluginName (\s a -> s { _pluginName = a })
-
-preSendHook :: Lens' PluginDict (PreSendHook Unconstrained)
-preSendHook = lens _preSendHook (\s a -> s { _preSendHook = a })
-
-
-class Hook t where
-  setHook :: t -> PluginDict -> PluginDict
-
-instance (forall m. Unconstrained m => cap m) => Hook (PreSendHook cap) where
-  setHook (PreSendHook f) = set preSendHook (PreSendHook f)
-
-instance (Hook h1, Hook h2) => Hook (h1, h2) where
-  setHook (h1, h2) = setHook h1 . setHook h2
-
-instance Hook () where
-  setHook _ = id
-
--- | Plugin constructor.  Apply to the plugin name, and the hooks.
--- @hooks@ can be a single hook, or a nested tuple of hooks.
---
-data Plugin hooks = Plugin String hooks
-
--- | Convert a plugin to a `PluginDict`.
-usePlugin :: (Hook hooks) => Plugin hooks -> PluginDict
-usePlugin (Plugin name hook) = setHook hook $ PluginDict name
-  (PreSendHook pure)
+import Purebred.Plugin.Internal

--- a/src/Purebred/Plugin.hs
+++ b/src/Purebred/Plugin.hs
@@ -1,0 +1,110 @@
+-- This file is part of purebred
+-- Copyright (C) 2021 Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-|
+
+Types and helpers for plugins.
+
+-}
+module Purebred.Plugin
+  (
+  -- * Using plugins
+    usePlugin
+  , PluginDict
+
+  -- * Constructing a plugin
+  , Plugin(..)
+  , pluginName
+  , preSendHook
+
+  -- * Hooks
+  , PreSendHook(..)
+
+  -- * Hook capabilities
+  , Pure, CanIO, CanReadConfig, CanRWAppState, Unconstrained
+  ) where
+
+import Control.DeepSeq
+
+import Control.Lens (Lens', lens, set)
+import Control.Monad.Reader
+import Control.Monad.State
+
+import Data.MIME (MIMEMessage)
+
+import Types (AppState, InternalConfiguration)
+
+type Pure = Applicative
+type CanIO = MonadIO
+type CanRWAppState = MonadState AppState
+type CanReadConfig = MonadReader InternalConfiguration
+
+class (CanReadConfig m, CanIO m, CanRWAppState m) => Unconstrained m where
+instance (CanReadConfig m, CanIO m, CanRWAppState m) => Unconstrained m where
+
+-- | Process a message before sending.
+-- Available capabilities: __all__.
+newtype PreSendHook cap =
+  PreSendHook { getPreSendHook :: forall m. (cap m) => MIMEMessage -> m MIMEMessage }
+
+-- | This is the internal plugin type; a flat record of all hook functions,
+-- with relaxed constraints.  Plugin modules should provide a 'Plugin' instead.
+-- 'usePlugin' converts a 'Plugin' to a 'PluginDict'.
+--
+data PluginDict = PluginDict
+  { _pluginName :: String
+  , _preSendHook :: PreSendHook Unconstrained
+  }
+
+instance NFData PluginDict where
+  rnf (PluginDict name _) = force name `seq` ()
+
+pluginName :: Lens' PluginDict String
+pluginName = lens _pluginName (\s a -> s { _pluginName = a })
+
+preSendHook :: Lens' PluginDict (PreSendHook Unconstrained)
+preSendHook = lens _preSendHook (\s a -> s { _preSendHook = a })
+
+
+class Hook t where
+  setHook :: t -> PluginDict -> PluginDict
+
+instance (forall m. Unconstrained m => cap m) => Hook (PreSendHook cap) where
+  setHook (PreSendHook f) = set preSendHook (PreSendHook f)
+
+instance (Hook h1, Hook h2) => Hook (h1, h2) where
+  setHook (h1, h2) = setHook h1 . setHook h2
+
+instance Hook () where
+  setHook _ = id
+
+-- | Plugin constructor.  Apply to the plugin name, and the hooks.
+-- @hooks@ can be a single hook, or a nested tuple of hooks.
+--
+data Plugin hooks = Plugin String hooks
+
+-- | Convert a plugin to a `PluginDict`.
+usePlugin :: (Hook hooks) => Plugin hooks -> PluginDict
+usePlugin (Plugin name hook) = setHook hook $ PluginDict name
+  (PreSendHook pure)

--- a/src/Purebred/Plugin.hs
+++ b/src/Purebred/Plugin.hs
@@ -16,24 +16,146 @@
 
 {-|
 
-Types and helpers for plugins.
+The Purebred plugin system.
 
 -}
 module Purebred.Plugin
   (
   -- * Using plugins
+  -- $using
     usePlugin
   , PluginDict
 
-  -- * Constructing a plugin
+  -- ** Advanced usage for security-conscious users
+  -- $paranoia
+
+  -- * Defining plugins
+  -- $defining
   , Plugin(..)
 
+  -- ** Capabilities
+  -- $capabilities
+  , Pure, CanIO, CanReadConfig, CanRWAppState, Unconstrained
+
   -- ** Hooks
+  -- $hooks
   , PreSendHook(..)
   , ConfigHook(..)
-
-  -- ** Capabilities
-  , Pure, CanIO, CanReadConfig, CanRWAppState, Unconstrained
   ) where
 
 import Purebred.Plugin.Internal
+
+{- $using
+
+To use plugins, update your @~\/.config\/purebred\/purebred.hs@ to
+use the 'Purebred.purebredWithPlugins' entry point with a list of
+plugins.  Apply 'usePlugin' to each plugin value to prepare it for
+use.
+
+@
+main = 'Purebred.purebredWithPlugins'
+  [ 'usePlugin' ('Purebred.Plugin.TweakConfig.tweakConfig' tweak)
+  , 'usePlugin' Purebred.Plugin.ICU.plugin
+  ]
+@
+
+Some plugins could require additional configuration arguments.
+Refer to the documentation for individual plugin modules to find out
+how to configure them.
+
+Purebred plugins have the type @'Plugin' hooks@.  @hooks@ encodes
+the hooks implemented by the plugin, and the required capabilities.
+In this way, the plugin type is (machine-enforced) documentation
+about the possible range of plugin behaviour.
+
+-}
+
+{- $paranoia
+
+Security-conscious users can use type annotations to protect against
+plugins acquiring new capabilities upon upgrade.  In the example
+below, the ICU plugin is fixed at @ConfigHook Pure@.  If a new
+version changes to @ConfigHook CanIO@ or uses additional hooks, the
+program will not compile.  The user can decide whether to accept the
+new type (by updating the annotation), or remove the plugin.
+
+@
+main = 'Purebred.purebredWithPlugins'
+  [ 'usePlugin' (Purebred.Plugin.TweakConfig.tweakConfig tweak)
+  , 'usePlugin' (Purebred.Plugin.ICU.plugin :: 'Plugin' ('ConfigHook' 'Pure'))
+  ]
+@
+
+-}
+
+{- $defining
+
+The type of a plugin is @'Plugin' hooks@ where @hooks@ is either a
+single hook function newtype, or a nested tuple of hook functions.
+Many plugins will only use a single hook.  Some will use multiple
+hooks.
+
+To define a plugin, apply the 'Plugin' constructor to a plugin name,
+'Version', and hooks.  If the plugin requires user configuration (as
+in the following example), use function argument(s).
+
+@
+-- | Add a signature to outgoing messages
+signature :: Text -> Plugin (PreSendHook CanReadConfig)
+signature str = Plugin "UserAgent" version (PreSendHook hook)
+  where
+  hook msg = view confCharsets >>= manipulateTheMessage msg
+@
+
+Each hook has a set of /available/ capabilities, and plugins declare
+the /required/ capabilities for the implemented hooks.  Available
+capabilities differ and are documented at each hook newtype, and in
+the table below.
+
+-}
+
+{- $capabilities
+
+The plugin system defines the following capabilities.
+
++---------------------+--------------------------------+
+| Capabilitity        | Description                    |
+|                     |                                |
++=====================+================================+
+| 'Pure'              | The hook function can only     |
+|                     | perform a pure computation     |
+|                     | based on its input.            |
++---------------------+--------------------------------+
+| 'CanReadConfig'     | The hook function can read the |
+|                     | configuration via 'ask'.       |
++---------------------+--------------------------------+
+| 'CanRWAppState'     | The hook function can read and |
+|                     | write the 'AppState' via 'get' |
+|                     | and 'put'.                     |
++---------------------+--------------------------------+
+| 'CanIO'             | The hook function can perform  |
+|                     | I/O via 'liftIO'.              |
++---------------------+--------------------------------+
+| 'Unconstrained'     | Meta-capability that implies   |
+|                     | all defined capabilities.      |
++---------------------+--------------------------------+
+
+Not all capabilities are available to all hooks (see hooks table
+below).
+
+
+-}
+
+{- $hooks
+
++---------------------+----------------------------+------------------+
+| Hook                | Description                | Available        |
+|                     |                            | capabilities     |
++=====================+============================+==================+
+| 'ConfigHook'        | Modify config at startup   | 'CanIO'          |
++---------------------+----------------------------+------------------+
+| 'PreSendHook'       | Modify or process message  | 'Unconstrained'  |
+|                     | before sending             |                  |
++---------------------+----------------------------+------------------+
+
+-}

--- a/src/Purebred/Plugin.hs
+++ b/src/Purebred/Plugin.hs
@@ -48,12 +48,12 @@ import Purebred.Plugin.Internal
 {- $using
 
 To use plugins, update your @~\/.config\/purebred\/purebred.hs@ to
-use the 'Purebred.purebredWithPlugins' entry point with a list of
+use the 'Purebred.purebred' entry point with a list of
 plugins.  Apply 'usePlugin' to each plugin value to prepare it for
 use.
 
 @
-main = 'Purebred.purebredWithPlugins'
+main = 'Purebred.purebred'
   [ 'usePlugin' ('Purebred.Plugin.TweakConfig.tweakConfig' tweak)
   , 'usePlugin' Purebred.Plugin.ICU.plugin
   ]
@@ -80,7 +80,7 @@ program will not compile.  The user can decide whether to accept the
 new type (by updating the annotation), or remove the plugin.
 
 @
-main = 'Purebred.purebredWithPlugins'
+main = 'Purebred.purebred'
   [ 'usePlugin' (Purebred.Plugin.TweakConfig.tweakConfig tweak)
   , 'usePlugin' (Purebred.Plugin.ICU.plugin :: 'Plugin' ('ConfigHook' 'Pure'))
   ]

--- a/src/Purebred/Plugin.hs-boot
+++ b/src/Purebred/Plugin.hs-boot
@@ -1,0 +1,22 @@
+-- This file is part of purebred
+-- Copyright (C) 2021 Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+module Purebred.Plugin where
+
+import Control.DeepSeq
+
+data PluginDict
+instance NFData PluginDict

--- a/src/Purebred/Plugin/Internal.hs
+++ b/src/Purebred/Plugin/Internal.hs
@@ -114,7 +114,7 @@ instance (forall m. CanIO m => cap m) => Hook (ConfigHook cap) where
 --
 data Plugin hooks = Plugin String Version hooks
 
--- | Convert a plugin to a `PluginDict`.
+-- | Prepare a plugin for use in the main program.
 usePlugin :: (Hook hooks) => Plugin hooks -> PluginDict
 usePlugin (Plugin name ver hook) = setHook hook $ PluginDict name ver False
   (ConfigHook pure)

--- a/src/Purebred/Plugin/Internal.hs
+++ b/src/Purebred/Plugin/Internal.hs
@@ -1,0 +1,112 @@
+-- This file is part of purebred
+-- Copyright (C) 2021 Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Purebred.Plugin.Internal where
+
+import Control.DeepSeq
+
+import Control.Lens (Lens', lens, set)
+import Control.Monad.Reader
+import Control.Monad.State
+
+import Data.MIME (MIMEMessage)
+
+import Types (AppState, InternalConfiguration, UserConfiguration)
+
+type Pure = Applicative
+type CanIO = MonadIO
+type CanRWAppState = MonadState AppState
+type CanReadConfig = MonadReader InternalConfiguration
+
+class (CanReadConfig m, CanIO m, CanRWAppState m) => Unconstrained m where
+instance (CanReadConfig m, CanIO m, CanRWAppState m) => Unconstrained m where
+
+-- | This is the internal plugin type; a flat record of all hook functions,
+-- with relaxed constraints.  Plugin modules should provide a 'Plugin' instead.
+-- 'usePlugin' converts a 'Plugin' to a 'PluginDict'.
+--
+data PluginDict = PluginDict
+  { _pluginName :: String
+  , _pluginBuiltIn :: Bool
+  , _configHook :: ConfigHook CanIO
+  , _preSendHook :: PreSendHook Unconstrained
+  }
+
+instance NFData PluginDict where
+  rnf (PluginDict name builtin _ _) = force name `seq` force builtin `seq` ()
+
+pluginName :: Lens' PluginDict String
+pluginName = lens _pluginName (\s a -> s { _pluginName = a })
+
+pluginBuiltIn :: Lens' PluginDict Bool
+pluginBuiltIn = lens _pluginBuiltIn (\s a -> s { _pluginBuiltIn = a })
+
+configHook :: Lens' PluginDict (ConfigHook CanIO)
+configHook = lens _configHook (\s a -> s { _configHook = a })
+
+preSendHook :: Lens' PluginDict (PreSendHook Unconstrained)
+preSendHook = lens _preSendHook (\s a -> s { _preSendHook = a })
+
+
+class Hook t where
+  setHook :: t -> PluginDict -> PluginDict
+
+instance (Hook h1, Hook h2) => Hook (h1, h2) where
+  setHook (h1, h2) = setHook h1 . setHook h2
+
+instance Hook () where
+  setHook _ = id
+
+
+-- | Process a message before sending.
+-- Available capabilities: __all__.
+newtype PreSendHook cap =
+  PreSendHook { getPreSendHook :: forall m. (cap m) => MIMEMessage -> m MIMEMessage }
+
+instance (forall m. Unconstrained m => cap m) => Hook (PreSendHook cap) where
+  setHook (PreSendHook f) = set preSendHook (PreSendHook f)
+
+-- | Process the program configuration at program initialisation.
+-- Available capabilities: __CanIO__.
+newtype ConfigHook cap =
+  ConfigHook
+    { getConfigHook
+        :: forall m. (cap m)
+        => UserConfiguration -> m UserConfiguration
+    }
+
+instance (forall m. CanIO m => cap m) => Hook (ConfigHook cap) where
+  setHook (ConfigHook f) = set configHook (ConfigHook f)
+
+
+-- | Plugin constructor.  Apply to the plugin name, and the hooks.
+-- @hooks@ can be a single hook, or a nested tuple of hooks.
+--
+data Plugin hooks = Plugin String hooks
+
+-- | Convert a plugin to a `PluginDict`.
+usePlugin :: (Hook hooks) => Plugin hooks -> PluginDict
+usePlugin (Plugin name hook) = setHook hook $ PluginDict name False
+  (ConfigHook pure)
+  (PreSendHook pure)

--- a/src/Purebred/Plugin/Internal.hs-boot
+++ b/src/Purebred/Plugin/Internal.hs-boot
@@ -14,7 +14,7 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-module Purebred.Plugin where
+module Purebred.Plugin.Internal where
 
 import Control.DeepSeq
 

--- a/src/Purebred/Plugin/TweakConfig.hs
+++ b/src/Purebred/Plugin/TweakConfig.hs
@@ -29,7 +29,7 @@ tweak =
     set (confNotmuch . nmDatabase) (pure "\/home\/alice\/mail")
   . set (confNotmuch . nmNewTag) "inbox"
 
-main = purebredWithPlugins
+main = purebred
   [ usePlugin $ 'tweakConfig' tweak
   , ...
   ]

--- a/src/Purebred/Plugin/TweakConfig.hs
+++ b/src/Purebred/Plugin/TweakConfig.hs
@@ -1,0 +1,57 @@
+-- This file is part of purebred
+-- Copyright (C) 2021 Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-| Plugins for adjusting Purebred's configuration.
+
+You can use 'tweakConfig' to apply a pure transformation to the
+'UserConfiguration' at startup.
+
+@
+-- override notmuch database and "new" tag
+tweak =
+    set (confNotmuch . nmDatabase) (pure "\/home\/alice\/mail")
+  . set (confNotmuch . nmNewTag) "inbox"
+
+main = purebredWithPlugins
+  [ usePlugin $ 'tweakConfig' tweak
+  , ...
+  ]
+@
+
+The 'tweakConfigWithIO' variant allows the transform function to
+perform I/O.
+
+-}
+module Purebred.Plugin.TweakConfig where
+
+import Purebred.Plugin
+import Types (UserConfiguration)
+
+tweakConfig
+  :: (UserConfiguration -> UserConfiguration)
+  -> Plugin (ConfigHook Pure)
+tweakConfig hook =
+  Plugin "Purebred.Plugin.TweakConfig" (ConfigHook (pure . hook))
+
+tweakConfigWithIO
+  :: (forall m. CanIO m => UserConfiguration -> m UserConfiguration)
+  -> Plugin (ConfigHook CanIO)
+tweakConfigWithIO hook =
+  Plugin "Purebred.Plugin.TweakConfig (IO)" (ConfigHook hook)

--- a/src/Purebred/Plugin/TweakConfig.hs
+++ b/src/Purebred/Plugin/TweakConfig.hs
@@ -42,16 +42,17 @@ perform I/O.
 module Purebred.Plugin.TweakConfig where
 
 import Purebred.Plugin
+import Purebred.Version (version)
 import Types (UserConfiguration)
 
 tweakConfig
   :: (UserConfiguration -> UserConfiguration)
   -> Plugin (ConfigHook Pure)
 tweakConfig hook =
-  Plugin "Purebred.Plugin.TweakConfig" (ConfigHook (pure . hook))
+  Plugin "Purebred.Plugin.TweakConfig" version (ConfigHook (pure . hook))
 
 tweakConfigWithIO
   :: (forall m. CanIO m => UserConfiguration -> m UserConfiguration)
   -> Plugin (ConfigHook CanIO)
 tweakConfigWithIO hook =
-  Plugin "Purebred.Plugin.TweakConfig (IO)" (ConfigHook hook)
+  Plugin "Purebred.Plugin.TweakConfig (IO)" version (ConfigHook hook)

--- a/src/Purebred/Plugin/UserAgent.hs
+++ b/src/Purebred/Plugin/UserAgent.hs
@@ -1,0 +1,36 @@
+-- This file is part of purebred
+-- Copyright (C) 2021 Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-| Add a User-Agent header to outgoing messages. -}
+module Purebred.Plugin.UserAgent (plugin) where
+
+import Control.Lens (set, view)
+
+import Data.MIME (headerText)
+
+import Purebred.Plugin
+import Purebred.Version (userAgent)
+import Types
+
+plugin :: Plugin (PreSendHook CanReadConfig)
+plugin = Plugin "UserAgent" (PreSendHook hook)
+  where
+  hook msg = do
+    charsets <- view confCharsets
+    pure $ set (headerText charsets "User-Agent") (Just userAgent) msg

--- a/src/Purebred/Plugin/UserAgent.hs
+++ b/src/Purebred/Plugin/UserAgent.hs
@@ -25,11 +25,11 @@ import Control.Lens (set, view)
 import Data.MIME (headerText)
 
 import Purebred.Plugin
-import Purebred.Version (userAgent)
+import Purebred.Version (version, userAgent)
 import Types
 
 plugin :: Plugin (PreSendHook CanReadConfig)
-plugin = Plugin "UserAgent" (PreSendHook hook)
+plugin = Plugin "UserAgent" version (PreSendHook hook)
   where
   hook msg = do
     charsets <- view confCharsets

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -47,7 +47,6 @@ import Control.Monad.Catch (bracket, MonadMask)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Except (MonadError, throwError)
 import Control.Lens (_2, over, view)
-import Data.Semigroup ((<>))
 import System.Process.Typed
 import System.IO.Temp (emptyTempFile, emptySystemTempFile)
 import System.FilePath ((</>))

--- a/src/Purebred/Version.hs
+++ b/src/Purebred/Version.hs
@@ -1,0 +1,31 @@
+-- This file is part of purebred
+-- Copyright (C) 2021 Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE OverloadedStrings #-}
+
+{-| Version info and related data -}
+module Purebred.Version
+  ( version
+  , userAgent
+  ) where
+
+import qualified Data.Text as T
+import Data.Version (showVersion)
+
+import Paths_purebred (version)
+
+userAgent :: T.Text
+userAgent = "purebred/" <> T.pack (showVersion version)

--- a/src/Storage/Notmuch.hs
+++ b/src/Storage/Notmuch.hs
@@ -58,8 +58,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Except (MonadError, throwError, ExceptT, runExceptT)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as LB
-import Data.Traversable (traverse)
-import Data.List (union, notElem, nub, sort)
+import Data.List (union, nub, sort)
 import Data.Maybe (fromMaybe)
 import Data.Functor (($>))
 import qualified Data.Vector as Vec

--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -61,7 +61,6 @@ import Prelude hiding (Word)
 import Data.MIME
 
 import Error
-import UI.Notifications (makeWarning)
 import Storage.Notmuch (mailFilepath)
 import Types
 import Purebred.System (tryIO)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -145,7 +145,7 @@ module Types
     -- * Configuration
   , UserConfiguration
   , InternalConfiguration
-  , InternalConfigurationFields
+  , InternalConfigurationFields(..)
   , confBChan
   , confBoundary
   , confLogSink
@@ -626,7 +626,11 @@ data Configuration extra a b c = Configuration
     }
     deriving (Generic, NFData)
 
-type InternalConfigurationFields = (BChan PurebredEvent, String, LT.Text -> IO ())
+data InternalConfigurationFields = InternalConfigurationFields
+  { _bChan :: BChan PurebredEvent
+  , _boundary :: String
+  , _logSink :: LT.Text -> IO ()
+  }
 
 -- | The configuration from the user holding IO side effects. This
 -- configuration is evaluated to 'InternalConfiguration' by evaluating
@@ -673,13 +677,13 @@ confExtra :: Lens (Configuration extra a b c) (Configuration extra' a b c) extra
 confExtra = lens _confExtra (\cfg x -> cfg { _confExtra = x })
 
 confBChan :: Lens' InternalConfiguration (BChan PurebredEvent)
-confBChan = confExtra . _1
+confBChan = confExtra . lens _bChan (\s a -> s { _bChan = a })
 
 confBoundary :: Lens' InternalConfiguration String
-confBoundary = confExtra . _2
+confBoundary = confExtra . lens _boundary (\s a -> s { _boundary = a })
 
 confLogSink :: Lens' InternalConfiguration (LT.Text -> IO ())
-confLogSink = confExtra . _3
+confLogSink = confExtra . lens _logSink (\s a -> s { _logSink = a })
 
 
 data ComposeViewSettings = ComposeViewSettings

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -302,7 +302,7 @@ import Data.MIME
 
 import Brick.Widgets.StatefulEdit (StatefulEditor(..))
 import Error
-import {-# SOURCE #-} Purebred.Plugin
+import {-# SOURCE #-} Purebred.Plugin.Internal
 import Purebred.LazyVector (V)
 import Purebred.Types.IFC (Tainted)
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -161,6 +161,7 @@ module Types
   , confDefaultView
   , confFileBrowserView
   , confCharsets
+  , confPlugins
   , confExtra
 
     -- ** Notmuch Configuration
@@ -280,7 +281,6 @@ import Control.Lens
 import qualified Data.Map as Map
 import Control.Monad.State
 import Control.Monad.Except (MonadError)
-import Control.Monad.Reader (MonadIO)
 import Control.Concurrent (ThreadId)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as B
@@ -302,6 +302,7 @@ import Data.MIME
 
 import Brick.Widgets.StatefulEdit (StatefulEditor(..))
 import Error
+import {-# SOURCE #-} Purebred.Plugin
 import Purebred.LazyVector (V)
 import Purebred.Types.IFC (Tainted)
 
@@ -622,6 +623,7 @@ data Configuration extra a b c = Configuration
     , _confDefaultView :: ViewName
     , _confFileBrowserView :: FileBrowserSettings c
     , _confCharsets :: CharsetLookup
+    , _confPlugins :: [PluginDict]
     , _confExtra :: extra  -- data specific to a particular "phase" of configuration
     }
     deriving (Generic, NFData)
@@ -672,6 +674,9 @@ confFileBrowserView = lens _confFileBrowserView (\conf x -> conf { _confFileBrow
 
 confCharsets :: ConfigurationLens CharsetLookup
 confCharsets = lens _confCharsets (\conf x -> conf { _confCharsets = x })
+
+confPlugins :: ConfigurationLens [PluginDict]
+confPlugins = lens _confPlugins (\conf x -> conf { _confPlugins = x })
 
 confExtra :: Lens (Configuration extra a b c) (Configuration extra' a b c) extra extra'
 confExtra = lens _confExtra (\cfg x -> cfg { _confExtra = x })

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -168,7 +168,7 @@ import UI.Views
         focusedViewWidget)
 import Purebred.Events (nextGeneration)
 import Purebred.LazyVector (V)
-import Purebred.Plugin
+import Purebred.Plugin.Internal
 import Purebred.Tags (parseTagOps)
 import Purebred.System (tryIO)
 import Purebred.System.Process

--- a/src/UI/Keybindings.hs
+++ b/src/UI/Keybindings.hs
@@ -48,7 +48,6 @@ module UI.Keybindings (
   , eventHandlerViewMailComposeTo
   ) where
 
-import Control.Monad ((<=<))
 import qualified Brick.Types as Brick
 import qualified Brick.Main as Brick
 import qualified Brick.Widgets.Edit as E

--- a/tools/Keybinding.hs
+++ b/tools/Keybinding.hs
@@ -21,7 +21,7 @@ import Types
 main :: IO ()
 main = do 
   bchan <- newBChan 32
-  cfg' <- processConfig (bchan, "asdf", dummyLogSink) defaultConfig
+  cfg' <- processConfig (InternalConfigurationFields bchan "asdf" dummyLogSink) defaultConfig
   s <- initialState cfg'
   T.putStrLn (renderHelpAsAsciidoc s cfg')
 


### PR DESCRIPTION
Add a plugin system.  The design of the system is described in [1]
Also provide a built-in plugin to add the User-Agent header to
outgoing mail (fixes #414).

Further improvements to the system and documentation will follow in
subsequent commits.

[1] https://frasertweedale.github.io/blog-fp/posts/2021-02-02-plugin-system-prototype.html

Fixes: https://github.com/purebred-mua/purebred/issues/414