### PR TITLE
stay in compose view if send fails

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -984,6 +984,13 @@ data Action (v :: ViewName) (ctx :: Name) a = Action
 instance NFData (Action v ctx a) where
   rnf (Action desc (StateT f)) = Action (force desc) (StateT (force f)) `seq` ()
 
+instance Functor (Action v ctx) where
+  fmap f (Action desc go) = Action desc (fmap f go)
+
+instance Applicative (Action v ctx) where
+  pure a = Action [] (pure a)
+  Action desc1 f <*> Action desc2 a = Action (desc1 <> desc2) (f <*> a)
+
 aAction :: Getter (Action v ctx a) (StateT AppState (EventM Name) a)
 aAction = to (\(Action _ b) -> b)
 

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -913,7 +913,7 @@ saveAttachmentToPath =
 -- | Chain sequences of actions to create a keybinding
 --
 chain :: Action v ctx a -> Action v ctx b -> Action v ctx b
-chain (Action d1 f1) (Action d2 f2) = Action (d1 <> d2) (f1 *> f2)
+chain = (*>)
 
 -- | /Special/ form of chain allowing to sequencing actions registered
 -- for a different view/widget. This is useful to perform actions on

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -102,6 +102,9 @@ module UI.Actions (
   , handleConfirm
   , fileBrowserToggleFile
 
+  -- ** Debug actions
+  , debug
+
   -- * API
   , applySearch
   , initialCompose
@@ -964,6 +967,12 @@ switchView = Action [desc] $ do
     next = show (viewname (Proxy @v')) <> "/" <> show (name (Proxy @ctx'))
     msg = "focus switch: " <> cur <> " -> " <> next
     desc = T.pack $ "focus " <> next
+
+-- | Log a debug message
+debug :: LT.Text -> Action v ctx ()
+debug msg = Action [] $ do
+  sink <- use (asConfig . confLogSink)
+  liftIO $ sink msg
 
 done :: forall a v. (HasViewName v, Completable a) => Action v a (CompletableResult a)
 done = Action ["apply"] (complete (Proxy @a))

--- a/src/UI/ComposeEditor/Keybindings.hs
+++ b/src/UI/ComposeEditor/Keybindings.hs
@@ -87,7 +87,8 @@ listOfAttachmentsKeybindings =
     , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
     , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'y') []) (done `focus` continue @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'y') [])
+        (ifte done (switchView @'Threads @'ListOfThreads) noop *> continue)
     , Keybinding (V.EvKey (V.KChar '\t') []) (noop `focus` continue @'Threads @'ListOfThreads)
     , Keybinding (V.EvKey (V.KChar 'e') []) edit
     , Keybinding (V.EvKey (V.KChar 'D') []) (delete `chain` continue)


### PR DESCRIPTION
If sending mail fails, we currently return to the thread index and the mail
is lost.  Update the send Action to be a conditional action.  On success,
return to the thread view.  But on failure, don't switch view.  As a
result, the user is able to take another action.  They can try sending
again, or save the mail as a draft.

Fixes: https://github.com/purebred-mua/purebred/issues/418
Related: https://github.com/purebred-mua/purebred/issues/294

```
289810c (Fraser Tweedale, 5 minutes ago)
   uat: add test for send failure handling

   Add a test for send failure handling.  We update the purebred.hs test
   configuration to recognise the PUREBRED_SEND_FAIL environment variable. 
   When defined and non-empty, the send action fails the first time, and
   succeeds thereafter.  This allows us to test that after a send failure:

   - purebred displays the error message
   - the compose view remains focused
   - the program is not stuck (user can retry send)

30355e1 (Fraser Tweedale, 63 minutes ago)
   stay in compose view if send fails

   If sending mail fails, we currently return to the thread index and the mail
   is lost.  Update the send Action to be a conditional action.  On success,
   return to the thread view.  But on failure, don't switch view.  As a
   result, the user is able to take another action.  They can try sending
   again, or save the mail as a draft.

   Fixes: https://github.com/purebred-mua/purebred/issues/418 Related:
   https://github.com/purebred-mua/purebred/issues/294

3a6a961 (Fraser Tweedale, 71 minutes ago)
   sendMail: improve error handling

   The subroutines invoked by `sendMail` have inconsistent error handling. 
   The result of `trySendAndCatch` gets written to the AppState, but then
   processing continues.  Purebred always tries to write and index a sent
   "file", even when sending failed.

   Update `trySendAndCatch` to return a result in `MonadError Error m`. Update
   `sendMail` to execute `trySendAndCatch` in the `runExceptT`. As a result,
   if sending fails, `sendMail` returns *that* error and does not attempt to
   write and index a "sent" file.

4142a18 (Fraser Tweedale, 75 minutes ago)
   add debug (log message) action

   Add an Action that can be used to log a debug message.  I found it useful
   while debugging an issue, so I figured others might find it useful too.

9bbd2b1 (Fraser Tweedale, 5 hours ago)
   add support for conditional actions

   Add `bindAction`, which makes it possible to decide how to act based on the
   result from the previous action.  This function is similar to
   `(>>=)` but `Action v ctx` does not have a lawful `Monad` instance.
   (The description of the second action gets ignored, thus disagreeing with
   the Applicative instance).

   Also add `ifte` ("if-then-else"), an action combinator that chooses the
   next action based on whether the previous action returned `True` or
   `False`.  Because the arguments are constant Action values, we can (and do)
   describe the behaviour of the combined action.

4a7644d (Fraser Tweedale, 5 hours ago)
   add action for switching focus

   Add an explicit action for switching view and focused widget. Refactor
   `focus` to use the behaviour of this widget.

   Also add `(!*>)` as a synonym of `focus`.

4429cb2 (Fraser Tweedale, 8 hours ago)
   add Functor and Applicative instances for Action

   Supply Functor and Applicative instances for `Action v ctx`.  `chain
   = (*>)`.

504d265 (Fraser Tweedale, 15 hours ago)
   sendMail: return Bool to signal success/failure

   To facilitate responding to send success or failure with different actions,
   enhance the `Completable` type class with an associated type family
   `CompletableResult`.  Update the
   `'ComposeListOfattachments` instance to return a `Bool`.

   This commit is just an interim step toward better handling of send failure
   and support for "reject send" plugins.  It does not change the behaviour of
   the program.
```