### PR TITLE
Refactor and simplify nix sources

### DIFF
--- a/.github/workflows/nixos-ci.yml
+++ b/.github/workflows/nixos-ci.yml
@@ -9,12 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Local cache
-        uses: actions/cache@v2
-        with:
-          path: /nix/store
-          key: "{{ runner.os }}-Nixpkgs-integration-test"
-
       - name: Install Nix
         uses: cachix/install-nix-action@v12
         with:

--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,19 +1,6 @@
 { compiler ? null, nixpkgs ? null}:
 
 let
-  compilerVersion = if isNull compiler then "ghc901" else compiler;
-  haskellPackagesOverlay = self: super: with super.haskell.lib; {
-    haskellPackages = super.haskell.packages.${compilerVersion}.override {
-      overrides = hself: hsuper: {
-        purebred = hsuper.callPackage ./purebred.nix { };
-        purebred-email = hsuper.callPackage ./purebred-email.nix { };
-        purebred-icu = hsuper.callPackage ./purebred-icu.nix { };
-        dyre = hsuper.callPackage ./dyre.nix { };
-        brick = hsuper.callPackage ./brick.nix { };
-        typed-process = hsuper.callPackage ./typed-process.nix { };
-      };
-    };
-  };
   lock = builtins.fromJSON (builtins.readFile ../flake.lock);
   pkgSrc =
     if isNull nixpkgs
@@ -25,5 +12,6 @@ let
     }
     else
     nixpkgs;
+    haskellPackagesOverlay = import ./overlays.nix;
 in
-import pkgSrc { overlays = [ haskellPackagesOverlay ]; }
+import pkgSrc { overlays = haskellPackagesOverlay; }

--- a/.nix/overlays.nix
+++ b/.nix/overlays.nix
@@ -1,0 +1,55 @@
+let
+  haskellCompilerVersion = "ghc901";
+  haskellPackagesOverlay = self: super: with super.haskell.lib; {
+    haskellPackages = super.haskell.packages.${haskellCompilerVersion}.override {
+      overrides = hself: hsuper: {
+        purebred = hsuper.callPackage ./purebred.nix { };
+        purebred-email = hsuper.callPackage ./purebred-email.nix { };
+        purebred-icu = hsuper.callPackage ./purebred-icu.nix { };
+        dyre = hsuper.callPackage ./dyre.nix { };
+        brick = hsuper.callPackage ./brick.nix { };
+        typed-process = hsuper.callPackage ./typed-process.nix { };
+      };
+    };
+    make-purebred-with-packages = with-icu:
+    let
+      envPackages = self: if with-icu then [ self.purebred-icu ] else [ self.purebred ];
+      env = self.haskellPackages.ghcWithPackages envPackages;
+    in self.stdenv.mkDerivation {
+      name = "purebred-with-packages-${env.version}";
+      nativeBuildInputs = [ self.makeWrapper ];
+      # This creates a Bash script, which sets the GHC in order for dyre to be
+      # able to build the config file.
+      buildCommand = ''
+        mkdir -p $out/bin
+        makeWrapper ${env}/bin/purebred $out/bin/purebred \
+        --set NIX_GHC "${env}/bin/ghc"
+      '';
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+    };
+    purebred-with-packages-icu = self.make-purebred-with-packages true;
+    purebred-with-packages = self.make-purebred-with-packages false;
+    make-purebred-shell = with-icu: let
+      nativeBuildTools = with self.haskellPackages; [
+        cabal-install
+        cabal2nix
+        ghcid
+        hlint
+        haskell-language-server
+        ormolu
+        hie-bios
+        self.notmuch
+        self.tmux
+        self.gnumake
+        self.asciidoctor
+        self.python3Packages.pygments
+      ];
+    in self.haskellPackages.shellFor {
+      withHoogle = true;
+      packages = hp: [ hp.purebred ] ++ (if with-icu then [hp.purebred-icu] else []);
+      nativeBuildInputs = self.haskellPackages.purebred.env.nativeBuildInputs ++ nativeBuildTools;
+    };
+  };
+
+in [haskellPackagesOverlay]

