### PR TITLE
deps: require brick < 0.68

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -103,7 +103,7 @@ library
                      , deepseq >= 1.4.2
                      , dyre >= 0.9.1
                      , lens
-                     , brick >= 0.64
+                     , brick >= 0.64 && < 0.68
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0


### PR DESCRIPTION
brick-0.68 removed `Brick.Markup` which we currently use.
We need to migrate away from this feature but for now set the
upper bound < 0.68 to fix the build.