### PR TITLE
simplify configuration type

### DIFF
--- a/src/Purebred/Plugin/Internal.hs
+++ b/src/Purebred/Plugin/Internal.hs
@@ -33,12 +33,12 @@ import Control.Monad.State
 
 import Data.MIME (MIMEMessage)
 
-import Purebred.Types (AppState, InternalConfiguration, UserConfiguration)
+import Purebred.Types (AppState, Configuration)
 
 type Pure = Applicative
 type CanIO = MonadIO
 type CanRWAppState = MonadState AppState
-type CanReadConfig = MonadReader InternalConfiguration
+type CanReadConfig = MonadReader Configuration
 
 class (CanReadConfig m, CanIO m, CanRWAppState m) => Unconstrained m where
 instance (CanReadConfig m, CanIO m, CanRWAppState m) => Unconstrained m where
@@ -102,9 +102,9 @@ instance (forall m. Unconstrained m => cap m) => Hook (PreSendHook cap) where
 -- | Process the program configuration at program initialisation.
 -- Available capabilities: __CanIO__.
 newtype ConfigHook cap = ConfigHook
-  ( forall m. (cap m) => UserConfiguration -> m UserConfiguration )
+  ( forall m. (cap m) => Configuration -> m Configuration )
 
-getConfigHook :: (cap m) => ConfigHook cap -> UserConfiguration -> m UserConfiguration
+getConfigHook :: (cap m) => ConfigHook cap -> Configuration -> m Configuration
 getConfigHook (ConfigHook f) = f
 
 instance (forall m. CanIO m => cap m) => Hook (ConfigHook cap) where

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -956,7 +956,7 @@ switchView
       )
   => Action v ctx ()
 switchView = Action [desc] $ do
-  sink <- use (asConfig . confLogSink)
+  sink <- use logSink
   liftIO . sink . LT.pack $ msg
   onFocusSwitch (Proxy @v') (Proxy @ctx')
   modify (transitionHook (Proxy @v) (Proxy @v'))
@@ -971,7 +971,7 @@ switchView = Action [desc] $ do
 -- | Log a debug message
 debug :: LT.Text -> Action v ctx ()
 debug msg = Action [] $ do
-  sink <- use (asConfig . confLogSink)
+  sink <- use logSink
   liftIO $ sink msg
 
 done :: forall a v. (HasViewName v, Completable a) => Action v a (CompletableResult a)
@@ -1400,7 +1400,7 @@ runSearch searchterms = do
 notifyNumThreads :: (MonadState AppState m, MonadIO m, Foldable t) => t a -> m ()
 notifyNumThreads l = do
   nextGen <- uses (asThreadsView . miListOfThreadsGeneration) nextGeneration
-  chan <- use (asConfig . confBChan)
+  chan <- use bChan
   void . liftIO . forkIO $
     let len = length l
     in len `seq` writeBChan chan (NotifyNumThreads len nextGen)
@@ -1768,7 +1768,7 @@ fileBrowserSetWorkingDirectory = do
 
 switchMode' :: (MonadIO m, MonadState AppState m) => ViewName -> Name -> m ()
 switchMode' vn w = do
-  sink <- use (asConfig . confLogSink)
+  sink <- use logSink
   liftIO . sink . LT.pack $
     "focus on " <> show vn <> "/" <> show w
   modifying (asViews . vsFocusedView) (Brick.focusSetCurrent vn)

--- a/src/Purebred/UI/Help/Main.hs
+++ b/src/Purebred/UI/Help/Main.hs
@@ -49,7 +49,7 @@ type HelpIndex = M.Map Name [KeybindingHelp]
 
 -- | Build a map between widget and it's configured key bindings
 --
-createKeybindingIndex :: Configuration extra a b c -> HelpIndex
+createKeybindingIndex :: Configuration -> HelpIndex
 createKeybindingIndex cfg = M.fromList
   [ (ListOfThreads, views (confIndexView . ivBrowseThreadsKeybindings) kbGroup cfg)
   , (ComposeSubject, views (confComposeView . cvSubjectKeybindings) kbGroup cfg)

--- a/src/Purebred/UI/Index/Main.hs
+++ b/src/Purebred/UI/Index/Main.hs
@@ -48,7 +48,7 @@ renderListOfThreads s = L.renderList (listDrawThread s (ListOfThreads == focused
 renderListOfMails :: AppState -> Widget Name
 renderListOfMails s = L.renderList (listDrawMail s) True $ view (asThreadsView . miListOfMails) s
 
-notmuchConfig :: AppState -> NotmuchSettings FilePath
+notmuchConfig :: AppState -> NotmuchSettings
 notmuchConfig = view (asConfig . confNotmuch)
 
 isNewMail :: ManageTags a => a -> AppState -> Bool

--- a/src/Purebred/UI/Validation.hs
+++ b/src/Purebred/UI/Validation.hs
@@ -42,7 +42,7 @@ dispatchValidation ::
   -> IO AppState
 dispatchValidation fx a s =
   let go = maybe schedule (\t -> killThread t *> schedule) . view (asAsync . aValidation)
-      chan = view (asConfig . confBChan) s
+      chan = view bChan s
       schedule =
         forkIO (sleepMs 500 >> writeBChan chan (InputValidated (fx a)))
    in do tid <- go s


### PR DESCRIPTION
Several fields in the base configuration type are abstract, to allow
user customisation.  The `UserConfiguration` type synonym
instantiates these fields at `IO ...` so that users can provide an
alternative IO action that yields the desired final value(s).
During launch, purebred executes these actions to produce the final
configuration record.

Thanks to the plugin system and `ConfigHook`, we can now simplify
the design and implementation:

- Remove all abstraction from the `Configuration` data type (and the
  types of relevant fields).

- Change the type of `defaultConfig` to `IO UserConfiguration` so
  that the default "environment dependent" values can be populated.

- Move the BChan and log sink fields from `Configuration` to
  `AppState`.

- Remove the `InternalConfiguration` type synonym.  Retain
  `UserConfiguration` (for now) as a synonym of `Configuration`.

- Update the "default editor" action to respect the `VISUAL`
  environment variable, preferring it over `EDITOR` if defined.