--- a/.nix/purebred.nix
+++ b/.nix/purebred.nix
@@ -1,34 +1,32 @@
 { mkDerivation, attoparsec, base, brick, bytestring
-  , case-insensitive, containers, deepseq, directory, dyre
-  , exceptions, filepath, ini, lens, lib, mime-types, mtl, notmuch
-  , optparse-applicative, purebred-email, quickcheck-instances
-  , random, regex-posix, stm, tasty, tasty-hunit
-  , tasty-quickcheck, temporary, text, text-zipper, time
-  , typed-process, vector, vty
-  , Cabal, tasty-tmux
+, case-insensitive, containers, deepseq, directory, dyre
+, exceptions, filepath, lens, lib, mime-types, mtl, notmuch
+, optparse-applicative, purebred-email, quickcheck-instances
+, random, stm, tasty, tasty-hunit, tasty-quickcheck, tasty-tmux
+, temporary, text, text-zipper, time, typed-process, unix, vector
+, vty, word-wrap
 }:
 mkDerivation {
   pname = "purebred";
   version = "0.1.0.0";
-  src = ../.;
+  src = ./..;
   isLibrary = true;
   isExecutable = true;
-  setupHaskellDepends = [ Cabal ];
   libraryHaskellDepends = [
     attoparsec base brick bytestring case-insensitive containers
     deepseq directory dyre exceptions filepath lens mime-types mtl
-    notmuch optparse-applicative purebred-email random temporary text
-    text-zipper time typed-process vector vty
+    notmuch optparse-applicative purebred-email random stm temporary
+    text text-zipper time typed-process vector vty word-wrap
   ];
-  testTarget = "unit";
   executableHaskellDepends = [ base ];
+  testTarget = "unit";
   testHaskellDepends = [
-    base brick bytestring directory filepath ini lens mtl notmuch
-    purebred-email quickcheck-instances regex-posix stm tasty
-    tasty-hunit tasty-quickcheck temporary text time typed-process
-    vector tasty-tmux
+    attoparsec base brick bytestring directory filepath lens mtl
+    notmuch purebred-email quickcheck-instances tasty tasty-hunit
+    tasty-quickcheck tasty-tmux temporary text time typed-process unix
+    vector
   ];
-  homepage = "https://github.com/githubuser/purebred#readme";
+  homepage = "https://github.com/purebred-mua/purebred#readme";
   description = "An mail user agent built around notmuch";
-  license = lib.licenses.agpl3;
+  license = lib.licenses.agpl3Plus;
 }

--- a/default.nix
+++ b/default.nix
@@ -31,47 +31,6 @@
 #
 # $ nix-shell default.nix
 #
-{ compiler ? null, nixpkgs ? null, with-icu ? false }:
+{ compiler ? null, nixpkgs ? null, with-icu ? false }@args:
 
-with (import .nix/nixpkgs.nix { inherit compiler nixpkgs; });
-
-let
-  envPackages = self: if with-icu then [ self.purebred-icu ] else [ self.purebred ];
-  icuPackageDep = hp: if with-icu then [ hp.purebred-icu ] else [];
-  env = haskellPackages.ghcWithPackages envPackages;
-  nativeBuildTools = with pkgs.haskellPackages; [
-    cabal-install
-    cabal2nix
-    ghcid
-    hlint
-    haskell-language-server
-    ormolu
-    hie-bios
-    pkgs.notmuch
-    pkgs.tmux
-    pkgs.gnumake
-    pkgs.asciidoctor
-    pkgs.python3Packages.pygments
-  ];
-in
-    if pkgs.lib.inNixShell
-    then haskellPackages.shellFor {
-      withHoogle = true;
-      packages = haskellPackages: [ haskellPackages.purebred ] ++ icuPackageDep haskellPackages;
-      nativeBuildInputs = haskellPackages.purebred.env.nativeBuildInputs ++ nativeBuildTools;
-    }
-    else {
-      purebred = pkgs.stdenv.mkDerivation {
-        name = "purebred-with-packages-${env.version}";
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        # This creates a Bash script, which sets the GHC in order for dyre to be
-        # able to build the config file.
-        buildCommand = ''
-          mkdir -p $out/bin
-          makeWrapper ${env}/bin/purebred $out/bin/purebred \
-          --set NIX_GHC "${env}/bin/ghc"
-        '';
-        preferLocalBuild = true;
-        allowSubstitutes = false;
-      };
-    }
+(import .nix/nixpkgs.nix args).purebred-with-packages

