### PR TITLE
simplify InputValidated event

### DIFF
--- a/src/Purebred/Types.hs
+++ b/src/Purebred/Types.hs
@@ -1226,9 +1226,7 @@ data PurebredEvent
   | NotifyNewMailArrived Int
   | -- | Event used for real time validation. Provides the setter in
     -- the 'AppState' to set the given 'UserMessage'.
-    InputValidated
-      (Lens' AppState (Maybe UserMessage))
-      (Maybe UserMessage)
+    InputValidated (Maybe UserMessage)
 
 data MessageSeverity
   = Error Error

--- a/src/Purebred/UI/App.hs
+++ b/src/Purebred/UI/App.hs
@@ -154,7 +154,7 @@ appEvent s (T.AppEvent ev) = case ev of
     then set (asThreadsView . miThreads . listLength) (Just n) s
     else s
   NotifyNewMailArrived n -> M.continue (set (asThreadsView . miNewMail) n s)
-  InputValidated l err -> M.continue . ($ s) $
+  InputValidated err -> M.continue . ($ s) $
     case err of
       -- No error at all. Clear any existing errors set in the state.
       Nothing -> set asUserMessage Nothing . set (asAsync . aValidation) Nothing
@@ -164,7 +164,7 @@ appEvent s (T.AppEvent ev) = case ev of
          in if widget `elem` allVisible
                -- Widget for this message is still visible, display
                -- the message and clear the thread ID.
-              then set l err . set (asAsync . aValidation) Nothing
+              then set asUserMessage err . set (asAsync . aValidation) Nothing
                -- Widget for this message is hidden, ignore the
                -- message, clear existing message and thread states.
               else set asUserMessage Nothing . set (asAsync . aValidation) Nothing

--- a/src/Purebred/UI/Keybindings.hs
+++ b/src/Purebred/UI/Keybindings.hs
@@ -103,7 +103,7 @@ runValidation ::
   -> AppState
   -> IO AppState
 runValidation fx l s =
-  dispatchValidation fx asUserMessage (view (l . E.editContentsL . to currentLine) s) s
+  dispatchValidation fx (view (l . E.editContentsL . to currentLine) s) s
 
 -- $eventhandlers
 -- Each event handler is handling a single widget in Purebreds UI

--- a/src/Purebred/UI/Validation.hs
+++ b/src/Purebred/UI/Validation.hs
@@ -37,15 +37,14 @@ import Purebred.Types
 --
 dispatchValidation ::
      (a -> Maybe UserMessage)  -- ^ validation function
-  -> Lens' AppState (Maybe UserMessage)
   -> a
   -> AppState
   -> IO AppState
-dispatchValidation fx l a s =
+dispatchValidation fx a s =
   let go = maybe schedule (\t -> killThread t *> schedule) . view (asAsync . aValidation)
       chan = view (asConfig . confBChan) s
       schedule =
-        forkIO (sleepMs 500 >> writeBChan chan (InputValidated l (fx a)))
+        forkIO (sleepMs 500 >> writeBChan chan (InputValidated (fx a)))
    in do tid <- go s
          pure $ set (asAsync . aValidation) (Just tid) s
 


### PR DESCRIPTION
The InputValidated event currently contains a Lens to the AppState
constituent that validation error messages should be written to.
But at the moment the only target is `asUserMessage`.  Furthermore,
some places use the optics whereas other places on the "sink" side
of the event channel still explicitly mention `asUserMessage` (e.g.
when clearing the message).

Simplify the type by removing the Lens argument.  Explicitly mention
`asUserMessage` in all places, eliminating the contradictions and
potential for confusion.

Perhaps we will need this behaviour again in the future - that is,
to specify the part of the AppState that a validation error shall be
written to.  If that happens, we will implement this behaviour
afresh, and hopefully avoid the aforementioned mistakes.