### PR TITLE
nix: bump to purebred-email 0.6

### DIFF
--- a/.nix/purebred-email.nix
+++ b/.nix/purebred-email.nix
@@ -1,13 +1,13 @@
 { mkDerivation, attoparsec, base, base64-bytestring, bytestring
 , case-insensitive, concise, deepseq, hedgehog, lens, lib
-, QuickCheck, quickcheck-instances, random, semigroupoids
-, stringsearch, tasty, tasty-golden, tasty-hedgehog, tasty-hunit
-, tasty-quickcheck, text, time
+, quickcheck-instances, random, semigroupoids, stringsearch, tasty
+, tasty-golden, tasty-hedgehog, tasty-hunit, tasty-quickcheck, text
+, time
 }:
 mkDerivation {
   pname = "purebred-email";
-  version = "0.5.1";
-  sha256 = "b518af3f8d4077f179a7acc5afd16bb5e58468d1b357196ac2badcb522f8c4bc";
+  version = "0.6";
+  sha256 = "05a539b91afc187bbd0e03c6a36b85707405e1d7592bacddccda11e0bf970945";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
@@ -16,8 +16,8 @@ mkDerivation {
   ];
   testHaskellDepends = [
     attoparsec base bytestring case-insensitive hedgehog lens
-    QuickCheck quickcheck-instances random tasty tasty-golden
-    tasty-hedgehog tasty-hunit tasty-quickcheck text time
+    quickcheck-instances random tasty tasty-golden tasty-hedgehog
+    tasty-hunit tasty-quickcheck text time
   ];
   homepage = "https://github.com/purebred-mua/purebred-email";
   description = "types and parser for email messages (including MIME)";


### PR DESCRIPTION
This just bumps the nix builds to use the latest purebred-email release.