### PR TITLE
nix: stick with building purebred for x86 for now

### DIFF
--- a/.github/workflows/nixos-ci-flakes.yml
+++ b/.github/workflows/nixos-ci-flakes.yml
@@ -1,0 +1,24 @@
+name: NixOS Build (Flakes - build only)
+on:
+  - push
+  - pull_request
+jobs:
+  linux:
+    name: Nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Local cache
+        uses: actions/cache@v2
+        with:
+          path: /nix/store
+          key: "{{ runner.os }}-Nixpkgs-integration-test"
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v15
+        with:
+          nix_path: "nixpkgs=channel:nixos-unstable"
+
+      - run: nix build
+      - run: nix flake check

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         };
       };
     };
-  } // utils.lib.eachDefaultSystem (system:
+  } // utils.lib.eachSystem ["x86_64-linux"] (system:
   let
     pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.purebred ]; };
     nativeBuildTools = with pkgs.haskellPackages; [


### PR DESCRIPTION
The flake-utils allow us to build purebred for non-x86-64 systems.
However at the beginning we don't support these platforms. Part of the
downside is that we're also snapping up any potential broken package in
the nixos-unstable channel. Granted, we could pin to a specific
revision, but the channel is mostly fine for x86_64.

Drive-by add on to also run `nix flake check` in CI.