### PR TITLE
group reply

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -109,7 +109,7 @@ library
                      , filepath
                      , mtl
                      , exceptions
-                     , purebred-email >= 0.4.1 && < 0.5
+                     , purebred-email >= 0.5 && < 0.6
                      , attoparsec
                      , containers
                      , mime-types

--- a/src/Storage/ParsedMail.hs
+++ b/src/Storage/ParsedMail.hs
@@ -29,10 +29,6 @@ module Storage.ParsedMail (
   , makeScrollSteps
 
   -- ** Header data
-  , getTo
-  , getSubject
-  , getForwardedSubject
-  , getFrom
   , toQuotedMail
   , takeFileName
 
@@ -53,7 +49,6 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Catch (MonadMask)
 import Data.Foldable (toList)
 import qualified Data.ByteString as B
-import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as T
 import qualified System.FilePath as FP (takeFileName)
 import Prelude hiding (Word)
@@ -86,27 +81,6 @@ parseMail m dbpath = do
     >>= either (throwError . FileReadError filePath) pure
     >>= either (throwError . FileParseError filePath) pure
         . parse (message mime)
-
-getHeader :: CI.CI B.ByteString -> Message s a -> T.Text
-getHeader k =
-  maybe "header not found" decodeLenient
-  . firstOf (headers . header k)
-
-getFrom :: Message s a -> T.Text
-getFrom = getHeader "from"
-
-getSubject :: Message s a -> T.Text
-getSubject = getHeader "subject"
-
-getTo :: Message s a -> T.Text
-getTo = getHeader "to"
-
--- | Returns the subject line formatted for forwarding.
---
-getForwardedSubject ::
-     Message s a -- ^ the encapsulated mail
-  -> T.Text
-getForwardedSubject m = "[" <> getFrom m <> ": " <> getSubject m <> "]"
 
 -- | Create a list of steps to record which absolute positions
 -- brick/the terminal should scroll.

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -78,7 +78,8 @@ module UI.Actions (
   , displayThreadMails
   , toggleHeaders
   , switchComposeEditor
-  , replyMail
+  , senderReply
+  , groupReply
   , encapsulateMail
   , selectNextUnread
   , composeAsNew
@@ -1146,15 +1147,15 @@ encapsulateMail =
               (insertMany newSubj . clearZipper)
     }
 
--- | Update the 'AppState' with a quoted form of the first preferred
--- entity in order to reply to the e-mail.
 -- | Update the 'AppState' with a quoted version of the currently
 -- selected mail in order to reply to it.
 --
-replyMail :: Action 'ViewMail 'ScrollingMailView ()
-replyMail = Action
-  { _aDescription = ["reply to an e-mail"]
-  , _aAction = do
+senderReply, groupReply :: Action 'ViewMail 'ScrollingMailView ()
+senderReply = Action ["reply"] (replyWithMode ReplyToSender)
+groupReply = Action ["group-reply"] (replyWithMode ReplyToGroup)
+
+replyWithMode :: ReplyMode -> StateT AppState (T.EventM Name) ()
+replyWithMode mode = do
       mail <- use (asMailView . mvMail)
       charsets <- use (asConfig . confCharsets)
       case mail of
@@ -1167,7 +1168,7 @@ replyMail = Action
             idents = case mailboxes of
               [] -> pure $ Mailbox Nothing (AddrSpec "CHANGE.ME" (DomainDotAtom $ "YOUR" :| ["DOMAIN"]))
               (x:xs) -> x :| xs
-            settings = defaultReplySettings idents
+            settings = defaultReplySettings idents & set replyMode mode
           mbody <- use (asMailView . mvBody)
           let
             quoted = toQuotedMail charsets settings mbody m
@@ -1176,8 +1177,8 @@ replyMail = Action
           setText cTo (views (headerTo charsets) AddressText.renderAddresses quoted)
           setText cFrom (views (headerFrom charsets) AddressText.renderAddresses quoted)
           setText cSubject (views (headerSubject charsets) fold quoted)
+          setText cCc (views (headerCC charsets) AddressText.renderAddresses quoted)
           modifying (asCompose . cAttachments) (insertOrReplaceAttachment quoted)
-  }
 
 -- | Toggles whether we want to show all headers from an e-mail or a
 -- filtered list in the 'AppState'.

--- a/src/UI/Actions.hs
+++ b/src/UI/Actions.hs
@@ -134,11 +134,11 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.List (union)
 import qualified Data.Vector as Vector
 import Prelude hiding (readFile, unlines)
-import Data.Foldable (toList, traverse_)
+import Data.Foldable (fold, toList, traverse_)
 import Data.Functor.Identity (Identity(..))
 import Control.Lens
        (_Just, to, at, ix, _1, _2, toListOf, traversed, has,
-        filtered, set, over, preview, view, (&), firstOf, non, Traversal',
+        filtered, set, over, preview, view, views, (&), firstOf, non, Traversal',
         Getting, Lens', folded, assign, modifying, preuse, use, uses
         , Ixed, Index, IxValue)
 import Control.Concurrent (forkIO)
@@ -153,11 +153,10 @@ import Data.Time (getCurrentTime, getZonedTime)
 import System.Directory (doesPathExist)
 
 import qualified Data.RFC5322.Address.Text as AddressText
-  ( renderMailboxes, addressList, mailboxList )
 import Data.MIME
 import qualified Storage.Notmuch as Notmuch
 import Storage.ParsedMail
-       ( parseMail, getTo, getFrom, getSubject, getForwardedSubject, toQuotedMail
+       ( parseMail, toQuotedMail
        , entityToBytes, toMIMEMessage, takeFileName, bodyToDisplay
        , removeMatchingWords, findMatchingWords, makeScrollSteps
        , writeEntityToPath)
@@ -1136,10 +1135,15 @@ encapsulateMail =
         case mail of
           Nothing -> showWarning "No mail selected for forwarding"
           Just m -> do
+            charsets <- use (asConfig . confCharsets)
+            let
+              origSubj = views (headerSubject charsets) fold m
+              origFrom = views (headerFrom charsets) AddressText.renderAddresses m
+              newSubj = "[" <> origFrom <> ": " <> origSubj <> "]"
             modifying (asCompose . cAttachments)
               (L.listInsert 1 (encapsulate m) . L.listInsert 0 (createTextPlainMessage mempty))
             modifying (asCompose . cSubject . editEditorL . E.editContentsL)
-              (insertMany (getForwardedSubject m) . clearZipper)
+              (insertMany newSubj . clearZipper)
     }
 
 -- | Update the 'AppState' with a quoted form of the first preferred
@@ -1167,9 +1171,11 @@ replyMail = Action
           mbody <- use (asMailView . mvBody)
           let
             quoted = toQuotedMail charsets settings mbody m
-          modifying (asCompose . cTo . editEditorL . E.editContentsL) (insertMany (getTo quoted) . clearZipper)
-          modifying (asCompose . cFrom . editEditorL . E.editContentsL) (insertMany (getFrom quoted) . clearZipper)
-          modifying (asCompose . cSubject . editEditorL . E.editContentsL) (insertMany (getSubject quoted) . clearZipper)
+            setText l t = modifying (asCompose . l . editEditorL . E.editContentsL)
+                                    (insertMany t . clearZipper)
+          setText cTo (views (headerTo charsets) AddressText.renderAddresses quoted)
+          setText cFrom (views (headerFrom charsets) AddressText.renderAddresses quoted)
+          setText cSubject (views (headerSubject charsets) fold quoted)
           modifying (asCompose . cAttachments) (insertOrReplaceAttachment quoted)
   }
 

