### PR TITLE
migrate to brick-1.0

### DIFF
--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -38,16 +38,14 @@ import Data.List.NonEmpty (NonEmpty(..))
 
 myBrowseThreadsKbs :: [Keybinding 'Threads 'ListOfThreads]
 myBrowseThreadsKbs =
-  [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"]
-                                       `chain` untoggleListItems
-                                       `chain` continue)
+  [ Keybinding (EvKey (KChar 'a') [])
+      (setTags [RemoveTag "inbox", AddTag "archive"] *> untoggleListItems)
   ]
 
 myMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 myMailKeybindings =
-    [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"]
-                                         `chain` untoggleListItems
-                                         `chain` continue)
+    [ Keybinding (EvKey (KChar 'a') [])
+      (setTags [RemoveTag "inbox", AddTag "archive"] *> untoggleListItems)
     ]
 
 sendFailRef :: IORef Bool

--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -95,8 +95,8 @@ main =
 
 myColoredTags :: [(AttrName, Attr)]
 myColoredTags =
-  [ (mailTagAttr <> "inbox", fg cyan)
-  , (mailTagAttr <> "archive", fg cyan)
-  , (mailTagAttr <> "signed", fg green)
-  , (mailTagAttr <> "attachment", fg brightRed)
+  [ (mailTagAttr <> attrName "inbox", fg cyan)
+  , (mailTagAttr <> attrName "archive", fg cyan)
+  , (mailTagAttr <> attrName "signed", fg green)
+  , (mailTagAttr <> attrName "attachment", fg brightRed)
   ]

--- a/docs/man/index.adoc
+++ b/docs/man/index.adoc
@@ -118,8 +118,7 @@ import Purebred
 
 myMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]    -- <1>
 myMailKeybindings =
-    [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"]  -- <2>
-                                         `chain` continue)  -- <3>
+    [ Keybinding (EvKey (KChar 'a') []) (setTags [RemoveTag "inbox", AddTag "archive"])  -- <2>
     ]
 
 -- Tweak the default configuration before starting Purebred
@@ -128,17 +127,14 @@ main = purebred
   [ usePlugin $ tweakConfig tweak
   ]
   where
-  tweak = over (confMailView . mvKeybindings) (myMailKeybindings <>)  -- <4>
+  tweak = over (confMailView . mvKeybindings) (myMailKeybindings <>)  -- <3>
 
 ----
 <1> The type indicates that this list holds key bindings for the
 `ViewMail` view and the `ScrollingMailView` widget.
 <2> The keybinding starts by calling the `setTags` action, removing
 and adding labels.
