### PR TITLE
Update to Dyre 0.9

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -92,7 +92,7 @@ library
   build-depends:       base >= 4.11 && < 5
                      , stm >= 2.4
                      , deepseq >= 1.4.2
-                     , dyre >= 0.8.12
+                     , dyre >= 0.9.1
                      , lens
                      , brick >= 0.55
                      , text-zipper

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -157,10 +157,11 @@ module Purebred (
 
 import UI.App (theApp, initialState)
 
+import Control.Concurrent (rtsSupportsBoundThreads)
 import Purebred.System.Logging (setupLogsink)
 import qualified Config.Dyre as Dyre
 import qualified Control.DeepSeq
-import Control.Monad ((>=>), void)
+import Control.Monad ((>=>), void, unless)
 import Options.Applicative hiding (str)
 import qualified Options.Applicative.Builder as Builder
 import qualified Data.Text.Lazy as T
@@ -335,6 +336,7 @@ genBoundary = filter isBoundaryChar . randomRs (minimum boundaryChars, maximum b
 --
 purebred :: [PluginDict] -> IO ()
 purebred plugins = do
+  unless rtsSupportsBoundThreads (error "purebred was not compiled with -threaded")
   configDir <- lookupEnv "PUREBRED_CONFIG_DIR"
   ghcOptsEnv <- maybe [] words <$> lookupEnv "GHCOPTS"
   libdir <- getLibDir

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -342,11 +342,8 @@ purebred plugins = do
   let
     cfg = over confPlugins (plugins <>) defaultConfig
     ghcOpts = ghcOptsEnv
-    dyreParams = Dyre.defaultParams
-      { Dyre.projectName = "purebred"
-      , Dyre.realMain = launch ghcOpts
-      , Dyre.showError = const error
-      , Dyre.configDir = pure <$> configDir
+    dyreParams = (Dyre.newParams "purebred" (launch ghcOpts) (const error))
+      { Dyre.configDir = pure <$> configDir
       -- if config dir specified, also use it as cache dir to avoid
       -- clobbering cached binaries for other configurations
       , Dyre.cacheDir = pure <$> configDir


### PR DESCRIPTION
Dyre 0.9 has support for cabal store built in.  Update to 0.9 and remove our
own cabal store-related behaviour.

```
f6790da (Fraser Tweedale, 4 weeks ago)
   crash early if program was not compiled with -threaded

   It is better to crash with a clear error message than to hang when we enter
   the Brick main loop.  Dyre should take care of adding the
   '-threaded' option when compiling the custom executable, but add this check
   just in case.

32e5eda (Fraser Tweedale, 4 weeks ago)
   dyre: defaultParams -> newParams

   Avoid deprecated 'defaultParams'; use the new and improved
   'newParams'.

2346a1d (Fraser Tweedale, 4 weeks ago)
   dyre: use v0.9 to avoid work related to cabal store and -threaded

   Dyre v0.9 brings internal support for cabal store (it deduces
   -package-id from the extra include dirs).  Migrate to cabal 0.9 and remove
   our own cabal store-related behaviour.

   Dyre v0.9 also adds -threaded when the main executable is running with the
   threaded RTS.  We no longer need to explicitly provide
   '-threaded', so remove it.
```