### PR TITLE
ci: Fix Nix CI runs

### DIFF
--- a/.nix/bimap.nix
+++ b/.nix/bimap.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, containers, deepseq, exceptions, lib
+, QuickCheck, template-haskell
+}:
+mkDerivation {
+  pname = "bimap";
+  version = "0.5.0";
+  sha256 = "b0b44b0f2eaceb83f46dfa3d1747e080c45204c64d18bb9e63747299266f0c95";
+  libraryHaskellDepends = [ base containers deepseq exceptions ];
+  testHaskellDepends = [
+    base containers deepseq exceptions QuickCheck template-haskell
+  ];
+  homepage = "https://github.com/joelwilliamson/bimap";
+  description = "Bidirectional mapping between two key types";
+  license = lib.licenses.bsd3;
+}

--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -1,20 +1,20 @@
-{ mkDerivation, base, bytestring, config-ini, containers
+{ mkDerivation, base, bimap, bytestring, config-ini, containers
 , contravariant, data-clist, deepseq, directory, dlist, exceptions
-, filepath, lib, microlens, microlens-mtl, microlens-th, QuickCheck
-, stm, template-haskell, text, text-zipper, transformers, unix
+, filepath, lib, microlens, microlens-mtl, microlens-th, mtl
+, QuickCheck, stm, template-haskell, text, text-zipper, unix
 , vector, vty, word-wrap
 }:
 mkDerivation {
   pname = "brick";
-  version = "0.73";
-  sha256 = "741c8d0717f0ab5addd5d3acc88cb36d645a0c73907bde509b2fd9d9bc02039c";
+  version = "1.0";
+  sha256 = "73812075c1c211761bad65478dc7e18bf81e1703b98583133af96f0f18d52003";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base bytestring config-ini containers contravariant data-clist
-    deepseq directory dlist exceptions filepath microlens microlens-mtl
-    microlens-th stm template-haskell text text-zipper transformers
-    unix vector vty word-wrap
+    base bimap bytestring config-ini containers contravariant
+    data-clist deepseq directory dlist exceptions filepath microlens
+    microlens-mtl microlens-th mtl stm template-haskell text
+    text-zipper unix vector vty word-wrap
   ];
   testHaskellDepends = [
     base containers microlens QuickCheck vector vty

--- a/.nix/overlays.nix
+++ b/.nix/overlays.nix
@@ -1,5 +1,5 @@
 let
-  haskellCompilerVersion = "ghc901";
+  haskellCompilerVersion = "ghc924";
   haskellPackagesOverlay = self: super: with super.haskell.lib; {
     haskellPackages = super.haskell.packages.${haskellCompilerVersion}.override {
       overrides = hself: hsuper: {
@@ -7,9 +7,9 @@ let
         purebred-email = hsuper.callPackage ./purebred-email.nix { };
         purebred-icu = hsuper.callPackage ./purebred-icu.nix { };
         brick = hsuper.callPackage ./brick.nix { };
-        typed-process = hsuper.callPackage ./typed-process.nix { };
-        vty = hsuper.callPackage ./vty.nix { };
         text-zipper = hsuper.callPackage ./text-zipper.nix { };
+        bimap = hsuper.callPackage ./bimap.nix { };
+        vty = hsuper.callPackage ./vty.nix { };
         notmuch = hsuper.callPackage ./hsnotmuch.nix {
           notmuch = self.pkgs.notmuch;
           talloc = self.pkgs.talloc;

--- a/.nix/purebred-email.nix
+++ b/.nix/purebred-email.nix
@@ -1,24 +1,23 @@
 { mkDerivation, attoparsec, base, base64-bytestring, bytestring
 , case-insensitive, concise, deepseq, hedgehog, lens, lib
 , QuickCheck, quickcheck-instances, random, semigroupoids
-, semigroups, stringsearch, tasty, tasty-golden, tasty-hedgehog
-, tasty-hunit, tasty-quickcheck, text, time
+, stringsearch, tasty, tasty-golden, tasty-hedgehog, tasty-hunit
+, tasty-quickcheck, text, time
 }:
 mkDerivation {
   pname = "purebred-email";
-  version = "0.5";
-  sha256 = "412dc455ff244f864b66ee00ad0fc5f9986cdbc41e60c62f7468108dddf47645";
+  version = "0.5.1";
+  sha256 = "b518af3f8d4077f179a7acc5afd16bb5e58468d1b357196ac2badcb522f8c4bc";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     attoparsec base base64-bytestring bytestring case-insensitive
-    concise deepseq lens random semigroupoids semigroups stringsearch
-    text time
+    concise deepseq lens random semigroupoids stringsearch text time
   ];
   testHaskellDepends = [
     attoparsec base bytestring case-insensitive hedgehog lens
-    QuickCheck quickcheck-instances random semigroups tasty
-    tasty-golden tasty-hedgehog tasty-hunit tasty-quickcheck text time
+    QuickCheck quickcheck-instances random tasty tasty-golden
+    tasty-hedgehog tasty-hunit tasty-quickcheck text time
   ];
   homepage = "https://github.com/purebred-mua/purebred-email";
   description = "types and parser for email messages (including MIME)";

--- a/.nix/purebred.nix
+++ b/.nix/purebred.nix
@@ -2,9 +2,9 @@
 , case-insensitive, containers, deepseq, directory, dyre
 , exceptions, filepath, lens, lib, mime-types, mtl, notmuch
 , optparse-applicative, purebred-email, quickcheck-instances
-, random, stm, tasty, tasty-hunit, tasty-quickcheck, tasty-tmux
-, temporary, text, text-zipper, time, typed-process, unix, vector
-, vty, word-wrap
+, random, stm, stm-delay, tasty, tasty-hunit, tasty-quickcheck
+, tasty-tmux, temporary, text, text-zipper, time, typed-process
+, unix, vector, vty, word-wrap
 }:
 mkDerivation {
   pname = "purebred";
@@ -15,11 +15,11 @@ mkDerivation {
   libraryHaskellDepends = [
     attoparsec base brick bytestring case-insensitive containers
     deepseq directory dyre exceptions filepath lens mime-types mtl
-    notmuch optparse-applicative purebred-email random stm temporary
-    text text-zipper time typed-process vector vty word-wrap
+    notmuch optparse-applicative purebred-email random stm stm-delay
+    temporary text text-zipper time typed-process vector vty word-wrap
   ];
-  executableHaskellDepends = [ base ];
   testTarget = "unit";
+  executableHaskellDepends = [ base ];
   testHaskellDepends = [
     attoparsec base brick bytestring directory filepath lens mtl
     notmuch purebred-email quickcheck-instances tasty tasty-hunit
@@ -29,4 +29,5 @@ mkDerivation {
   homepage = "https://github.com/purebred-mua/purebred#readme";
   description = "An mail user agent built around notmuch";
   license = lib.licenses.agpl3Plus;
+  mainProgram = "purebred";
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1634782485,
-        "narHash": "sha256-psfh4OQSokGXG0lpq3zKFbhOo3QfoeudRcaUnwMRkQo=",
-        "owner": "nixos",
+        "lastModified": 1660263190,
+        "narHash": "sha256-jneVdNZ0QDIcHm/uCBW8VOJpdkO94BD0ejcLJj0Z9D8=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
+        "rev": "9b94af387d1cbb1a29e75e0891ea7ab5887bce24",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
-        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
         "type": "github"
       }
     },
@@ -24,11 +24,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Purebred development environment";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?rev=34ad3ffe08adfca17fcb4e4a47bb5f3b113687be";
+    nixpkgs.url = "github:NixOS/nixpkgs/haskell-updates";
     utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
We recently bumped and changed versions causing the nix runs to
fail.

This patch updates these versions and it's nix derivations. We also
upgrade the base nix package set to grab newer versions of packages as well.

Fixes #479