-<3> Every keybinding will have to end with a Brick event loop
-action. The `continue` action continues the event loop and therefore
-Purebred.
-<4> Add the custom key bindings to the configuration (via the `tweakPlugin`
+<3> Add the custom key bindings to the configuration (via the `tweakPlugin`
 plugin).  Use <<lens>> functions to prepend the custom keybindings to the
 default keybindings.
 custom list.

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -105,7 +105,7 @@ library
                      , deepseq >= 1.4.2
                      , dyre >= 0.9.1
                      , lens
-                     , brick >= 0.72 && < 0.74
+                     , brick >= 1.0
                      , text-zipper
                      , vty
                      , vector >= 0.12.0.0

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -45,17 +45,17 @@ tweak =
 
 scrollKeybindings :: ('Scrollable' w) => ['Keybinding' v w]
 scrollKeybindings =
-  [ 'Keybinding' (EvKey (KChar 'j') []) ('scrollDown' \`chain\` 'continue')
-  , Keybinding (EvKey (KChar 'k') []) ('scrollUp' \`chain\` 'continue')
-  , Keybinding (EvKey (KChar 'd') []) ('scrollPageDown' \`chain\` 'continue')
-  , Keybinding (EvKey (KChar 'u') []) ('scrollPageUp' \`chain\` 'continue')
+  [ 'Keybinding' (EvKey (KChar 'j') []) 'scrollDown'
+  , Keybinding (EvKey (KChar 'k') []) 'scrollUp'
+  , Keybinding (EvKey (KChar 'd') []) 'scrollPageDown'
+  , Keybinding (EvKey (KChar 'u') []) 'scrollPageUp'
   ]
 
 mailViewKeybindings =
-  [ Keybinding (EvKey (KChar 'J') []) ('listDown' \`focus\` 'displayMail' \`chain\` continue)
-  , Keybinding (EvKey (KChar 'K') []) ('listUp' \`focus\` displayMail \`chain\` continue)
-  , Keybinding (EvKey (KChar 'G') []) ('listJumpToEnd' \`chain\` continue)
-  , Keybinding (EvKey (KChar 'g') []) ('listJumpToStart' \`chain\` continue)
+  [ Keybinding (EvKey (KChar 'J') []) ('listDown' !*> 'displayMail')
+  , Keybinding (EvKey (KChar 'K') []) ('listUp' !*> displayMail)
+  , Keybinding (EvKey (KChar 'G') []) 'listJumpToEnd'
+  , Keybinding (EvKey (KChar 'g') []) 'listJumpToStart'
   ]
   <> scrollKeybindings
 @

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -136,8 +136,8 @@ module Purebred (
   Event(..),
   Key(..),
   Modifier(..),
-  Next,
   AttrName,
+  attrName,
   on,
   fg,
   bg,
@@ -193,9 +193,8 @@ import Graphics.Vty.Attributes
 import Graphics.Vty.Input.Events (Event(..), Key(..), Modifier(..))
 import Brick.BChan (newBChan)
 import Brick.Main (customMain)
-import Brick.Types (Next)
 import Brick.Util (on, fg, bg)
-import Brick.AttrMap (AttrName, applyAttrMappings)
+import Brick.AttrMap (AttrName, applyAttrMappings, attrName)
 import Control.Lens ((&), _head, ifoldMap, ix, over, preview, set, toListOf, view, views)
 import Data.Text.Lens (packed)
 import Data.MIME (Mailbox(..), AddrSpec(..), Domain(..))

--- a/src/Purebred/Config.hs
+++ b/src/Purebred/Config.hs
@@ -139,33 +139,33 @@ solarizedDark =
 -- That means that for example, any new list items will inherit colour
 -- definitions from selected and toggled attributes.
 listStateSelectedAttr :: A.AttrName
-listStateSelectedAttr = "selected"
+listStateSelectedAttr = A.attrName "selected"
 
 listStateNewmailAttr :: A.AttrName
-listStateNewmailAttr = "newmail"
+listStateNewmailAttr = A.attrName "newmail"
 
 listStateToggledAttr :: A.AttrName
-listStateToggledAttr = "toggled"
+listStateToggledAttr = A.attrName "toggled"
 
 -- ** Widget Attributes
 --
 defaultAttr :: A.AttrName
-defaultAttr = "default"
+defaultAttr = A.attrName "default"
 
 mailViewAttr :: A.AttrName
-mailViewAttr = "mailview"
+mailViewAttr = A.attrName "mailview"
 
 statusbarAttr :: A.AttrName
-statusbarAttr = "statusbar"
+statusbarAttr = A.attrName "statusbar"
 
 statusbarErrorAttr :: A.AttrName
-statusbarErrorAttr = statusbarAttr <> "error"
+statusbarErrorAttr = statusbarAttr <> A.attrName "error"
 
 statusbarInfoAttr :: A.AttrName
-statusbarInfoAttr = statusbarAttr <> "info"
+statusbarInfoAttr = statusbarAttr <> A.attrName "info"
 
 statusbarWarningAttr :: A.AttrName
-statusbarWarningAttr = statusbarAttr <> "warning"
+statusbarWarningAttr = statusbarAttr <> A.attrName "warning"
 
 editorAttr :: A.AttrName
 editorAttr = E.editAttr
@@ -174,10 +174,10 @@ editorFocusedAttr :: A.AttrName
 editorFocusedAttr = E.editFocusedAttr
 
 editorErrorAttr :: A.AttrName
-editorErrorAttr = editorAttr <> "error"
+editorErrorAttr = editorAttr <> A.attrName "error"
 
 editorLabelAttr :: A.AttrName
-editorLabelAttr = editorAttr <> "label"
+editorLabelAttr = editorAttr <> A.attrName "label"
 
 listAttr :: A.AttrName
 listAttr = L.listAttr
@@ -201,16 +201,16 @@ listSelectedToggledAttr :: A.AttrName
 listSelectedToggledAttr = listStateSelectedAttr <> listToggledAttr
 
 mailAttr :: A.AttrName
-mailAttr = "mail"
+mailAttr = A.attrName "mail"
 
 mailTagAttr :: A.AttrName
-mailTagAttr = mailAttr <> "tag"
+mailTagAttr = mailAttr <> A.attrName "tag"
 
 mailTagToggledAttr :: A.AttrName
 mailTagToggledAttr = mailTagAttr <> listStateToggledAttr
 
 mailAuthorsAttr :: A.AttrName
-mailAuthorsAttr = mailAttr <> "authors"
+mailAuthorsAttr = mailAttr <> A.attrName "authors"
 
 mailNewmailAuthorsAttr :: A.AttrName
 mailNewmailAuthorsAttr = mailAuthorsAttr <> listStateNewmailAttr
@@ -228,35 +228,35 @@ mailSelectedToggledAuthorsAttr :: A.AttrName
 mailSelectedToggledAuthorsAttr = mailSelectedAuthorsAttr <> listStateToggledAttr
 
 headerAttr :: A.AttrName
-headerAttr = "header"
+headerAttr = A.attrName "header"
 
 headerKeyAttr :: A.AttrName
-headerKeyAttr = headerAttr <> "key"
+headerKeyAttr = headerAttr <> A.attrName "key"
 
 headerValueAttr :: A.AttrName
-headerValueAttr = headerAttr <> "value"
+headerValueAttr = headerAttr <> A.attrName "value"
 
 helpAttr :: A.AttrName
-helpAttr = "help"
+helpAttr = A.attrName "help"
 
 helpTitleAttr :: A.AttrName
-helpTitleAttr = helpAttr <> "title"
+helpTitleAttr = helpAttr <> A.attrName "title"
 
 helpKeybindingAttr :: A.AttrName
-helpKeybindingAttr = helpAttr <> "keybinding"
+helpKeybindingAttr = helpAttr <> A.attrName "keybinding"
 
 
 textMatchHighlightAttr :: A.AttrName
-textMatchHighlightAttr = "match"
+textMatchHighlightAttr = A.attrName "match"
 
 currentTextMatchHighlightAttr :: A.AttrName
-currentTextMatchHighlightAttr = textMatchHighlightAttr <> "current"
+currentTextMatchHighlightAttr = textMatchHighlightAttr <> A.attrName "current"
 
 mailbodyAttr :: A.AttrName
-mailbodyAttr = "mailbody"
+mailbodyAttr = A.attrName "mailbody"
 
 mailbodySourceAttr :: A.AttrName
-mailbodySourceAttr = mailbodyAttr <> "source"
+mailbodySourceAttr = mailbodyAttr <> A.attrName "source"
 
 
 -- | Returns the notmuch database path by executing 'notmuch config

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -325,27 +325,7 @@ instance
   type Inner n = Snd (E n)
   toggleState = _1
   inner = _2
-  toggle = modifying (list @n . listSelectedElementL . toggleState @n) not
-
--- | Traversal of selected element (if any)
---
--- This has been merged in Brick master and we can switch
--- to the version exported by Brick, after it sees release.
---
-listSelectedElementL
-  :: (L.Splittable t, Traversable t, Semigroup (t e))
-  => Traversal' (L.GenericList n t e) e
-listSelectedElementL f l =
-  case view L.listSelectedL l of
-    Nothing -> pure l
-    Just i -> L.listElementsL go l
-      where
-      go l' =
-        let
-          (left, rest) = L.splitAt i l'
-          -- middle contains the target element (if any)
-          (middle, right) = L.splitAt 1 rest
-        in fmap (\m -> left <> m <> right) (traverse f middle)
+  toggle = modifying (list @n . L.listSelectedElementL . toggleState @n) not
 
 -- | A function which is run at the end of a chained sequence of actions.
 --
@@ -1429,9 +1409,9 @@ toggledOrSelectedItemHelper
   -> m ()
 toggledOrSelectedItemHelper fx updateFx = do
   toggled   <- gets (toListOf (toggledItemsL @n))
-  selected  <- gets (toListOf (list @n . listSelectedElementL . inner @n))
+  selected  <- gets (toListOf (list @n . L.listSelectedElementL . inner @n))
   if null toggled
-    then fx selected >> modifying (list @n . listSelectedElementL . inner @n) updateFx
+    then fx selected >> modifying (list @n . L.listSelectedElementL . inner @n) updateFx
     else fx toggled >> modifying (toggledItemsL @n) updateFx
   pure ()
 

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -45,7 +45,6 @@ module Purebred.UI.Actions (
   -- ** Brick Event Loop Actions
   -- $brick_actions
   , quit
-  , continue
   , edit
   , invokeEditor
   , openWithCommand
@@ -191,13 +190,13 @@ This keybinding registered to backspace, scrolls a page up and
 continues with the event loop:
 
 @
-'Keybinding' (EvKey KBS []) ('scrollPageUp' ``chain`` 'continue')
+'Keybinding' (EvKey KBS []) 'scrollPageUp'
 @
 
 This keybinding is used to change the view and focus to a different widget:
 
 @
-'Keybinding' (EvKey KEsc []) ('noop' ``focus`` 'continue' @@''Threads' @@''ListOfThreads')
+'Keybinding' (EvKey KEsc []) (switchView @@''Threads' @@''ListOfThreads')
 @
 -}
 
@@ -792,25 +791,10 @@ instance HasViewName 'ComposeView where
 instance HasViewName 'FileBrowser where
   viewname = FileBrowser
 
-
--- $brick_actions
--- These actions wrap Brick's event loop functions. They are used to
--- indicate whether we continue the event loop or halt (quit). These
--- actions typically finish a sequence of chained Actions. Use them at
--- the __end__ of a chained sequence.
---
--- Note:
--- While only 'quit' and 'continue' falls into this category, more
--- Purebred functions fall into this category because we're missing
--- ways to modularise them. See #294
+-- | Cause Brick to terminate the event loop
 --
 quit :: Action v ctx ()
 quit = Action ["quit the application"] Brick.halt
-
--- | A noop used to continue the Brick event loop.
---
-continue :: Action v ctx ()
-continue = Action mempty (pure ())
 
 -- | Suspends Purebred and invokes the configured editor.
 --

--- a/src/Purebred/UI/ComposeEditor/Keybindings.hs
+++ b/src/Purebred/UI/ComposeEditor/Keybindings.hs
@@ -26,75 +26,89 @@ import Purebred.Types
 
 composeSubjectKeybindings :: [Keybinding 'ComposeView 'ComposeSubject]
 composeSubjectKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    [ Keybinding (V.EvKey V.KEsc [])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter [])
+        (done *> switchView @'ComposeView @'ComposeListOfAttachments)
     ]
 
 composeFromKeybindings :: [Keybinding 'ComposeView 'ComposeFrom]
 composeFromKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    [ Keybinding (V.EvKey V.KEsc [])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter [])
+        (done *> switchView @'ComposeView @'ComposeListOfAttachments)
     ]
 
 composeToKeybindings :: [Keybinding 'ComposeView 'ComposeTo]
 composeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    [ Keybinding (V.EvKey V.KEsc [])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter [])
+        (done *> switchView @'ComposeView @'ComposeListOfAttachments)
     ]
 
 composeCcKeybindings :: [Keybinding 'ComposeView 'ComposeCc]
 composeCcKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    [ Keybinding (V.EvKey V.KEsc [])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter [])
+        (done *> switchView @'ComposeView @'ComposeListOfAttachments)
     ]
 
 composeBccKeybindings :: [Keybinding 'ComposeView 'ComposeBcc]
 composeBccKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ComposeView @'ComposeListOfAttachments)
+    [ Keybinding (V.EvKey V.KEsc [])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl])
+        (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey V.KEnter [])
+        (done *> switchView @'ComposeView @'ComposeListOfAttachments)
     ]
 
 confirmKeybindings :: [Keybinding 'ComposeView 'ConfirmDialog]
 confirmKeybindings =
   [ Keybinding
       (V.EvKey V.KEnter [])
-      (handleConfirm `focus` reloadList `chain` continue)
+      (handleConfirm !*> reloadList)
   , Keybinding
       (V.EvKey (V.KChar 'q') [])
-      (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
+      (switchView @'ComposeView @'ComposeListOfAttachments)
   , Keybinding
       (V.EvKey V.KEsc [])
-      (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
+      (switchView @'ComposeView @'ComposeListOfAttachments)
   ]
 
 confirmAbort :: Action 'ComposeView 'ComposeListOfAttachments ()
-confirmAbort =
-  noop `focus` continue @'ComposeView @'ConfirmDialog
+confirmAbort = switchView @'ComposeView @'ConfirmDialog
 
 listOfAttachmentsKeybindings :: [Keybinding 'ComposeView 'ComposeListOfAttachments]
 listOfAttachmentsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) confirmAbort
     , Keybinding (V.EvKey (V.KChar 'q') []) confirmAbort
-    , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
-    , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
+    , Keybinding (V.EvKey V.KDown []) listDown
+    , Keybinding (V.EvKey V.KUp []) listUp
+    , Keybinding (V.EvKey (V.KChar 'j') []) listDown
+    , Keybinding (V.EvKey (V.KChar 'k') []) listUp
+    , Keybinding (V.EvKey (V.KChar 'G') []) listJumpToEnd
+    , Keybinding (V.EvKey (V.KChar '1') []) listJumpToStart
     , Keybinding (V.EvKey (V.KChar 'y') [])
-        (ifte done (switchView @'Threads @'ListOfThreads) noop *> continue)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (noop `focus` continue @'Threads @'ListOfThreads)
+        (ifte done (switchView @'Threads @'ListOfThreads) noop)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (switchView @'Threads @'ListOfThreads)
     , Keybinding (V.EvKey (V.KChar 'e') []) edit
-    , Keybinding (V.EvKey (V.KChar 'D') []) (delete `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'a') []) (noop `focus` continue @'FileBrowser @'ListOfFiles)
-    , Keybinding (V.EvKey (V.KChar 't') []) (noop `focus` continue @'ComposeView @'ComposeTo)
-    , Keybinding (V.EvKey (V.KChar 'c') []) (noop `focus` continue @'ComposeView @'ComposeCc)
-    , Keybinding (V.EvKey (V.KChar 'b') []) (noop `focus` continue @'ComposeView @'ComposeBcc)
-    , Keybinding (V.EvKey (V.KChar 's') []) (noop `focus` continue @'ComposeView @'ComposeSubject)
-    , Keybinding (V.EvKey (V.KChar 'f') []) (noop `focus` continue @'ComposeView @'ComposeFrom)
+    , Keybinding (V.EvKey (V.KChar 'D') []) delete
+    , Keybinding (V.EvKey (V.KChar 'a') []) (switchView @'FileBrowser @'ListOfFiles)
+    , Keybinding (V.EvKey (V.KChar 't') []) (switchView @'ComposeView @'ComposeTo)
+    , Keybinding (V.EvKey (V.KChar 'c') []) (switchView @'ComposeView @'ComposeCc)
+    , Keybinding (V.EvKey (V.KChar 'b') []) (switchView @'ComposeView @'ComposeBcc)
+    , Keybinding (V.EvKey (V.KChar 's') []) (switchView @'ComposeView @'ComposeSubject)
+    , Keybinding (V.EvKey (V.KChar 'f') []) (switchView @'ComposeView @'ComposeFrom)
     ]

