### PR TITLE
Put an (invisible) cursor at the beginning of thread list items

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -94,7 +94,7 @@ library
                      , deepseq >= 1.4.2
                      , dyre >= 0.9.1
                      , lens
-                     , brick >= 0.55
+                     , brick >= 0.64
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0

--- a/src/UI/Index/Main.hs
+++ b/src/UI/Index/Main.hs
@@ -20,27 +20,27 @@ module UI.Index.Main (
     renderListOfThreads
   , renderListOfMails) where
 
-import           Brick.AttrMap       (AttrName, attrName)
-import           Brick.Types         (Location (..), Padding (..), Widget)
-import           Brick.Widgets.Core  (hBox, hLimitPercent, padLeft, padRight,
-                                      putCursor, txt, vLimit, withAttr, (<+>))
-import qualified Brick.Widgets.List  as L
-import           Control.Lens.Getter (view)
-import           Data.Text           as T (Text, pack, unpack, unwords)
-import           Data.Time.Clock     (NominalDiffTime, UTCTime (..),
-                                      diffUTCTime, nominalDay)
-import           Data.Time.Format    (defaultTimeLocale, formatTime)
+import Brick.Types (Padding(..), Widget)
+import Brick.AttrMap (AttrName, attrName)
+import Brick.Types (Location(..))
+import Brick.Widgets.Core
+  (hBox, hLimitPercent, padRight, padLeft, putCursor, txt, vLimit, withAttr, (<+>))
+import qualified Brick.Widgets.List as L
+import Control.Lens.Getter (view)
+import Data.Time.Clock
+       (UTCTime(..), NominalDiffTime, nominalDay, diffUTCTime)
+import Data.Time.Format (formatTime, defaultTimeLocale)
+import Data.Text as T (Text, pack, unpack, unwords)
 
-import           Notmuch             (getTag)
+import Notmuch (getTag)
 
-import           Config.Main         (listAttr, listStateNewmailAttr,
-                                      listStateSelectedAttr,
-                                      listStateToggledAttr, mailAuthorsAttr,
-                                      mailTagAttr)
-import           Storage.Notmuch     (ManageTags, hasTag)
-import           Types
-import           UI.Draw.Main        (fillLine)
-import           UI.Views            (focusedViewWidget)
+import UI.Draw.Main (fillLine)
+import UI.Views (focusedViewWidget)
+import Storage.Notmuch (hasTag, ManageTags)
+import Types
+import Config.Main
+  (listAttr, listStateNewmailAttr, listStateSelectedAttr,
+  listStateToggledAttr, mailAuthorsAttr, mailTagAttr)
 
 renderListOfThreads :: AppState -> Widget Name
 renderListOfThreads s = L.renderList (listDrawThread s (ListOfThreads == focusedViewWidget s)) True $ view (asThreadsView . miListOfThreads) s


### PR DESCRIPTION
This is for the benefit of screen readers which use the cursor position
as the primary focus indicator.
