### PR TITLE
Initialize flake

### DIFF
--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -13,13 +13,14 @@ let
       };
     };
   };
+  lock = builtins.fromJSON (builtins.readFile ../flake.lock);
   pkgSrc =
     if isNull nixpkgs
     then
     # nixpkgs nixos-unstable - 2021-01-06
     builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/266dc8c3d052f549826ba246d06787a219533b8f.tar.gz";
-      sha256 = "09ydqx2lznixmw8z4cfz1j3k137mh8n3cdpygwqymknhfdjq7lg4";
+      url = "https://github.com/NixOS/nixpkgs/archive/${lock.nodes.nixpkgs.locked.rev}.tar.gz";
+      sha256 = lock.nodes.nixpkgs.locked.narHash;
     }
     else
     nixpkgs;

--- a/HACKING
+++ b/HACKING
@@ -66,7 +66,7 @@ an application entirely written using Brick widgets only:
 
 ## Using Nix as a development environment
 
-The `nix-shell --arg with-icu true` command will give you a
+The `nix develop .#shell-with-icu` command will give you a
 development environment in which package dependencies for `purebred`
 and `purebred-icu` are installed. From there a typical compile/run
 session could look like this:
@@ -83,3 +83,5 @@ session could look like this:
 
     # run only acceptance tests containing 'user can abort'
     PATH=~/.cabal/bin:$PATH cabal --enable-nix test --show-details=streaming --test-option='-p /user can abort/' uat
+
+Legacy nix is also supported, check the `default.nix` file.

--- a/README.md
+++ b/README.md
@@ -57,18 +57,21 @@ repository which provides easily installable RPM packages.
 
 ### Nix
 
-If you're using the nix package manager - whether on NixOS or any other Linux distribution - you can build purebred too.
-You can use `nix-build` to try out purebred without installing it:
+If you're using the nix package manager - whether on NixOS or any other Linux
+distribution - you can build purebred too. You can use try out purebred without
+installing it:
 
 ```
-$ nix-build default.nix
+$ nix build && result/bin/purebred
 ```
 
-and `nix-env` to install the application:
+and `nix profile install` to install the application:
 
 ```
-$ nix-env --file default.nix --install
+$ nix profile install .#purebred-with-packages
 ```
+
+There is also a default.nix file to be used with legacy nix.
 
 ### Arch Linux
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1631663639,
+        "narHash": "sha256-5NGDZXPQzuoxf/42NiyC9YwwhwzfMfIRrz3aT0XHzSc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "266dc8c3d052f549826ba246d06787a219533b8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs }: {
+  outputs = { self, nixpkgs, utils }: {
 
     overlays = {
       purebred = final: prev: with prev.haskell.lib; {
@@ -21,17 +22,17 @@
         };
       };
     };
+  } // utils.lib.eachDefaultSystem (system:
+  let pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.purebred ]; };
+  in rec {
+    packages.purebred = pkgs.haskellPackages.purebred;
+    defaultPackage = packages.purebred;
 
-    packages.x86_64-linux.purebred =
-      let pkgs = import nixpkgs { system = "x86_64-linux"; overlays = [ self.overlays.purebred ]; };
-      in pkgs.haskellPackages.purebred;
-    defaultPackage.x86_64-linux = self.packages.x86_64-linux.purebred;
-
-#    devShell.x86_64-linux = nixpkgs.haskellPackages.shellFor {
+#    devShell = nixpkgs.haskellPackages.shellFor {
 #      withHoogle = true;
 #      packages = haskellPackages: [ haskellPackages.purebred ] ++ icuPackageDep haskellPackages;
 #      nativeBuildInputs = haskellPackages.purebred.env.nativeBuildInputs ++ nativeBuildTools;
 #    };
 
-  };
+  });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,8 @@
     };
 
     packages.x86_64-linux.purebred =
-      let pkgs = import nixpkgs { overlays = [ self.overlays.purebred ]; };
-      in pkgs.purebred;
+      let pkgs = import nixpkgs { system = "x86_64-linux"; overlays = [ self.overlays.purebred ]; };
+      in pkgs.haskellPackages.purebred;
     defaultPackage.x86_64-linux = self.packages.x86_64-linux.purebred;
 
 #    devShell.x86_64-linux = nixpkgs.haskellPackages.shellFor {

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,11 @@
       pkgs.asciidoctor
       pkgs.python3Packages.pygments
     ];