--- a/src/Purebred/UI/ComposeEditor/Keybindings.hs
+++ b/src/Purebred/UI/ComposeEditor/Keybindings.hs
@@ -19,7 +19,6 @@
 
 module Purebred.UI.ComposeEditor.Keybindings where
 
-import qualified Brick.Types as T
 import qualified Graphics.Vty as V
 import Purebred.UI.Actions
 import Purebred.Types
@@ -73,7 +72,7 @@ confirmKeybindings =
       (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
   ]
 
-confirmAbort :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
+confirmAbort :: Action 'ComposeView 'ComposeListOfAttachments ()
 confirmAbort =
   noop `focus` continue @'ComposeView @'ConfirmDialog
 

--- a/src/Purebred/UI/ComposeEditor/Main.hs
+++ b/src/Purebred/UI/ComposeEditor/Main.hs
@@ -25,9 +25,9 @@ module Purebred.UI.ComposeEditor.Main
   , renderConfirm
   ) where
 
-import Brick.Types (Padding(..), Widget)
+import Brick.Types (Widget)
 import Brick.Widgets.Core
-  ((<+>), (<=>), emptyWidget, hLimit, padBottom, padLeft,
+  (Padding(..), (<+>), (<=>), emptyWidget, hLimit, padBottom, padLeft,
    txt, vLimit)
 import qualified Brick.Widgets.Edit as E
 import qualified Brick.Widgets.List as L

--- a/src/Purebred/UI/Draw/Main.hs
+++ b/src/Purebred/UI/Draw/Main.hs
@@ -25,9 +25,9 @@ module Purebred.UI.Draw.Main
   , attachmentsHeader
   ) where
 
