### PR TITLE
Search related threads by author

### DIFF
--- a/src/Error.hs
+++ b/src/Error.hs
@@ -32,6 +32,7 @@ data Error
   | ThreadNotFound B.ByteString -- thread id
   | FileReadError FilePath IOError -- ^ failed to read a file
   | FileParseError FilePath String -- ^ failed to parse a file
+  | InvalidQueryError String -- ^ unable to perform notmuch query
   | SendMailError String
   | ProcessError String
   | ParseError String

--- a/src/UI/Index/Keybindings.hs
+++ b/src/UI/Index/Keybindings.hs
@@ -40,6 +40,7 @@ browseThreadsKeybindings =
     , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
     , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
     , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem `chain` listDown `chain` continue)
+    , Keybinding (V.EvKey (V.KChar '+') []) (searchRelated `chain` continue)
     ]
 
 searchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -128,7 +128,21 @@ main = do
       , testAbortedEditsResetState
       , testReloadsThreadListAfterReply
       , testAbortsCompositionIfEditorExits
+      , testSearchRelated
       ]
+
+testSearchRelated :: PurebredTestCase
+testSearchRelated = purebredTmuxSession "searches related" $
+  \step -> do
+    startApplication
+
+    capture >>= put
+    assertSubstringS "Item 1 of 4"
+    assertRegexS (buildAnsiRegex ["37"] ["43"] [] <> "\\sAug'17 frase@host.exa")
+
+    step "search related"
+    sendKeys "+" (Substring "Item 1 of 2") >>= put
+    assertRegexS ("Query:\\s" <> buildAnsiRegex ["34"] [] [] <> "frase@host.example")
 
 -- https://github.com/purebred-mua/purebred/issues/336
 testAbortsCompositionIfEditorExits :: PurebredTestCase


### PR DESCRIPTION
This implements a new Action which implements a related search. It picks
the first author of a thread and uses it as a full text search term.

Fixes https://github.com/purebred-mua/purebred/issues/111