+    mkShell = with-icu: pkgs.haskellPackages.shellFor {
+      withHoogle = true;
+      packages = hp: [ hp.purebred ] ++ (if with-icu then [hp.purebred-icu] else []);
+      nativeBuildInputs = pkgs.haskellPackages.purebred.env.nativeBuildInputs ++ nativeBuildTools;
+    };
   in rec {
     packages = {
       purebred = pkgs.haskellPackages.purebred;
@@ -46,14 +51,11 @@
       purebred-icu = pkgs.haskellPackages.purebred-icu;
       dyre = pkgs.haskellPackages.dyre;
       brick = pkgs.haskellPackages.brick;
+      # shell "packages" for `nix develop .#shell-with/out-icu`
+      shell-without-icu = mkShell false;
+      shell-with-icu = mkShell true;
     };
     defaultPackage = packages.purebred;
-
-    devShell = pkgs.haskellPackages.shellFor {
-      withHoogle = true;
-      packages = haskellPackages: [ haskellPackages.purebred ] ;#++ icuPackageDep haskellPackages;
-      nativeBuildInputs = defaultPackage.env.nativeBuildInputs ++ nativeBuildTools;
-    };
-
+    devShell = packages.shell-without-icu;
   });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,11 @@
+{
+  description = "Purebred development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }: {
+
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,5 +7,31 @@
 
   outputs = { self, nixpkgs }: {
 
+    overlays = {
+      purebred = final: prev: with prev.haskell.lib; {
+        # TODO handle different compilers
+        haskellPackages = prev.haskell.packages.ghc884.override {
+          overrides = hself: hsuper: {
+            purebred = hsuper.callPackage .nix/purebred.nix { };
+            purebred-email = hsuper.callPackage .nix/purebred-email.nix { };
+            purebred-icu = hsuper.callPackage .nix/purebred-icu.nix { };
+            dyre = hsuper.callPackage .nix/dyre.nix { };
+            brick = hsuper.callPackage .nix/brick.nix { };
+          };
+        };
+      };
+    };
+
+    packages.x86_64-linux.purebred =
+      let pkgs = import nixpkgs { overlays = [ self.overlays.purebred ]; };
+      in pkgs.purebred;
+    defaultPackage.x86_64-linux = self.packages.x86_64-linux.purebred;
+
+#    devShell.x86_64-linux = nixpkgs.haskellPackages.shellFor {
+#      withHoogle = true;
+#      packages = haskellPackages: [ haskellPackages.purebred ] ++ icuPackageDep haskellPackages;
+#      nativeBuildInputs = haskellPackages.purebred.env.nativeBuildInputs ++ nativeBuildTools;
+#    };
+
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,16 +23,31 @@
       };
     };
   } // utils.lib.eachDefaultSystem (system:
-  let pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.purebred ]; };
+  let
+    pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.purebred ]; };
+    nativeBuildTools = with pkgs.haskellPackages; [
+      cabal-install
+      cabal2nix
+      ghcid
+      hlint
+      haskell-language-server
+      ormolu
+      hie-bios
+      pkgs.notmuch
+      pkgs.tmux
+      pkgs.gnumake
+      pkgs.asciidoctor
+      pkgs.python3Packages.pygments
+    ];
   in rec {
     packages.purebred = pkgs.haskellPackages.purebred;
     defaultPackage = packages.purebred;
 
-#    devShell = nixpkgs.haskellPackages.shellFor {
-#      withHoogle = true;
-#      packages = haskellPackages: [ haskellPackages.purebred ] ++ icuPackageDep haskellPackages;
-#      nativeBuildInputs = haskellPackages.purebred.env.nativeBuildInputs ++ nativeBuildTools;
-#    };
+    devShell = pkgs.haskellPackages.shellFor {
+      withHoogle = true;
+      packages = haskellPackages: [ haskellPackages.purebred ] ;#++ icuPackageDep haskellPackages;
+      nativeBuildInputs = defaultPackage.env.nativeBuildInputs ++ nativeBuildTools;
+    };
 
   });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,13 @@
       pkgs.python3Packages.pygments
     ];
   in rec {
-    packages.purebred = pkgs.haskellPackages.purebred;
+    packages = {
+      purebred = pkgs.haskellPackages.purebred;
+      purebred-email = pkgs.haskellPackages.purebred-email;
+      purebred-icu = pkgs.haskellPackages.purebred-icu;
+      dyre = pkgs.haskellPackages.dyre;
+      brick = pkgs.haskellPackages.brick;
+    };
     defaultPackage = packages.purebred;
 
     devShell = pkgs.haskellPackages.shellFor {


### PR DESCRIPTION
The aim of this PR is to switch to flakes.

# Open questions:

- Should `default.nix` be keept for interoerability with people who are not using flakes?
- Are you fine with inputs (dependencies) like https://github.com/numtide/flake-utils?
- Flakes do (to  my knowledge) not support arguments set from the command line.  The current default.nix uses that.  Should we create an extra derivation for every combination of arguments (compiler & icu) or are some of these arguments not needed any longer?  (The nixpkgs argument is a flake input and can be overwritten from the command line.)

# Plan

I marked this as a draft for now and I will push more commits and come back with questions.  Hopefully that will lead to some code that can be merged.  This is my first work with flakes (and second with nix) outside of my own system config, so please bear with me.