-import Brick.Types (Padding(..), Widget)
+import Brick.Types (Widget)
 import Brick.Widgets.Core
-  (fill, txt, vLimit, padRight, (<+>), withAttr, padLeft, hBox)
+  (Padding(..), fill, txt, vLimit, padRight, (<+>), withAttr, padLeft, hBox)
 import qualified Brick.Widgets.Edit as E
 import qualified Data.Text as T
 import Data.Proxy

--- a/src/Purebred/UI/FileBrowser/Keybindings.hs
+++ b/src/Purebred/UI/FileBrowser/Keybindings.hs
@@ -26,16 +26,16 @@ import Purebred.Types
 -- | Default Keybindings
 fileBrowserKeybindings :: [Keybinding 'FileBrowser 'ListOfFiles]
 fileBrowserKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (noop `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar ':') []) (noop `focus` continue @'FileBrowser @'ManageFileBrowserSearchPath)
-    , Keybinding (V.EvKey V.KEnter []) (createAttachments `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '*') []) (fileBrowserToggleFile `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar ':') []) (switchView @'FileBrowser @'ManageFileBrowserSearchPath)
+    , Keybinding (V.EvKey V.KEnter []) createAttachments
+    , Keybinding (V.EvKey (V.KChar '*') []) fileBrowserToggleFile
     ]
 
 manageSearchPathKeybindings :: [Keybinding 'FileBrowser 'ManageFileBrowserSearchPath]
 manageSearchPathKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'FileBrowser @'ListOfFiles)
-  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'FileBrowser @'ListOfFiles)
-  , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'FileBrowser @'ListOfFiles)
+  [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'FileBrowser @'ListOfFiles)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'FileBrowser @'ListOfFiles)
+  , Keybinding (V.EvKey V.KEnter []) (done *> switchView @'FileBrowser @'ListOfFiles)
   ]

--- a/src/Purebred/UI/GatherHeaders/Keybindings.hs
+++ b/src/Purebred/UI/GatherHeaders/Keybindings.hs
@@ -25,22 +25,22 @@ import Purebred.UI.Actions
 
 gatherFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
 gatherFromKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey V.KEnter []) (noop `focus` continue @'Threads @'ComposeTo)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (switchView @'Threads @'ComposeTo)
     ]
 
 gatherToKeybindings :: [Keybinding 'Threads 'ComposeTo]
 gatherToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey V.KEnter []) (noop `focus` continue @'Threads @'ComposeSubject)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (switchView @'Threads @'ComposeSubject)
     ]
 
 gatherSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]
 gatherSubjectKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'Threads @'ListOfThreads)
     , Keybinding (V.EvKey V.KEnter []) (
         noop
         `focus` (

--- a/src/Purebred/UI/GatherHeaders/Keybindings.hs
+++ b/src/Purebred/UI/GatherHeaders/Keybindings.hs
@@ -22,7 +22,6 @@ module Purebred.UI.GatherHeaders.Keybindings where
 import qualified Graphics.Vty as V
 import Purebred.Types
 import Purebred.UI.Actions
-import qualified Brick.Types as T
 
 gatherFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
 gatherFromKeybindings =
@@ -46,6 +45,6 @@ gatherSubjectKeybindings =
         noop
         `focus` (
             invokeEditor Threads ListOfThreads
-            :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState))
+            :: Action 'ComposeView 'ComposeListOfAttachments ())
         )
     ]

--- a/src/Purebred/UI/Help/Keybindings.hs
+++ b/src/Purebred/UI/Help/Keybindings.hs
@@ -26,9 +26,9 @@ import Purebred.Types
 -- | Default Keybindings
 helpKeybindings :: [Keybinding 'Help 'ScrollingHelpView]
 helpKeybindings =
-    [ Keybinding (EvKey KEsc []) (noop `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (EvKey (KChar 'q') []) (noop `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)
-    , Keybinding (EvKey (KChar ' ') []) (scrollPageDown `chain` continue)
-    , Keybinding (EvKey KBS []) (scrollPageUp `chain` continue)
+    [ Keybinding (EvKey KEsc []) (switchView @'Threads @'ListOfThreads)
+    , Keybinding (EvKey (KChar 'q') []) (switchView @'Threads @'ListOfThreads)
+    , Keybinding (EvKey KBS []) scrollPageUp
+    , Keybinding (EvKey (KChar ' ') []) scrollPageDown
+    , Keybinding (EvKey KBS []) scrollPageUp
     ]

--- a/src/Purebred/UI/Help/Main.hs
+++ b/src/Purebred/UI/Help/Main.hs
@@ -26,10 +26,10 @@ module Purebred.UI.Help.Main
 
 import Data.Function (on)
 import Data.List (nubBy)
-import Brick.Types (Padding(..), Widget)
+import Brick.Types (Widget)
 import qualified Brick.Types as T
 import Brick.Widgets.Core
-       (viewport, hLimit, padLeft, padBottom, padRight, txt, (<=>),
+       (Padding(..), viewport, hLimit, padLeft, padBottom, padRight, txt, (<=>),
         (<+>), vBox, withAttr, emptyWidget)
 import Graphics.Vty.Input.Events (Event(..), Key(..), Modifier(..))
 import Control.Lens (view, views, ifoldr)

--- a/src/Purebred/UI/Index/Keybindings.hs
+++ b/src/Purebred/UI/Index/Keybindings.hs
@@ -27,32 +27,32 @@ browseThreadsKeybindings :: [Keybinding 'Threads 'ListOfThreads]
 browseThreadsKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) quit
     , Keybinding (V.EvKey (V.KChar 'q') []) quit
-    , Keybinding (V.EvKey V.KEnter []) (displayThreadMails `focus` selectNextUnread `focus` displayMail `chain` continue)
-    , Keybinding (V.EvKey (V.KChar ':') []) (noop `focus` continue @'Threads @'SearchThreadsEditor)
-    , Keybinding (V.EvKey (V.KChar 'm') []) (noop `focus` continue @'Threads @'ComposeFrom)
-    , Keybinding (V.EvKey (V.KChar '`') []) (noop `focus` continue @'Threads @'ManageThreadTagsEditor)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (switchComposeEditor `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '?') []) (noop `focus` continue @'Help @'ScrollingHelpView)
-    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
-    , Keybinding (V.EvKey V.KDown []) (listDown `chain` continue)
-    , Keybinding (V.EvKey V.KUp []) (listUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'G') []) (listJumpToEnd `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '1') []) (listJumpToStart `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem `chain` listDown `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '+') []) (searchRelated `chain` continue)
+    , Keybinding (V.EvKey V.KEnter []) (displayThreadMails !*> selectNextUnread !*> displayMail)
+    , Keybinding (V.EvKey (V.KChar ':') []) (switchView @'Threads @'SearchThreadsEditor)
+    , Keybinding (V.EvKey (V.KChar 'm') []) (switchView @'Threads @'ComposeFrom)
+    , Keybinding (V.EvKey (V.KChar '`') []) (switchView @'Threads @'ManageThreadTagsEditor)
+    , Keybinding (V.EvKey (V.KChar '\t') []) switchComposeEditor
+    , Keybinding (V.EvKey (V.KChar '?') []) (switchView @'Help @'ScrollingHelpView)
+    , Keybinding (V.EvKey (V.KChar 'j') []) listDown
+    , Keybinding (V.EvKey (V.KChar 'k') []) listUp
+    , Keybinding (V.EvKey V.KDown []) listDown
+    , Keybinding (V.EvKey V.KUp []) listUp
+    , Keybinding (V.EvKey (V.KChar 'G') []) listJumpToEnd
+    , Keybinding (V.EvKey (V.KChar '1') []) listJumpToStart
+    , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem *> listDown)
+    , Keybinding (V.EvKey (V.KChar '+') []) searchRelated
     ]
 
 searchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]
 searchThreadsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'Threads @'ListOfThreads)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (done *> switchView @'Threads @'ListOfThreads)
     ]
 
 manageThreadTagsKeybindings :: [Keybinding 'Threads 'ManageThreadTagsEditor]
 manageThreadTagsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` untoggleListItems @'Threads @'ListOfThreads `chain` continue)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KEnter []) (done !*> untoggleListItems @'Threads @'ListOfThreads)
     ]

--- a/src/Purebred/UI/Index/Main.hs
+++ b/src/Purebred/UI/Index/Main.hs
@@ -21,10 +21,10 @@ module Purebred.UI.Index.Main (
     renderListOfThreads
   , renderListOfMails) where
 
-import Brick.Types (Location(..), Padding(..), Widget)
+import Brick.Types (Location(..), Widget)
 import Brick.AttrMap (AttrName, attrName)
 import Brick.Widgets.Core
-  (hBox, hLimitPercent, padRight, padLeft, putCursor, txt, vLimit, withAttr, (<+>))
+  (Padding(..), hBox, hLimitPercent, padRight, padLeft, putCursor, txt, vLimit, withAttr, (<+>))
 import qualified Brick.Widgets.List as L
 import Control.Lens.Getter (view)
 import Data.Time.Clock

--- a/src/Purebred/UI/Mail/Keybindings.hs
+++ b/src/Purebred/UI/Mail/Keybindings.hs
@@ -22,7 +22,6 @@ module Purebred.UI.Mail.Keybindings where
 import qualified Graphics.Vty as V
 import Purebred.UI.Actions
 import Purebred.Types
-import qualified Brick.Types as T
 
 displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 displayMailKeybindings =
@@ -58,14 +57,13 @@ displayMailKeybindings =
         senderReply
         `focus` (
             invokeEditor ViewMail ScrollingMailView
-            :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
+            :: Action 'ComposeView 'ComposeListOfAttachments ()
             )
         )
     , Keybinding (V.EvKey (V.KChar 'g') []) (
         groupReply
         `focus` (
-            invokeEditor ViewMail ScrollingMailView
-            :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
+            invokeEditor ViewMail ScrollingMailView :: Action 'ComposeView 'ComposeListOfAttachments ()
             )
         )
     , Keybinding (V.EvKey (V.KChar 'v') []) (noop `focus` continue @'ViewMail @'MailListOfAttachments)
@@ -135,7 +133,7 @@ mailviewComposeToKeybindings =
     , Keybinding (V.EvKey V.KEnter []) (
         done `focus` (
             invokeEditor ViewMail ScrollingMailView
-            :: Action 'ComposeView 'ComposeListOfAttachments (T.Next AppState)
+            :: Action 'ComposeView 'ComposeListOfAttachments ()
             )
         )
     ]

--- a/src/Purebred/UI/Mail/Keybindings.hs
+++ b/src/Purebred/UI/Mail/Keybindings.hs
@@ -25,34 +25,36 @@ import Purebred.Types
 
 displayMailKeybindings :: [Keybinding 'ViewMail 'ScrollingMailView]
 displayMailKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `focus` continue @'Threads @'ListOfThreads)
-    , Keybinding (V.EvKey V.KBS []) (scrollPageUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem `chain` listDown `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 't') []) (setUnread `chain` continue)
-    , Keybinding (V.EvKey (V.KChar ' ') []) (scrollPageDown `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'h') []) (toggleHeaders `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '`') []) (noop `focus` continue @'ViewMail @'ManageMailTagsEditor)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey (V.KChar 'q') []) (abort *> switchView @'Threads @'ListOfThreads)
+    , Keybinding (V.EvKey V.KBS []) scrollPageUp
+    , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem *> listDown)
+    , Keybinding (V.EvKey (V.KChar 't') []) setUnread
+    , Keybinding (V.EvKey (V.KChar ' ') []) scrollPageDown
+    , Keybinding (V.EvKey (V.KChar 'h') []) toggleHeaders
+    , Keybinding (V.EvKey (V.KChar '`') []) (switchView @'ViewMail @'ManageMailTagsEditor)
 
