### PR TITLE
rename countThreads -> countMessages

### DIFF
--- a/src/Purebred/Storage/Notmuch.hs
+++ b/src/Purebred/Storage/Notmuch.hs
@@ -27,7 +27,7 @@ module Purebred.Storage.Notmuch (
     -- ** Threads
     getThreads
   , getThreadMessages
-  , countThreads
+  , countMessages
 
     -- ** Messages
   , messageTagModify
@@ -217,10 +217,10 @@ getDatabasePath = do
   where
       decode = T.unpack . sanitiseText . decodeLenient . LB.toStrict
 
--- | Return the number of threads for the given query
-countThreads ::
+-- | Return the number of messages for the given query
+countMessages ::
      (MonadError Error m, MonadIO m) => T.Text -> FilePath -> m Int
-countThreads query fp =
+countMessages query fp =
   withDatabaseReadOnly fp $
   flip Notmuch.query (Notmuch.Bare $ T.unpack query)
   >=> Notmuch.queryCountMessages

--- a/src/Purebred/UI/Status/Main.hs
+++ b/src/Purebred/UI/Status/Main.hs
@@ -49,7 +49,7 @@ import Purebred.UI.Widgets (editEditorL)
 
 checkForNewMail :: BChan PurebredEvent -> FilePath -> Text -> Delay -> IO ()
 checkForNewMail chan dbpath query delay = do
-  r <- runExceptT (Notmuch.countThreads query dbpath)
+  r <- runExceptT (Notmuch.countMessages query dbpath)
   case r of
     Left _ -> pure ()
     Right n -> notify n *> rescheduleMailcheck chan dbpath query delay


### PR DESCRIPTION
The countThreads command actually counts the number of messages in
threads matching the query term.  Rename the function to express
this.