### PR TITLE
mail body search: refactors, add "previous match" action

### DIFF
--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -93,7 +93,8 @@ module Purebred.UI.Actions (
   , scrollDown
   , scrollPageUp
   , scrollPageDown
-  , scrollNextWord
+  , scrollNextMatch
+  , scrollPreviousMatch
   , removeHighlights
 
   -- ** Actions for composing mails
@@ -1014,11 +1015,18 @@ scrollPageDown = Action
   , _aAction = Brick.vScrollPage (makeViewportScroller @ctx) T.Down
   }
 
-scrollNextWord :: forall ctx v. (Scrollable ctx) => Action v ctx ()
-scrollNextWord =
+scrollNextMatch :: forall ctx v. (Scrollable ctx) => Action v ctx ()
+scrollNextMatch =
   Action
-    { _aDescription = ["find next word in mail body"]
+    { _aDescription = ["scroll to next match in mail body"]
     , _aAction = scrollMatch (makeViewportScroller @ctx) (+1)
+    }
+
+scrollPreviousMatch :: forall ctx v. (Scrollable ctx) => Action v ctx ()
+scrollPreviousMatch =
+  Action
+    { _aDescription = ["scroll to previous match in mail body"]
+    , _aAction = scrollMatch (makeViewportScroller @ctx) (subtract 1)
     }
 
 -- | Scroll to a particular match, the index of which can be calculated

--- a/src/Purebred/UI/App.hs
+++ b/src/Purebred/UI/App.hs
@@ -207,14 +207,14 @@ initialState conf chan server sink = do
             0
     mv = MailView
            Nothing
-           (MailBody mempty [])
+           (MailBody mempty {- source -} mempty {- matches -} mempty {- lines -})
            Filtered
            (L.list MailListOfAttachments mempty 1)
            (E.editorText SaveToDiskPathEditor Nothing "")
            (E.editorText MailAttachmentOpenWithEditor Nothing "")
            (E.editorText MailAttachmentPipeToEditor Nothing "")
            (E.editorText ScrollingMailViewFindWordEditor Nothing "")
-           (focusRing [])
+           0 {- search match index -}
     viewsettings =
         ViewSettings
         { _vsViews = initialViews

--- a/src/Purebred/UI/Mail/Keybindings.hs
+++ b/src/Purebred/UI/Mail/Keybindings.hs
@@ -75,7 +75,9 @@ displayMailKeybindings =
     , Keybinding (V.EvKey (V.KChar '/') [])
         (switchView @'ViewMail @'ScrollingMailViewFindWordEditor)
     , Keybinding (V.EvKey (V.KChar 'n') [])
-        scrollNextWord
+        scrollNextMatch
+    , Keybinding (V.EvKey (V.KChar 'N') [])
+        scrollPreviousMatch
     , Keybinding (V.EvKey (V.KChar 'f') [])
         (encapsulateMail *> switchView @'ViewMail @'ComposeTo)
     , Keybinding (V.EvKey V.KEnter [])

--- a/src/Purebred/UI/Status/Main.hs
+++ b/src/Purebred/UI/Status/Main.hs
@@ -23,7 +23,6 @@ module Purebred.UI.Status.Main where
 
 import Brick.BChan (BChan, writeBChan)
 import Brick.Types (Widget)
-import Brick.Focus (focusGetCurrent, focusRingLength)
 import Brick.Widgets.Core
   (Padding(..), hBox, txt, str, withAttr, (<+>), strWrap,
   emptyWidget, padRight, padLeft, padLeftRight)
@@ -127,13 +126,12 @@ renderStatusbar w s = withAttr statusbarAttr $ hBox
 
 renderMatches :: AppState -> Widget n
 renderMatches s =
-  let showCount = view (non "0")
-        $ preview (asMailView . mvScrollSteps . to (show . focusRingLength)) s
-      currentItem = view (non "0")
-        $ preview (asMailView . mvScrollSteps . to focusGetCurrent . _Just . stNumber . to show) s
-   in if view (asMailView . mvBody . to matchCount) s > 0
-        then str (currentItem <> " of " <> showCount <> " matches")
-        else emptyWidget
+  case lengthOf (asMailView . mvBody . mbMatches . traverse) s of
+    0 -> emptyWidget
+    n -> let
+            i = view (asMailView . mvSearchIndex) s
+          in
+            str (show (i + 1) <> " of " <> show n <> " matches")
 
 renderNewMailIndicator :: AppState -> Widget n
 renderNewMailIndicator s =

--- a/test/TestMail.hs
+++ b/test/TestMail.hs
@@ -86,9 +86,7 @@ instance Arbitrary NotmuchMail where
 testFindsMatchingWords :: TestTree
 testFindsMatchingWords = testCase "finds matching words" $ expected @=? actual
   where
-    expected =
-      MailBody mempty
-        [Line [Match 9 3 0] "Purebred finds matching words"]
+    expected = MailBody mempty [Match 9 3 0] ["Purebred finds matching words"]
     actual =
       findMatchingWords "fin" $
-        MailBody mempty [Line [] "Purebred finds matching words"]
+        MailBody mempty mempty ["Purebred finds matching words"]

--- a/test/TestTextParser.hs
+++ b/test/TestTextParser.hs
@@ -32,12 +32,12 @@ testParsesParagraphs :: TestTree
 testParsesParagraphs =
   testCase "parses paragraphs" $ expected @=? parseMailbody 72 mempty paragraph
   where
-    expected = MailBody mempty
-      [ Line mempty "This is a"
-      , Line mempty "Paragraph"
-      , Line mempty "of Text"
-      , Line mempty ""
-      , Line mempty "And here"
-      , Line mempty "comes another one."
+    expected = MailBody mempty mempty
+      [ "This is a"
+      , "Paragraph"
+      , "of Text"
+      , ""
+      , "And here"
+      , "comes another one."
       ]
     paragraph = "This is a\nParagraph\nof Text\n\nAnd here\ncomes another one."


### PR DESCRIPTION
```
9206083 (Fraser Tweedale, 9 minutes ago)
   add scrollPreviousMatch action

   Alongside the existing "scroll to next match" action, add the
   `scrollPreviousMatch` action.  Bind `'N'` to this action in the default
   keybindings.

   Also rename `scrollNextWord` to `scrollNextMatch` which better expresses
   the real behaviour (a search term can match part of a term or span word
   boundaries).

d68f2f2 (Fraser Tweedale, 49 minutes ago)
   further simplify mail body search

   The remains a considerable dupliation of data within our implementation of
   mail body search.  In particular, `ScrollStep` duplicates `Match` values
   from `Line`.

   Refactor the implementation in the following ways:

   - Promote the `[Match]` from the `Line` data type to the `MailBody`
    type (as a single, combined list)

   - Remove the `Line` data type, replacing it with bare `Text`

   - Replace the `FocusRing ScrollStep` with an `Int` that records the
    current search hit index.

   - Extract the "scroll to search index" behaviour as a helper action.
    It modifies the search index, wrapping if necessary.  Update
    relevant actions to use the new method.

   - Clean up the rendering function
```