### PR TITLE
Refactor HasToggleableList, and other cleanups

### DIFF
--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -304,14 +304,14 @@ class (HasList (n :: Name), Traversable (T n)) =>
   toggleState :: Lens' (E n) Bool
   inner :: Lens' (E n) (Inner n)
 
-  untoggleAll :: (MonadState AppState m) => m ()
-  untoggleAll = assign (list @n . traversed . toggleState @n) False
-
   toggle :: StateT AppState (T.EventM Name) ()
 
-  -- | Traversal of selected items.
-  toggledItemsL :: Traversal' AppState (Inner n)
-  toggledItemsL = list @n . traversed . filtered (view (toggleState @n)) . inner @n
+untoggleAll :: forall n m. (HasToggleableList n, MonadState AppState m) => m ()
+untoggleAll = assign (list @n . traversed . toggleState @n) False
+
+-- | Traversal of selected items.
+toggledItemsL :: forall n. (HasToggleableList n) => Traversal' AppState (Inner n)
+toggledItemsL = list @n . traversed . filtered (view (toggleState @n)) . inner @n
 
 type family Snd a
 type instance Snd (a, b) = b

--- a/src/Purebred/UI/Draw/Main.hs
+++ b/src/Purebred/UI/Draw/Main.hs
@@ -15,10 +15,8 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Module holding generic widgets.
 module Purebred.UI.Draw.Main
@@ -55,11 +53,12 @@ editorDrawContent showError st = let widget = txt $ T.unlines st
                                  in if showError then withAttr editorErrorAttr widget else widget
 
 -- | Renders editor with a label on the left restricted to one line
-renderEditorWithLabel ::
-     (HasName n, HasEditor n) => Proxy n -> T.Text -> AppState -> Widget Name
-renderEditorWithLabel p label s =
-  let hasFocus = name p == focusedViewWidget s
-      inputW = E.renderEditor (editorDrawContent (hasError s)) hasFocus (view (editorL p) s)
+renderEditorWithLabel
+  :: forall n. (HasName n, HasEditor n)
+  => Proxy n -> T.Text -> AppState -> Widget Name
+renderEditorWithLabel _ label s =
+  let hasFocus = name @n == focusedViewWidget s
+      inputW = E.renderEditor (editorDrawContent (hasError s)) hasFocus (view (editorL @n) s)
       labelW = withAttr editorLabelAttr $ padRight (Pad 1) $ txt label
       eAttr =
         if hasFocus


### PR DESCRIPTION
Related to https://github.com/purebred-mua/purebred/issues/471, and accomplishes some of the
refactors and cleanup I had in mind when filing that issue - but without any behavioural changes
(hopefully!)

```
commit 20b614ad01a92127b0ab45ab365cc761cf72c943
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Thu Jul 28 16:42:34 2022 +1000

    ui: simplify 'toggle'
    
    Simplify the Toggleable class and in particular the 'toggle' effect.
    The previous approach was "two phase" - first find the index of the
    current item, then toggle it.  We now avoid this by way of the
    'listSelectedElementL' Traversal, which targets the currently
    selected item.
    
    `listSelectedElementL` has been merged into Brick itself, but is not
    yet released.  We can migrate to the Brick-supplied version after it
    has been released.

commit b5b4f328c81adccc9c3b6bd37d8b1a6d54dd3f28
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Fri Jul 29 11:34:57 2022 +1000

    ui: toggledItemsL: target "inner" values
    
    The toggledItemsL targets the whole `Toggleable a`, which includes
    the "is toggled" `Bool`.  This makes it an unlawful `Traversal` -
    you can changed the state that says which elements are targeted.  It
    is also unneeded.  Functions are forced to handle a (Bool, a), but
    always discard the first element.
    
    Fix these problem by changing 'toggledItemsL' to target the inner
    `a` values of the `Toggleable a` list items.  This makes it a lawful
    `Traversal` and simplifies the traversal functions.

commit 2e5257862c5f5dce21b9c0538d37531322e5c494
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Tue Aug 2 22:01:31 2022 +1000

    ui: use type applications instead of Proxy
    
    Make things just a little tidier in our Purebred.UI.Actions by using
    -XTypeApplications.  This avoids the need to construct and
    explicitly pass around Proxy values.

commit 431d0e44fb7fe20fb35edcfedca98dead306574b (HEAD -> refactor/toggleable, origin/refactor/toggleable)
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Tue Aug 2 22:08:24 2022 +1000

    ui: extract untoggleAll and toggledItemsL from class
    
    The `untoggleAll` and `toggledItemsL` functions are defined in terms
    of other members of `HasToggleableList` and its superclass
    `HasList`.  Extract them from the class as top-level values.
```