### PR TITLE
more refactors (move some definitions)

### DIFF
--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -177,14 +177,13 @@ import Purebred.UI.Mail.Keybindings
 import Purebred.UI.Actions
 import Purebred.UI.Status.Main (rescheduleMailcheck)
 import Purebred.Config
-    (defaultConfig, solarizedDark, mailTagAttr, sendmail,
+    (defaultConfig, solarizedDark, mailTagAttr, sendmail, getDatabasePath,
     listStateSelectedAttr, listStateToggledAttr, listStateNewmailAttr)
 import Purebred.Types
 import Purebred.Plugin
 import Purebred.Plugin.Internal
   ( configHook, pluginBuiltIn, pluginName, pluginVersion )
 import Purebred.Plugin.TweakConfig
-import Purebred.Storage.Notmuch (getDatabasePath)
 import Purebred.Storage.Tags (TagOp(..))
 import Purebred.Types.Error
 

--- a/src/Purebred/Config.hs
+++ b/src/Purebred/Config.hs
@@ -62,7 +62,6 @@ import Purebred.UI.ComposeEditor.Keybindings
 import Purebred.Types
 import Purebred.Plugin.Internal
 import qualified Purebred.Plugin.UserAgent
-import Purebred.Storage.Notmuch (getDatabasePath)
 import Purebred.System.Process
 import Purebred.Types.IFC (sanitiseText, untaint)
 import Purebred.Types.Error
@@ -259,6 +258,21 @@ mailbodyAttr = "mailbody"
 mailbodySourceAttr :: A.AttrName
 mailbodySourceAttr = mailbodyAttr <> "source"
 
+
+-- | Returns the notmuch database path by executing 'notmuch config
+-- get database.path' in a separate process.  If the process terminates
+-- abnormally, returns an empty string.
+--
+getDatabasePath :: IO FilePath
+getDatabasePath = do
+  let cmd = "notmuch"
+  let args = ["config", "get", "database.path"]
+  (exitc, stdout, _err) <- readProcess $ proc cmd args
+  pure $ case exitc of
+    ExitFailure _ -> ""
+    ExitSuccess -> filter (/= '\n') (untaint decode stdout)
+  where
+      decode = T.unpack . sanitiseText . decodeLenient . L.toStrict
 
 -- * Purebred's Configuration
 

--- a/src/Purebred/UI/Index/Main.hs
+++ b/src/Purebred/UI/Index/Main.hs
@@ -36,7 +36,7 @@ import Notmuch (getTag)
 
 import Purebred.UI.Draw.Main (fillLine)
 import Purebred.UI.Views (focusedViewWidget)
-import Purebred.Storage.Notmuch (hasTag, ManageTags)
+import Purebred.Storage.Tags (hasTag, ManageTags)
 import Purebred.Types
 import Purebred.Config
   (listAttr, listStateNewmailAttr, listStateSelectedAttr,

--- a/test/TestMail.hs
+++ b/test/TestMail.hs
@@ -35,9 +35,8 @@ import Test.QuickCheck.Instances ()
 import Notmuch (mkTag, tagMaxLen)
 
 import Purebred.Types
-import Purebred.Storage.Notmuch (addTags, removeTags, tagItem)
 import Purebred.Storage.Mail (findMatchingWords)
-import Purebred.Storage.Tags (TagOp(..))
+import Purebred.Storage.Tags (TagOp(..), addTags, removeTags, tagItem)
 
 mailTests ::
   TestTree


### PR DESCRIPTION
```
commit c936d6ec7767045fe48108ecd604b41bcc5faee7 (HEAD -> refactor/moves, origin/refactor/moves)
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Fri Aug 5 00:33:02 2022 +1000

    move getDatabasePath to Purebred.Config
    
    Let's keep Purebred.Storage.* focused on the database operations
    rather than finding out where the database is, which is a config
    consideration.

commit 3c407e436dccbd44b9293b52fbb0d115254475b2
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Fri Aug 5 00:32:00 2022 +1000

    extract tag management functions to Purebred.Storage.Tags
```