### PR TITLE
remove redundant import of System.Exit

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -109,7 +109,7 @@ library
                      , vector >= 0.12.0.0
                      , notmuch >= 0.3 && < 0.4
                      , text
-                     , typed-process >= 0.2.1.0
+                     , typed-process >= 0.2.8.0
                      , directory >= 1.2.5.0
                      , bytestring
                      , time >= 1.8

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -42,7 +42,6 @@ module Purebred.System.Process
 
 import Data.Bifunctor (bimap)
 import Data.Functor (($>))
-import System.Exit (ExitCode(..))
 import Control.Exception (IOException)
 import Control.Monad.Catch (bracket, MonadMask)
 import Control.Monad.IO.Class (MonadIO, liftIO)


### PR DESCRIPTION
typed-process >= 0.2.8.0 re-exports the `ExitCode` data type from
`System.Exit`.  This causes a redundant import warning.

Bump the type-process min bound to >= 0.2.8.0 and remove the
redundant import.