### PR TITLE
ci: Fix nix build error

### DIFF
--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,7 +1,7 @@
 { compiler ? null, nixpkgs ? null}:
 
 let
-  compilerVersion = if isNull compiler then "ghc884" else compiler;
+  compilerVersion = if isNull compiler then "ghc901" else compiler;
   haskellPackagesOverlay = self: super: with super.haskell.lib; {
     haskellPackages = super.haskell.packages.${compilerVersion}.override {
       overrides = hself: hsuper: {
@@ -10,6 +10,7 @@ let
         purebred-icu = hsuper.callPackage ./purebred-icu.nix { };
         dyre = hsuper.callPackage ./dyre.nix { };
         brick = hsuper.callPackage ./brick.nix { };
+        typed-process = hsuper.callPackage ./typed-process.nix { };
       };
     };
   };

--- a/.nix/typed-process.nix
+++ b/.nix/typed-process.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, async, base, base64-bytestring, bytestring, hspec
+, lib, process, stm, temporary, transformers, unliftio-core
+}:
+mkDerivation {
+  pname = "typed-process";
+  version = "0.2.8.0";
+  sha256 = "8578da545d6b2fa4b0b7296be389a736739153ced19d1dffbdee68aec978c0a9";
+  revision = "1";
+  editedCabalFile = "1m017nqbaqishii32gwhxa1849h0qnn06w7k1rn8c9d8w71m4vqm";
+  libraryHaskellDepends = [
+    async base bytestring process stm transformers unliftio-core
+  ];
+  testHaskellDepends = [
+    async base base64-bytestring bytestring hspec process stm temporary
+    transformers unliftio-core
+  ];
+  homepage = "https://github.com/fpco/typed-process";
+  description = "Run external processes, with strong typing of streams";
+  license = lib.licenses.mit;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
             purebred-icu = hsuper.callPackage .nix/purebred-icu.nix { };
             dyre = hsuper.callPackage .nix/dyre.nix { };
             brick = hsuper.callPackage .nix/brick.nix { };
+            typed-process = hsuper.callPackage .nix/typed-process.nix { };
           };
         };
       };
@@ -45,22 +46,22 @@
       nativeBuildInputs = pkgs.haskellPackages.purebred.env.nativeBuildInputs ++ nativeBuildTools;
     };
     mkPurebredWithPackages = with-icu:
-      let
-        envPackages = self: if with-icu then [ self.purebred-icu ] else [ self.purebred ];
-        env = pkgs.haskellPackages.ghcWithPackages envPackages;
-      in pkgs.stdenv.mkDerivation {
-        name = "purebred-with-packages-${env.version}";
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        # This creates a Bash script, which sets the GHC in order for dyre to be
-        # able to build the config file.
-        buildCommand = ''
-          mkdir -p $out/bin
-          makeWrapper ${env}/bin/purebred $out/bin/purebred \
-          --set NIX_GHC "${env}/bin/ghc"
-        '';
-        preferLocalBuild = true;
-        allowSubstitutes = false;
-      };
+    let
+      envPackages = self: if with-icu then [ self.purebred-icu ] else [ self.purebred ];
+      env = pkgs.haskellPackages.ghcWithPackages envPackages;
+    in pkgs.stdenv.mkDerivation {
+      name = "purebred-with-packages-${env.version}";
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      # This creates a Bash script, which sets the GHC in order for dyre to be
+      # able to build the config file.
+      buildCommand = ''
+        mkdir -p $out/bin
+        makeWrapper ${env}/bin/purebred $out/bin/purebred \
+        --set NIX_GHC "${env}/bin/ghc"
+      '';
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+    };
   in rec {
     packages = {
       purebred-with-packages = mkPurebredWithPackages false;


### PR DESCRIPTION
This adds the newer version of `typed-process` into the package mix,
since just updating to a newer package set will clash with our version
pins in `hs-notmuch` and `purebred-email` respectively.