--- a/flake.lock
+++ b/flake.lock
@@ -11,8 +11,8 @@
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
         "type": "github"
       }
     },
@@ -24,11 +24,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,78 +2,33 @@
   description = "Purebred development environment";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs?rev=34ad3ffe08adfca17fcb4e4a47bb5f3b113687be";
     utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { self, nixpkgs, utils }: {
 
-    overlays = {
-      purebred = final: prev: with prev.haskell.lib; {
-        # TODO handle different compilers
-        haskellPackages = prev.haskell.packages.ghc901.override {
-          overrides = hself: hsuper: {
-            purebred = hsuper.callPackage .nix/purebred.nix { };
-            purebred-email = hsuper.callPackage .nix/purebred-email.nix { };
-            purebred-icu = hsuper.callPackage .nix/purebred-icu.nix { };
-            dyre = hsuper.callPackage .nix/dyre.nix { };
-            brick = hsuper.callPackage .nix/brick.nix { };
-            typed-process = hsuper.callPackage .nix/typed-process.nix { };
-          };
-        };
-      };
-    };
+    overlay = final: prev:
+    let
+      overlays = import .nix/overlays.nix;
+    in
+    prev.lib.composeManyExtensions overlays final prev;
+
   } // utils.lib.eachSystem ["x86_64-linux"] (system:
   let
-    pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.purebred ]; };
-    nativeBuildTools = with pkgs.haskellPackages; [
-      cabal-install
-      cabal2nix
-      ghcid
-      hlint
-      haskell-language-server
-      ormolu
-      hie-bios
-      pkgs.notmuch
-      pkgs.tmux
-      pkgs.gnumake
-      pkgs.asciidoctor
-      pkgs.python3Packages.pygments
-    ];
-    mkShell = with-icu: pkgs.haskellPackages.shellFor {
-      withHoogle = true;
-      packages = hp: [ hp.purebred ] ++ (if with-icu then [hp.purebred-icu] else []);
-      nativeBuildInputs = pkgs.haskellPackages.purebred.env.nativeBuildInputs ++ nativeBuildTools;
-    };
-    mkPurebredWithPackages = with-icu:
-    let
-      envPackages = self: if with-icu then [ self.purebred-icu ] else [ self.purebred ];
-      env = pkgs.haskellPackages.ghcWithPackages envPackages;
-    in pkgs.stdenv.mkDerivation {
-      name = "purebred-with-packages-${env.version}";
-      nativeBuildInputs = [ pkgs.makeWrapper ];
-      # This creates a Bash script, which sets the GHC in order for dyre to be
-      # able to build the config file.
-      buildCommand = ''
-        mkdir -p $out/bin
-        makeWrapper ${env}/bin/purebred $out/bin/purebred \
-        --set NIX_GHC "${env}/bin/ghc"
-      '';
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    };
+    pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
   in rec {
     packages = {
-      purebred-with-packages = mkPurebredWithPackages false;
-      purebred-with-packages-icu = mkPurebredWithPackages true;
+      purebred-with-packages = pkgs.purebred-with-packages;
+      purebred-with-packages-icu = pkgs.purebred-with-packages-icu;
       purebred = pkgs.haskellPackages.purebred;
       purebred-email = pkgs.haskellPackages.purebred-email;
       purebred-icu = pkgs.haskellPackages.purebred-icu;
       dyre = pkgs.haskellPackages.dyre;
       brick = pkgs.haskellPackages.brick;
       # shell "packages" for `nix develop .#shell-with/out-icu`
-      shell-without-icu = mkShell false;
-      shell-with-icu = mkShell true;
+      shell-without-icu = pkgs.make-purebred-shell false;
+      shell-with-icu = pkgs.make-purebred-shell true;
     };
     defaultPackage = packages.purebred-with-packages;
     devShell = packages.shell-without-icu;


### PR DESCRIPTION
We currently define sources to build purebred in nix in different
files. Both keep around redundant information found in both. Since nix
flakes is still experimental, we didn't want to make `nix develop` the
default when building the nix package. So we kept the older `nix-build`
around which also defined overlays etc.

Instead simplify everything by defining a single source of truth in
`overlays` which is then used by two methods of building in nix: the old
`nix-build` way and the newer `nix build`.