-    , Keybinding (V.EvKey V.KUp []) (
-        noop `focus` listUp @'ViewMail @'ListOfMails `focus` displayMail `chain` continue)
-    , Keybinding (V.EvKey V.KDown []) (
-        noop `focus` listDown @'ViewMail @'ListOfMails `focus` displayMail `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown `focus` displayMail `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'J') []) (noop
-                                             `focus` listDown @'Threads @'ListOfThreads
-                                             `focus` displayThreadMails
-                                             `focus` selectNextUnread
-                                             `focus` displayMail
-                                             `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `focus` displayMail `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'K') []) (noop
-                                             `focus` listUp @'Threads @'ListOfThreads
-                                             `focus` displayThreadMails
-                                             `focus` selectNextUnread
-                                             `focus` displayMail
-                                             `chain` continue)
-    , Keybinding (V.EvKey (V.KChar '?') []) (noop `focus` continue @'Help @'ScrollingHelpView)
+    , Keybinding (V.EvKey V.KUp [])
+        (switchView @'ViewMail @'ListOfMails *> listUp *> displayMail)
+    , Keybinding (V.EvKey V.KDown [])
+        (switchView @'ViewMail @'ListOfMails *> listDown *> displayMail)
+    , Keybinding (V.EvKey (V.KChar 'j') []) (listDown !*> displayMail)
+    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp !*> displayMail)
+    , Keybinding (V.EvKey (V.KChar 'J') [])
+        ( noop
+          !*> listDown @'Threads @'ListOfThreads
+          !*> displayThreadMails
+          !*> selectNextUnread
+          !*> displayMail
+        )
+    , Keybinding (V.EvKey (V.KChar 'K') [])
+        ( noop
+          !*> listUp @'Threads @'ListOfThreads
+          !*> displayThreadMails
+          !*> selectNextUnread
+          !*> displayMail
+        )
+    , Keybinding (V.EvKey (V.KChar '?') []) (switchView @'Help @'ScrollingHelpView)
     , Keybinding (V.EvKey (V.KChar 'r') []) (
         senderReply
         `focus` (
@@ -66,70 +68,80 @@ displayMailKeybindings =
             invokeEditor ViewMail ScrollingMailView :: Action 'ComposeView 'ComposeListOfAttachments ()
             )
         )
