### PR TITLE
fix crash in substring search

### DIFF
--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -123,6 +123,7 @@ makeScrollSteps = mkScrollStep <$> itoListOf (indexing (mbParagraph . pLine . lM
 -- Note, that the matching is case sensitive.
 --
 findMatchingWords :: T.Text -> MailBody -> MailBody
+findMatchingWords     "" = removeMatchingWords
 findMatchingWords needle =
   over (mbParagraph . pLine) go
   where

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -492,6 +492,12 @@ testSubstringMatchesAreCleared = purebredTmuxSession "substring match indicator 
     step "enter needle and show results"
     sendKeys "et\r" (Substring "1 of 20 matches")
 
+    step "begin substring search"
+    sendKeys "/" (Substring "Search for")
+
+    step "enter empty search string (reset search)"
+    sendKeys "\r" (Not (Substring "matches ]"))
+
     step "go back to threads"
     sendKeys "Escape" (Regex "New:\\s[0-9]\\s+\\]\\s+Threads")
 


### PR DESCRIPTION
Purebred crashes when you enter an empty substring search term, due
to non-total Data.Text.breakOnAll.  Treat empty search term as a
"reset" operation and add UAT regression test.