--- a/src/UI/Mail/Keybindings.hs
+++ b/src/UI/Mail/Keybindings.hs
@@ -55,7 +55,14 @@ displayMailKeybindings =
                                              `chain` continue)
     , Keybinding (V.EvKey (V.KChar '?') []) (noop `focus` continue @'Help @'ScrollingHelpView)
     , Keybinding (V.EvKey (V.KChar 'r') []) (
-        replyMail
+        senderReply
+        `focus` (
+            invokeEditor ViewMail ScrollingMailView
+            :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
+            )
+        )
+    , Keybinding (V.EvKey (V.KChar 'R') []) (
+        groupReply
         `focus` (
             invokeEditor ViewMail ScrollingMailView
             :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -573,10 +573,10 @@ testCursorPositionedEndOnReply = purebredTmuxSession "cursor positioned on EOL w
                                       <> "\"Joe Bloggs\" <joe@foo.test>, fromuser@foo.test")
 
     step "user can change to header"
-    sendKeys "t" (Regex $ "To: " <> buildAnsiRegex [] ["37"] [] <> "<frase@host.example>")
+    sendKeys "t" (Regex $ "To: " <> buildAnsiRegex [] ["37"] [] <> "frase@host.example")
 
     step "append an additional from email"
-    sendKeys ", touser@foo.test\r" (Substring "To: <frase@host.example>, touser@foo.test")
+    sendKeys ", touser@foo.test\r" (Substring "To: frase@host.example, touser@foo.test")
 
     step "change subject"
     sendKeys "s" (Regex $ "Subject: " <> buildAnsiRegex [] ["37"] [] <> ".*subject\\s+$")
@@ -986,7 +986,7 @@ testRepliesToMailSuccessfully = purebredTmuxSession "replies to mail successfull
     sendLine ": x" (Substring "Attachments") >>= put
 
     assertRegexS "From: \"Joe Bloggs\" <joe@foo.test>\\s+$"
-    assertSubstringS "To: <frase@host.example>"
+    assertSubstringS "To: frase@host.example"
     assertSubstringS ("Subject: Re: " <> subject)
 
     -- https://github.com/purebred-mua/purebred/issues/379


### PR DESCRIPTION
Implement group reply (#419).  Requires
https://github.com/purebred-mua/purebred-email/pull/63.

Also fix a bug where non-ASCII headers were presented with raw encoded-words
when replying.  This affected UI only, but was quite annoying.

```
88842ca (Fraser Tweedale, 2 days ago)
   add group reply

   Implement the group reply action and bind it to 'R'.

   Fixes: https://github.com/purebred-mua/purebred/issues/419

ed56ed5 (Fraser Tweedale, 3 days ago)
   reply: render non-ASCII headers properly

   When replying, purebred does not perform encoded-word decoding of the
   values of the To/From/Subject header fields.  As a consequence, raw
   encoded-words can appear in these values.

   Use the specific header optics provided by purebred-email and remove our
   buggy and unneeded helper functions.  As a result, headers with 
   encoded-words are presented with the values decoded.

   Also add a regression test to UAT suite.

55ae926 (Fraser Tweedale, 7 weeks ago)
   use purebred-email 0.5

   Bump to purebred-email 0.5.  Note the following:

   - Outbound mail now uses zoned time in the `Date` header.

   - Replying now uses the new `Data.RFC5322.reply` function.  This
    results in possible different rendering of the From/To/Cc fields
    of the reply.  For example, see the UAT changes in this commit.

   - If user has not set cvIdentities, a reply will be constructed with
    the default `From` address `CHANGE.ME@YOUR.DOMAIN`.
    `Data.RFC5322.reply` requires a `NonEmpty` list of author
    mailboxes because RFC 5322 requires all messages to have a `From`
    field.  A future change could use info from the environment to
    construct a better default email, but for now we just use this
    hardcoded, in-your-face default.
```