### PR TITLE
refactor StatefulEditor

### DIFF
--- a/src/Purebred/Types.hs
+++ b/src/Purebred/Types.hs
@@ -302,7 +302,7 @@ import qualified Data.Vector as V
 import Notmuch (Tag)
 import Data.MIME
 
-import Purebred.UI.Widgets (StatefulEditor(..))
+import Purebred.UI.Widgets (StatefulEditor)
 import {-# SOURCE #-} Purebred.Plugin.Internal
 import Purebred.Types.Error
 import Purebred.Types.IFC (Tainted)

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -177,7 +177,7 @@ import Purebred.UI.Notifications
        (setUserMessage, makeWarning, showError, showWarning, showInfo
        , showUserMessage)
 import Purebred.UI.Widgets
-       (StatefulEditor(..), editEditorL, revertEditorState, saveEditorState)
+  ( statefulEditor, editEditorL, revertEditorState, saveEditorState )
 #if defined LAZYVECTOR
 import Purebred.Types.LazyVector (V)
 #endif
@@ -1578,11 +1578,11 @@ sanitizeMail charsets =
 initialCompose :: [Mailbox] -> Compose
 initialCompose mailboxes =
   Compose
-    (StatefulEditor mempty $ E.editorText ComposeFrom (Just 1) (AddressText.renderMailboxes mailboxes))
-    (StatefulEditor mempty $ E.editorText ComposeTo (Just 1) "")
-    (StatefulEditor mempty $ E.editorText ComposeCc (Just 1) "")
-    (StatefulEditor mempty $ E.editorText ComposeBcc (Just 1) "")
-    (StatefulEditor mempty $ E.editorText ComposeSubject (Just 1) "")
+    (statefulEditor $ E.editorText ComposeFrom (Just 1) (AddressText.renderMailboxes mailboxes))
+    (statefulEditor $ E.editorText ComposeTo (Just 1) "")
+    (statefulEditor $ E.editorText ComposeCc (Just 1) "")
+    (statefulEditor $ E.editorText ComposeBcc (Just 1) "")
+    (statefulEditor $ E.editorText ComposeSubject (Just 1) "")
     (L.list ComposeListOfAttachments mempty 1)
     initialDraftConfirmDialog
 
@@ -1600,11 +1600,11 @@ newComposeFromMail charsets m =
         view vector $ toMIMEMessage charsets <$> toListOf (_Just . entities) m
       orEmpty = view (non "")
    in Compose
-        (StatefulEditor mempty $ E.editorText ComposeFrom (Just 1) (orEmpty from))
-        (StatefulEditor mempty $ E.editorText ComposeTo (Just 1) (orEmpty to'))
-        (StatefulEditor mempty $ E.editorText ComposeCc (Just 1) (orEmpty cc))
-        (StatefulEditor mempty $ E.editorText ComposeBcc (Just 1) (orEmpty bcc))
-        (StatefulEditor mempty $ E.editorText ComposeSubject (Just 1) (orEmpty subject))
+        (statefulEditor $ E.editorText ComposeFrom (Just 1) (orEmpty from))
+        (statefulEditor $ E.editorText ComposeTo (Just 1) (orEmpty to'))
+        (statefulEditor $ E.editorText ComposeCc (Just 1) (orEmpty cc))
+        (statefulEditor $ E.editorText ComposeBcc (Just 1) (orEmpty bcc))
+        (statefulEditor $ E.editorText ComposeSubject (Just 1) (orEmpty subject))
         (L.list ComposeListOfAttachments attachments' 1)
         initialDraftConfirmDialog
 

--- a/src/Purebred/UI/App.hs
+++ b/src/Purebred/UI/App.hs
@@ -51,7 +51,7 @@ import Purebred.UI.Views
 import Purebred.UI.ComposeEditor.Main (attachmentsEditor, drawHeaders, renderConfirm)
 import Purebred.UI.Draw.Main (renderEditorWithLabel)
 import Purebred.Types
-import Purebred.UI.Widgets (StatefulEditor(..))
+import Purebred.UI.Widgets (statefulEditor)
 
 -- * Synopsis
 --
@@ -183,7 +183,7 @@ initialState conf = do
             (ListWithLength (L.list ListOfMails mempty 1) (Just 0))
             (ListWithLength (L.list ListOfThreads mempty 1) (Just 0))
             firstGeneration
-            (StatefulEditor mempty $ E.editorText SearchThreadsEditor Nothing searchterms)
+            (statefulEditor $ E.editorText SearchThreadsEditor Nothing searchterms)
             (E.editorText ManageMailTagsEditor Nothing "")
             (E.editorText ManageThreadTagsEditor Nothing "")
             0
@@ -210,7 +210,7 @@ initialState conf = do
     path = view (confFileBrowserView . fbHomePath) conf
     fb = CreateFileBrowser
          fb'
-         (StatefulEditor mempty $ E.editor ManageFileBrowserSearchPath Nothing path)
+         (statefulEditor $ E.editor ManageFileBrowserSearchPath Nothing path)
     mailboxes = view (confComposeView . cvIdentities) conf
     epoch = UTCTime (fromGregorian 2018 07 18) 1
     async = Async Nothing

--- a/src/Purebred/UI/Widgets.hs
+++ b/src/Purebred/UI/Widgets.hs
@@ -19,30 +19,24 @@
 -- order to roll it back. This is useful if newly changed editor state is
 -- to be canceled and to be rolled back to the previous state.
 module Purebred.UI.Widgets
-  ( StatefulEditor(..)
-  , editStateL
+  ( StatefulEditor
+  , statefulEditor
   , editEditorL
   , saveEditorState
   , revertEditorState
   ) where
 
-import Control.Lens (Lens', lens, view, set, to, over)
-import Data.Text.Zipper (currentLine, insertMany, clearZipper)
-import Brick.Widgets.Edit (Editor(..), editContentsL)
+import Control.Lens (Lens', lens)
+import Brick.Widgets.Edit (Editor)
 
 data StatefulEditor t n =
   StatefulEditor
-    { _editState :: t
+    { _editState :: Editor t n
     , _editEditor :: Editor t n
     }
 
-
--- | Access to the editors state.
--- Note: Do not rely on accessing the editor contents using this
--- lens. Always access the editor contents directly by accessing the
--- editor itself using 'editEditorL'.
-editStateL :: Lens' (StatefulEditor t n) t
-editStateL = lens _editState (\e v -> e { _editState = v})
+statefulEditor :: Editor t n -> StatefulEditor t n
+statefulEditor ed = StatefulEditor ed ed
 
 -- | Access to the underlying Brick Edit widget. 
 editEditorL :: Lens' (StatefulEditor t n) (Editor t n)
@@ -50,13 +44,9 @@ editEditorL = lens _editEditor (\e v -> e { _editEditor = v})
 
 -- | Save the editor state to potentially revert the editor back to it
 -- later.
-saveEditorState :: Monoid t => StatefulEditor t n -> StatefulEditor t n
-saveEditorState editor =
-  let contents = view (editEditorL . editContentsL . to currentLine) editor
-   in set editStateL contents editor
+saveEditorState :: StatefulEditor t n -> StatefulEditor t n
+saveEditorState (StatefulEditor _saved cur) = StatefulEditor cur cur
 
 -- | Revert the editor back to it's previously saved contents.
-revertEditorState :: Monoid t => StatefulEditor t n -> StatefulEditor t n
-revertEditorState editor =
-  let saved = view editStateL editor
-   in over (editEditorL . editContentsL) (insertMany saved . clearZipper) editor
+revertEditorState :: StatefulEditor t n -> StatefulEditor t n
+revertEditorState (StatefulEditor saved _cur)  = StatefulEditor saved saved


### PR DESCRIPTION
Refactor the `StatefulEditor` type and related functions.  Save the
whole `Editor` when creating a snapshot, which simplifies the
implementation.  Hide the constructor and the `_editState` field
accessor to prevent access to the saved editor state.  Add the
`statefulEditor` smart constructor which sets both the initial value
and the initial snapshot (to the same value).