### PR TITLE
modules: extract several modules from Purebred.Types

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -64,9 +64,12 @@ library
                      , Purebred.Types
                      , Purebred.Types.Display
                      , Purebred.Types.Error
+                     , Purebred.Types.Event
                      , Purebred.Types.LazyVector
+                     , Purebred.Types.Mailcap
                      , Purebred.Types.Parser.ByteString
                      , Purebred.Types.Parser.Text
+                     , Purebred.Types.UI
                      , Purebred.UI.Actions
                      , Purebred.UI.App
                      , Purebred.UI.ComposeEditor.Keybindings

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -126,6 +126,7 @@ module Purebred (
   purebred,
   module Purebred.Plugin,
   module Purebred.Plugin.TweakConfig,
+  module Purebred.Storage.Tags,
   module Purebred.Types,
   module Purebred.Types.Error,
   module Purebred.UI.Actions,
@@ -182,6 +183,7 @@ import Purebred.Plugin.Internal
   ( configHook, pluginBuiltIn, pluginName, pluginVersion )
 import Purebred.Plugin.TweakConfig
 import Purebred.Storage.Notmuch (getDatabasePath)
+import Purebred.Storage.Tags (TagOp(..))
 import Purebred.Types.Error
 
 -- re-exports for configuration

--- a/src/Purebred/Storage/Notmuch.hs
+++ b/src/Purebred/Storage/Notmuch.hs
@@ -70,6 +70,7 @@ import Control.Lens (view, over, set, firstOf, folded, Lens')
 import qualified Notmuch
 
 import Purebred.Types
+import Purebred.Storage.Tags
 import Purebred.System.Process (readProcess, proc)
 import Purebred.System (tryIO)
 import Purebred.Types.Error

--- a/src/Purebred/Storage/Tags.hs
+++ b/src/Purebred/Storage/Tags.hs
@@ -22,7 +22,8 @@
 -- just means labelling all mails in a thread.
 --
 module Purebred.Storage.Tags
-  ( parseTag
+  ( TagOp(..)
+  , parseTag
   , parseTagOps
   ) where
 
@@ -40,6 +41,10 @@ import Notmuch (mkTag)
 import Purebred.Types
 import Purebred.Types.Parser.ByteString (niceEndOfInput, skipSpaces)
 import Purebred.UI.Notifications (makeWarning)
+
+-- | Tag operations
+data TagOp = RemoveTag Tag | AddTag Tag | ResetTags
+  deriving (Eq, Show)
 
 tagOp :: Parser TagOp
 tagOp =

--- a/src/Purebred/Types/Event.hs
+++ b/src/Purebred/Types/Event.hs
@@ -1,0 +1,87 @@
+-- This file is part of purebred
+-- Copyright (C) 2017-2021 Róman Joost and Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{- |
+
+Event types and optics for Purebred.
+
+-}
+module Purebred.Types.Event
+  (
+    PurebredEvent(..)
+
+  , Generation
+  , firstGeneration
+  , nextGeneration
+
+  , UserMessage(..)
+  , umContext
+  , umSeverity
+  , MessageSeverity(..)
+  ) where
+
+import Control.Lens (Lens', lens)
+import qualified Data.Text as T
+
+import Purebred.Types.Error (Error)
+import Purebred.Types.UI (Name)
+
+-- | A serial number that can be used to match (or ignore as
+-- irrelevant) asynchronous events to current application state.
+--
+-- Use the 'Eq' and 'Ord' instances to compare generations.  The
+-- constructor is hidden; use 'firstGeneration' as the first
+-- generation, and use 'nextGeneration' to monotonically increment
+-- it.
+--
+newtype Generation = Generation Integer
+  deriving (Eq, Ord)
+
+firstGeneration :: Generation
+firstGeneration = Generation 0
+
+nextGeneration :: Generation -> Generation
+nextGeneration (Generation n) = Generation (succ n)
+
+-- | Purebred event type.  In the future we can abstract this over
+-- a custom event type to allow plugins to define their own events.
+-- But I've YAGNI'd it for now because it will require an event
+-- type parameter on 'AppState', which will be a noisy change.
+--
+data PurebredEvent
+  = NotifyNumThreads Int Generation
+  | NotifyNewMailArrived Int
+  | InputValidated (Maybe UserMessage) -- ^ Event used for real time validation
+
+data MessageSeverity
+  = Error Error
+  | Warning T.Text
+  | Info T.Text
+  deriving (Eq, Show)
+
+-- | UI feedback shown to the user.
+-- Uses context and severity to control visibility and importance.
+data UserMessage = UserMessage
+  { _umContext:: Name
+  , _umSeverity :: MessageSeverity
+  }
+  deriving (Eq, Show)
+
+umContext :: Lens' UserMessage Name
+umContext = lens _umContext (\m x -> m { _umContext = x })
+
+umSeverity :: Lens' UserMessage MessageSeverity
+umSeverity = lens _umSeverity (\m x -> m { _umSeverity = x })

--- a/src/Purebred/Types/Mailcap.hs
+++ b/src/Purebred/Types/Mailcap.hs
@@ -1,0 +1,171 @@
+-- This file is part of purebred
+-- Copyright (C) 2017-2021 Róman Joost and Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+{- |
+
+Types for handling message bodies with external programs.
+
+-}
+module Purebred.Types.Mailcap
+  (
+    MailcapHandler(..)
+  , mhMakeProcess
+  , mhCopiousoutput
+  , mhKeepTemp
+  , MakeProcess(..)
+  , mpCommand
+  , CopiousOutput(..)
+  , isCopiousOutput
+  , hasCopiousoutput
+  , TempfileOnExit(..)
+
+  , EntityCommand(..)
+  , ccResource
+  , ccRunProcess
+  , ccAfterExit
+  , ccEntity
+  , ccProcessConfig
+  , ResourceSpec(..)
+  , rsAcquire
+  , rsUpdate
+  , rsFree
+  ) where
+
+import Data.List.NonEmpty (NonEmpty)
+import GHC.Generics
+import System.Exit (ExitCode(..))
+
+import Control.DeepSeq (NFData)
+import Control.Lens (Lens', Traversal', filtered, lens, traversed, view)
+import Control.Monad.Except (MonadError, MonadIO)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as L
+import qualified Data.Text as T
+import System.Process.Typed (ProcessConfig)
+
+import Data.MIME (ContentType)
+
+import Purebred.Types.Error (Error)
+import Purebred.Types.IFC (Tainted)
+
+-- | A bracket-style type for creating and releasing acquired resources (e.g.
+-- temporary files). Note that extending this is perhaps not worth it and we
+-- should perhaps look at ResourceT if necessary.
+data ResourceSpec m a = ResourceSpec
+  { _rsAcquire :: m a
+ -- ^ acquire a resource (e.g. create temporary file)
+  , _rsFree :: a -> m ()
+ -- ^ release a resource (e.g. remove temporary file)
+  , _rsUpdate :: a -> B.ByteString -> m ()
+ -- ^ update the acquired resource with the ByteString obtained from serialising the WireEntity
+  }
+
+rsAcquire :: Lens' (ResourceSpec m a) (m a)
+rsAcquire = lens _rsAcquire (\rs x -> rs {_rsAcquire = x})
+
+rsFree :: Lens' (ResourceSpec m a) (a -> m ())
+rsFree = lens _rsFree (\rs x -> rs {_rsFree = x})
+
+rsUpdate :: Lens' (ResourceSpec m a) (a -> B.ByteString -> m ())
+rsUpdate = lens _rsUpdate (\rs x -> rs {_rsUpdate = x})
+
+data MakeProcess
+  = Shell (NonEmpty Char)
+  | Process (NonEmpty Char)
+            [String]
+  deriving (Generic, NFData)
+
+mpCommand :: Lens' MakeProcess (NonEmpty Char)
+mpCommand f (Shell x) = fmap Shell (f x)
+mpCommand f (Process x args) = fmap (\x' -> Process x' args) (f x)
+{-# ANN mpCommand ("HLint: ignore Avoid lambda using `infix`" :: String) #-}
+
+data CopiousOutput
+  = CopiousOutput
+  | IgnoreOutput
+  deriving (Generic, NFData)
+
+isCopiousOutput :: CopiousOutput -> Bool
+isCopiousOutput CopiousOutput = True
+isCopiousOutput _ = False
+
+data TempfileOnExit
+  = KeepTempfile
+  | DiscardTempfile
+  deriving (Generic, NFData)
+
+data MailcapHandler = MailcapHandler
+  { _mhMakeProcess :: MakeProcess
+  , _mhCopiousoutput :: CopiousOutput
+  -- ^ output should be paged or made scrollable
+  , _mhKeepTemp :: TempfileOnExit
+  -- ^ Keep the temporary file if application spawns child and parent
+  -- exits immediately (e.g. Firefox)
+  } deriving (Generic, NFData)
+
+mhMakeProcess :: Lens' MailcapHandler MakeProcess
+mhMakeProcess = lens _mhMakeProcess (\h x -> h { _mhMakeProcess = x })
+
+mhCopiousoutput :: Lens' MailcapHandler CopiousOutput
+mhCopiousoutput = lens _mhCopiousoutput (\h x -> h { _mhCopiousoutput = x })
+
+mhKeepTemp :: Lens' MailcapHandler TempfileOnExit
+mhKeepTemp = lens _mhKeepTemp (\h x -> h { _mhKeepTemp = x })
+
+hasCopiousoutput :: Traversal' [(ContentType -> Bool, MailcapHandler)] (ContentType -> Bool, MailcapHandler)
+hasCopiousoutput = traversed . filtered (isCopiousOutput . view mhCopiousoutput . snd)
+
+
+-- | Command configuration which is bound to an acquired resource
+-- (e.g. a tempfile) filtered through an external command. The
+-- resource may or may not be cleaned up after the external command
+-- exits.
+data EntityCommand m a = EntityCommand
+  { _ccAfterExit :: (ExitCode, Tainted L.ByteString) -> a -> m T.Text
+  , _ccResource :: ResourceSpec m a
+  , _ccProcessConfig :: B.ByteString -> a -> ProcessConfig () () ()
+  , _ccRunProcess :: ProcessConfig () () () -> m ( ExitCode
+                                                   , Tainted L.ByteString)
+  , _ccEntity :: B.ByteString
+  -- ^ The decoded Entity
+  }
+
+ccAfterExit ::
+     (MonadIO m, MonadError Error m)
+  => Lens' (EntityCommand m a) ((ExitCode, Tainted L.ByteString) -> a -> m T.Text)
+ccAfterExit = lens _ccAfterExit (\cc x -> cc {_ccAfterExit = x})
+
+ccEntity :: Lens' (EntityCommand m a) B.ByteString
+ccEntity = lens _ccEntity (\cc x -> cc {_ccEntity = x})
+
+ccProcessConfig ::
+     Lens' (EntityCommand m a) (B.ByteString -> a -> ProcessConfig () () ())
+ccProcessConfig = lens _ccProcessConfig (\cc x -> cc {_ccProcessConfig = x})
+
+ccResource ::
+     (MonadIO m, MonadError Error m)
+  => Lens' (EntityCommand m a) (ResourceSpec m a)
+ccResource = lens _ccResource (\cc x -> cc {_ccResource = x})
+
+ccRunProcess ::
+     (MonadError Error m, MonadIO m)
+  => Lens' (EntityCommand m a) (ProcessConfig () () () -> m ( ExitCode
+                                                            , Tainted L.ByteString))
+ccRunProcess = lens _ccRunProcess (\cc x -> cc {_ccRunProcess = x})

--- a/src/Purebred/Types/UI.hs
+++ b/src/Purebred/Types/UI.hs
@@ -1,0 +1,156 @@
+-- This file is part of purebred
+-- Copyright (C) 2017-2021 Róman Joost and Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+
+Types related to the UI.
+
+-}
+module Purebred.Types.UI
+  (
+    Name(..)
+
+  , ViewSettings(..)
+  , vsViews
+  , vsFocusedView
+  , ViewName(..)
+  , View(..)
+  , ViewState(..)
+  , vFocus
+  , vLayers
+  , Layer(..)
+  , Layers
+  , layeriso
+  , Tile(..)
+  , veName
+  , veState
+
+  , Toggleable
+  ) where
+
+import Control.DeepSeq (NFData)
+import Control.Lens
+import qualified Data.Map as Map
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+import qualified Brick.Focus as Brick
+
+{-# ANN module "HLint: ignore Avoid lambda" #-}
+
+-- | Widget identifiers. Each rendered widget has one unique
+-- identifier in Purebred's UI.
+--
+data Name
+  = ComposeBcc
+  | ComposeCc
+  | ComposeFrom
+  | ComposeHeaders
+  | ComposeListOfAttachments
+  | ComposeSubject
+  | ComposeTo
+  | ConfirmDialog
+  | ListOfFiles
+  | ListOfMails
+  | ListOfThreads
+  | MailAttachmentOpenWithEditor
+  | MailAttachmentPipeToEditor
+  | MailListOfAttachments
+  | ManageFileBrowserSearchPath
+  | ManageMailTagsEditor
+  | ManageThreadTagsEditor
+  | SaveToDiskPathEditor
+  | SearchThreadsEditor
+  | ScrollingHelpView
+  | ScrollingMailView
+  | ScrollingMailViewFindWordEditor
+  | StatusBar
+  deriving (Eq, Ord, Show)
+
+data ViewName
+  = Threads
+  | Mails
+  | ViewMail
+  | ComposeView
+  | Help
+  | FileBrowser
+  deriving (Eq, Ord, Show, Generic, NFData)
+
+data ViewState
+  = Hidden
+  | Visible
+  deriving (Eq, Show)
+
+-- | A view element is a name for a widget with a given view state
+data Tile = Tile ViewState Name
+  deriving (Eq, Show)
+
+veName :: Lens' Tile Name
+veName f (Tile a b) = fmap (\b' -> Tile a b') (f b)
+
+veState :: Lens' Tile ViewState
+veState f (Tile a b) = fmap (\a' -> Tile a' b) (f a)
+{-# ANN veState ("HLint: ignore Avoid lambda using `infix`" :: String) #-}
+
+type Layers = V.Vector Layer
+
+data View = View
+  { _vFocus :: Name
+  , _vLayers :: Layers
+  }
+
+vLayers :: Lens' View Layers
+vLayers = lens _vLayers (\settings x -> settings { _vLayers = x })
+
+vFocus :: Lens' View Name
+vFocus = lens _vFocus (\settings x -> settings { _vFocus = x})
+
+-- | A layer is a view element with a list of widgets and their view state
+newtype Layer = Layer (V.Vector Tile)
+  deriving (Eq, Show)
+
+type instance Index Layer = Name
+type instance IxValue Layer = Tile
+
+instance Ixed Layer where
+  ix = tile
+
+layeriso :: Iso' Layer (V.Vector Tile)
+layeriso = iso (\(Layer xs) -> xs) Layer
+
+tile :: Name -> Traversal' Layer Tile
+tile k = layeriso . traversed . filtered (\x -> k == view veName x)
+
+data ViewSettings = ViewSettings
+    { _vsViews :: Map.Map ViewName View
+    , _vsFocusedView :: Brick.FocusRing ViewName
+    }
+
+vsViews :: Lens' ViewSettings (Map.Map ViewName View)
+vsViews = lens _vsViews (\settings x -> settings { _vsViews = x })
+
+vsFocusedView :: Lens' ViewSettings (Brick.FocusRing ViewName)
+vsFocusedView = lens _vsFocusedView (\settings x -> settings { _vsFocusedView = x})
+
+-- | An item carrying it's selected state.
+-- Used in order to mark list items.
+--
+type Toggleable a = (Bool, a)

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -168,7 +168,7 @@ import Purebred.UI.Views
        (mailView, toggleLastVisibleWidget, indexView, resetView,
         focusedViewWidget)
 import Purebred.Plugin.Internal
-import Purebred.Storage.Tags (parseTagOps)
+import Purebred.Storage.Tags (TagOp(AddTag, RemoveTag), parseTagOps)
 import Purebred.System (tryIO)
 import Purebred.System.Process
 import Purebred.Types

--- a/src/Purebred/UI/Validation.hs
+++ b/src/Purebred/UI/Validation.hs
@@ -22,7 +22,7 @@ module Purebred.UI.Validation
   ) where
 
 import Control.Concurrent (forkIO, killThread, threadDelay)
-import Control.Lens (Lens', set, view)
+import Control.Lens (set, view)
 import Brick.BChan (writeBChan)
 
 import Purebred.Types

--- a/test/TestMail.hs
+++ b/test/TestMail.hs
@@ -37,6 +37,7 @@ import Notmuch (mkTag, tagMaxLen)
 import Purebred.Types
 import Purebred.Storage.Notmuch (addTags, removeTags, tagItem)
 import Purebred.Storage.Mail (findMatchingWords)
+import Purebred.Storage.Tags (TagOp(..))
 
 mailTests ::
   TestTree

--- a/test/TestTagParser.hs
+++ b/test/TestTagParser.hs
@@ -23,7 +23,7 @@ import Data.List (isInfixOf)
 
 import qualified Data.Text as T
 import Purebred.Storage.Tags
-import Purebred.Types (TagOp(..), UserMessage(..), Name(..), MessageSeverity(..))
+import Purebred.Types (UserMessage(..), Name(..), MessageSeverity(..))
 
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit ((@=?), testCase, assertBool, assertFailure)


### PR DESCRIPTION
From the overfull `Purebred.Types` module, extract three smaller
modules of related data types and functions:

- `Purebred.Types.Event`
- `Purebred.Types.Mailcap`
- `Purebred.Types.UI`

Also move the `TagOp` data type to `Purebre.Storage.Tags`.