### PR TITLE
nix: fix deprecation warning

### DIFF
--- a/.nix/purebred-email.nix
+++ b/.nix/purebred-email.nix
@@ -1,6 +1,6 @@
 { mkDerivation, attoparsec, base, base64-bytestring, bytestring
-, case-insensitive, concise, deepseq, hedgehog, lens, QuickCheck
-, quickcheck-instances, semigroupoids, semigroups, stdenv
+, case-insensitive, concise, deepseq, hedgehog, lens, lib
+, QuickCheck , quickcheck-instances, semigroupoids, semigroups
 , stringsearch, tasty, tasty-golden, tasty-hedgehog, tasty-hunit
 , tasty-quickcheck, text, time
 }:
@@ -22,5 +22,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/purebred-mua/purebred-email";
   description = "types and parser for email messages (including MIME)";
-  license = stdenv.lib.licenses.agpl3;
+  license = lib.licenses.agpl3;
 }

--- a/.nix/purebred-icu.nix
+++ b/.nix/purebred-icu.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, base, case-insensitive, fetchgit, lens, purebred
-, purebred-email, stdenv, text, text-icu
+{ mkDerivation, base, case-insensitive, fetchgit, lens, lib, purebred
+, purebred-email, text, text-icu
 }:
 mkDerivation {
   pname = "purebred-icu";
@@ -15,5 +15,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/purebred-mua/purebred-icu";
   description = "ICU charset support for purebred";
-  license = stdenv.lib.licenses.agpl3Plus;
+  license = lib.licenses.agpl3Plus;
 }

--- a/.nix/purebred.nix
+++ b/.nix/purebred.nix
@@ -1,8 +1,8 @@
 { mkDerivation, attoparsec, base, brick, bytestring
   , case-insensitive, containers, deepseq, directory, dyre
-  , exceptions, filepath, ini, lens, mime-types, mtl, notmuch
+  , exceptions, filepath, ini, lens, lib, mime-types, mtl, notmuch
   , optparse-applicative, purebred-email, quickcheck-instances
-  , random, regex-posix, stdenv, stm, tasty, tasty-hunit
+  , random, regex-posix, stm, tasty, tasty-hunit
   , tasty-quickcheck, temporary, text, text-zipper, time
   , typed-process, vector, vty
   , Cabal, tasty-tmux
@@ -30,5 +30,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/githubuser/purebred#readme";
   description = "An mail user agent built around notmuch";
-  license = stdenv.lib.licenses.agpl3;
+  license = lib.licenses.agpl3;
 }


### PR DESCRIPTION
I want to  try using purebred with nix flakes.  This came up because my nixpkgs is from the unstable branch and the `stdenv.lib` does not exist there any longer.

I ran `nix-build` on this branch to check that the move to lib was already possible on the nixpkgs commit you are pinning in .nix/nixpkgs.nix and it works.

Quick question: are you interested to switch the nix support to flakes?  After all you are already implementing one of its features with nixpkgs pinning by hand.  I have not investigated any further implications but I could open a PR.