### PR TITLE
fixes for GHC 9.2 support

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -109,7 +109,7 @@ library
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0
-                     , notmuch >= 0.3 && < 0.4
+                     , notmuch >= 0.3.1 && < 0.4
                      , text
                      , typed-process >= 0.2.8.0
                      , directory >= 1.2.5.0


### PR DESCRIPTION
```
commit a983dca07a183fd8289d856b2a6de75fc38e299e (HEAD -> fix/9.2-support, origin/fix/9.2-support)
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Sat Jul 23 10:47:00 2022 +1000

    deps: require notmuch >= 0.3.1
    
    notmuch-0.3.1 fixes a bug that can cause deadlock in databaseOpen.
    Bump notmuch lower-bound to >= 0.3.1.

commit 1492b3f03f129c65824d132c5a00ebca5bcc03fe
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Fri Jul 22 21:11:40 2022 +1000

    uat: implement backoff in assertFileAmountInMaildir
    
    For whatever reason, some operations take a bit longer in GHC 9.2
    and the tests that check whether files have been added/removed can
    fail spuriously.  We need to wait a bit longer.
    
    Increase the delay by way of exponential backoff, up to a total of
    just under one second.
```