-    , Keybinding (V.EvKey (V.KChar 'v') []) (noop `focus` continue @'ViewMail @'MailListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'e') []) (composeAsNew `focus` continue @'ComposeView @'ComposeListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar '/') []) (noop `focus` continue @'ViewMail @'ScrollingMailViewFindWordEditor)
-    , Keybinding (V.EvKey (V.KChar 'n') []) (scrollNextWord `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'f') []) (noop
-                                             `chain` encapsulateMail
-                                             `focus` continue @'ViewMail @'ComposeTo)
-    , Keybinding (V.EvKey V.KEnter []) (removeHighlights `chain` continue)
+    , Keybinding (V.EvKey (V.KChar 'v') [])
+        (switchView @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'e') [])
+        (composeAsNew *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '/') [])
+        (switchView @'ViewMail @'ScrollingMailViewFindWordEditor)
+    , Keybinding (V.EvKey (V.KChar 'n') [])
+        scrollNextWord
+    , Keybinding (V.EvKey (V.KChar 'f') [])
+        (encapsulateMail *> switchView @'ViewMail @'ComposeTo)
+    , Keybinding (V.EvKey V.KEnter [])
+        removeHighlights
     ]
 
 findWordEditorKeybindings :: [Keybinding 'ViewMail 'ScrollingMailViewFindWordEditor]
 findWordEditorKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
-  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'ScrollingMailView)
-  , Keybinding (V.EvKey V.KEnter []) (done `focus` continue @'ViewMail @'ScrollingMailView)
+  [ Keybinding (V.EvKey V.KEsc [])
+      (abort *> switchView @'ViewMail @'ScrollingMailView)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl])
+      (abort *> switchView @'ViewMail @'ScrollingMailView)
+  , Keybinding (V.EvKey V.KEnter [])
+      (done *> switchView @'ViewMail @'ScrollingMailView)
   ]
 
 
 mailAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
 mailAttachmentsKeybindings =
-    [ Keybinding (V.EvKey (V.KChar 'j') []) (listDown `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'k') []) (listUp `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'q') []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
+    [ Keybinding (V.EvKey (V.KChar 'j') []) listDown
+    , Keybinding (V.EvKey (V.KChar 'k') []) listUp
+    , Keybinding (V.EvKey (V.KChar 'q') []) (abort *> switchView @'ViewMail @'ScrollingMailView)
     , Keybinding (V.EvKey V.KEnter []) openAttachment
-    , Keybinding (V.EvKey (V.KChar 'o') []) (noop `focus` continue @'ViewMail @'MailAttachmentOpenWithEditor)
-    , Keybinding (V.EvKey (V.KChar '|') []) (noop `focus` continue @'ViewMail @'MailAttachmentPipeToEditor)
-    , Keybinding (V.EvKey (V.KChar 's') []) (noop `focus` continue @'ViewMail @'SaveToDiskPathEditor)
+    , Keybinding (V.EvKey (V.KChar 'o') []) (switchView @'ViewMail @'MailAttachmentOpenWithEditor)
+    , Keybinding (V.EvKey (V.KChar '|') []) (switchView @'ViewMail @'MailAttachmentPipeToEditor)
+    , Keybinding (V.EvKey (V.KChar 's') []) (switchView @'ViewMail @'SaveToDiskPathEditor)
     ]
 
 openWithKeybindings :: [Keybinding 'ViewMail 'MailAttachmentOpenWithEditor]
 openWithKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `focus` continue @'ViewMail @'MailAttachmentPipeToEditor)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (abort *> switchView @'ViewMail @'MailAttachmentPipeToEditor)
     , Keybinding (V.EvKey V.KEnter []) (done `focus` openWithCommand)
     ]
 
 pipeToKeybindings :: [Keybinding 'ViewMail 'MailAttachmentPipeToEditor]
 pipeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
-    , Keybinding (V.EvKey (V.KChar '\t') []) (abort `focus` continue @'ViewMail @'MailAttachmentOpenWithEditor)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'ViewMail @'MailListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (abort *> switchView @'ViewMail @'MailAttachmentOpenWithEditor)
     , Keybinding (V.EvKey V.KEnter []) (done `focus` pipeToCommand)
     ]
 
 mailViewManageMailTagsKeybindings :: [Keybinding 'ViewMail 'ManageMailTagsEditor]
 mailViewManageMailTagsKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
-    , Keybinding (V.EvKey V.KEnter []) (done `focus` untoggleListItems @'ViewMail @'ScrollingMailView `chain` continue)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'ScrollingMailView)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'ViewMail @'ScrollingMailView)
+    , Keybinding (V.EvKey V.KEnter []) (done `focus` untoggleListItems @'ViewMail @'ScrollingMailView)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'ViewMail @'ScrollingMailView)
     ]
 
 saveToDiskKeybindings :: [Keybinding 'ViewMail 'SaveToDiskPathEditor]
 saveToDiskKeybindings =
-  [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
-  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'MailListOfAttachments)
-  , Keybinding (V.EvKey V.KEnter []) (
-      done `chain` saveAttachmentToPath `focus` continue @'ViewMail @'MailListOfAttachments )
+  [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'ViewMail @'MailListOfAttachments)
+  , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'ViewMail @'MailListOfAttachments)
+  , Keybinding (V.EvKey V.KEnter [])
+      ( done
+        *> saveAttachmentToPath
+        *> switchView @'ViewMail @'MailListOfAttachments
+      )
   ]
 
 mailviewComposeToKeybindings :: [Keybinding 'ViewMail 'ComposeTo]
 mailviewComposeToKeybindings =
-    [ Keybinding (V.EvKey V.KEsc []) (abort `focus` continue @'ViewMail @'ScrollingMailView)
-    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort `focus` continue @'ViewMail @'ScrollingMailView)
+    [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'ViewMail @'ScrollingMailView)
+    , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'ViewMail @'ScrollingMailView)
     , Keybinding (V.EvKey V.KEnter []) (
         done `focus` (
             invokeEditor ViewMail ScrollingMailView

--- a/src/Purebred/UI/Mail/Main.hs
+++ b/src/Purebred/UI/Mail/Main.hs
@@ -25,10 +25,10 @@ module Purebred.UI.Mail.Main
   ) where
 
 import qualified Brick.AttrMap as A
-import Brick.Types (Padding(..), ViewportType(..), Widget)
+import Brick.Types (ViewportType(..), Widget)
 import qualified Brick.Widgets.List as L
 import Brick.Widgets.Core
-  (padTop, padBottom, txt, txtWrap, viewport, (<+>), (<=>), withAttr,
+  (Padding(..), padTop, padBottom, txt, txtWrap, viewport, (<+>), (<=>), withAttr,
    vBox, hBox, padLeftRight, padRight)
 import Brick.Focus (focusGetCurrent)
 import Data.Text.Markup (Markup, markupSet)

--- a/src/Purebred/UI/Status/Main.hs
+++ b/src/Purebred/UI/Status/Main.hs
@@ -22,10 +22,10 @@
 module Purebred.UI.Status.Main where
 
 import Brick.BChan (BChan, writeBChan)
-import Brick.Types (Widget, Padding(..))
+import Brick.Types (Widget)
 import Brick.Focus (focusGetCurrent, focusRingLength)
 import Brick.Widgets.Core
-  (hBox, txt, str, withAttr, (<+>), strWrap,
+  (Padding(..), hBox, txt, str, withAttr, (<+>), strWrap,
   emptyWidget, padRight, padLeft, padLeftRight)
 import Brick.Widgets.Center (hCenter)
 import qualified Brick.Widgets.List  as L


### PR DESCRIPTION
```
commit 65c588bb19c0e0d803f49d52affb006fb7a24c39
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Wed Aug 10 10:37:43 2022 +1000

    migrate to brick-1.0

commit 47b731e1c50f5f49609a0f7c3d812a5b6ec10286
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Wed Aug 10 11:25:49 2022 +1000

    use listSelectedElementL from Brick

commit 886a1283d0cceb34c1a51e44f11c7090d2009623 (HEAD -> refactor/brick-1.0, origin/refactor/brick-1.0)
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Wed Aug 10 14:50:11 2022 +1000

    remove 'continue' action
    
    With the brick-1.0 EventM change, actions no longer need to yield
    the new AppState.  The 'continue' action becomes a no-op.  Remove it
    entirely.  This results in a pleasant simplification of many
    keybindings.
```

Fixes https://github.com/purebred-mua/purebred/issues/464