### PR TITLE
avoid unnecessary recompilation due to CPP

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -94,6 +94,7 @@ library
                      , Purebred.Version
   other-modules:       Paths_purebred
                      , Purebred.Types.IFC
+                     , Purebred.Types.Items
                      , Purebred.Plugin.Internal
                      , Purebred.Plugin.UserAgent
   autogen-modules:     Paths_purebred

--- a/src/Purebred/Types.hs
+++ b/src/Purebred/Types.hs
@@ -14,7 +14,6 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -254,12 +253,9 @@ import Purebred.UI.Widgets (StatefulEditor)
 import {-# SOURCE #-} Purebred.Plugin.Internal
 import Purebred.Types.Error
 import Purebred.Types.Event
+import Purebred.Types.Items
 import Purebred.Types.Mailcap
 import Purebred.Types.UI
-
-#if defined LAZYVECTOR
-import Purebred.Types.LazyVector (V)
-#endif
 
 {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
@@ -291,11 +287,7 @@ listLength f (ListWithLength a b) = (\b' -> ListWithLength a b') <$> f b
 --
 data ThreadsView = ThreadsView
     { _miListOfMails  :: ListWithLength V.Vector (Toggleable NotmuchMail)
-#if defined LAZYVECTOR
-    , _miListOfThreads :: ListWithLength V (Toggleable NotmuchThread)
-#else
-    , _miListOfThreads :: ListWithLength V.Vector (Toggleable NotmuchThread)
-#endif
+    , _miListOfThreads :: ListWithLength Items (Toggleable NotmuchThread)
     , _miListOfThreadsGeneration :: Generation
     , _miSearchThreadsEditor :: StatefulEditor T.Text Name
     , _miMailTagsEditor :: E.Editor T.Text Name
@@ -306,24 +298,14 @@ data ThreadsView = ThreadsView
 miMails :: Lens' ThreadsView (ListWithLength V.Vector (Toggleable NotmuchMail))
 miMails = lens _miListOfMails (\m v -> m { _miListOfMails = v })
 
-#if defined LAZYVECTOR
-miThreads :: Lens' ThreadsView (ListWithLength V (Toggleable NotmuchThread))
+miThreads :: Lens' ThreadsView (ListWithLength Items (Toggleable NotmuchThread))
 miThreads = lens _miListOfThreads (\m v -> m { _miListOfThreads = v})
-#else
-miThreads :: Lens' ThreadsView (ListWithLength V.Vector (Toggleable NotmuchThread))
-miThreads = lens _miListOfThreads (\m v -> m { _miListOfThreads = v})
-#endif
 
 miListOfMails :: Lens' ThreadsView (L.GenericList Name V.Vector (Toggleable NotmuchMail))
 miListOfMails = miMails . listList
 
-#if defined LAZYVECTOR
-miListOfThreads :: Lens' ThreadsView (L.GenericList Name V (Toggleable NotmuchThread))
+miListOfThreads :: Lens' ThreadsView (L.GenericList Name Items (Toggleable NotmuchThread))
 miListOfThreads = miThreads . listList
-#else
-miListOfThreads :: Lens' ThreadsView (L.GenericList Name V.Vector (Toggleable NotmuchThread))
-miListOfThreads = miThreads . listList
-#endif
 
 miListOfThreadsGeneration :: Lens' ThreadsView Generation
 miListOfThreadsGeneration =

--- a/src/Purebred/Types/Items.hs
+++ b/src/Purebred/Types/Items.hs
@@ -1,0 +1,39 @@
+-- This file is part of purebred
+-- Copyright (C) 2021 Fraser Tweedale
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE CPP #-}
+
+module Purebred.Types.Items
+  ( Items
+  , fromList
+  ) where
+
+#if defined LAZYVECTOR
+
+import Purebred.Types.LazyVector (V, fromList)
+
+type Items = V
+
+#else
+
+import qualified Data.Vector
+
+type Items = Data.Vector.Vector
+
+fromList :: Int -> [a] -> Items a
+fromList _ = Data.Vector.fromList
+
+#endif

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -25,7 +25,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE CPP #-}
 
 module Purebred.UI.Actions (
   -- * Overview
@@ -173,14 +172,12 @@ import Purebred.System (tryIO)
 import Purebred.System.Process
 import Purebred.Types
 import Purebred.Types.Error
+import Purebred.Types.Items
 import Purebred.UI.Notifications
        (setUserMessage, makeWarning, showError, showWarning, showInfo
        , showUserMessage)
 import Purebred.UI.Widgets
   ( statefulEditor, editEditorL, revertEditorState, saveEditorState )
-#if defined LAZYVECTOR
-import Purebred.Types.LazyVector (V)
-#endif
 
 
 
@@ -275,11 +272,7 @@ class HasList (n :: Name) where
   list :: Proxy n -> Lens' AppState (L.GenericList Name (T n) (E n))
 
 instance HasList 'ListOfThreads where
-#if defined LAZYVECTOR
-  type T 'ListOfThreads = V
-#else
-  type T 'ListOfThreads = Vector.Vector
-#endif
+  type T 'ListOfThreads = Items
   type E 'ListOfThreads = Toggleable NotmuchThread
   list _ = asThreadsView . miListOfThreads
 


### PR DESCRIPTION
CPP is currently used in several large modules to choose between
lazy or strict list representations.  This leads to unecessary
recompilation when `cabal_macros.h` changes (e.g. due to dependency
changes).  See blog post for further explanation:

http://blog.haskell-exists.com/yuras/posts/stop-abusing-cpp-in-haskell.html

Abstract the list type behind a new module `Purebred.Types.Items`,
which uses CPP.  Refactor other modules that use CPP to choose a
list representation to use `Items` and avoid CPP in those modules.