### PR TITLE
nix: Make purebred with ICU the default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       shell-without-icu = pkgs.make-purebred-shell false;
       shell-with-icu = pkgs.make-purebred-shell true;
     };
-    defaultPackage = packages.purebred-with-packages;
+    defaultPackage = packages.purebred-with-packages-icu;
     devShell = packages.shell-without-icu;
   });
 }


### PR DESCRIPTION
Currently the purebred default package in the nix flake is set to
purebred without ICU. But arguably the ICU plugin is something most
users would want to have hence this patch to make it a default package.