### PR TITLE
minor mailcap and entity command refactors

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -97,6 +97,7 @@ library
                      , Purebred.Storage.Server
                      , Purebred.Types.IFC
                      , Purebred.Types.Items
+                     , Purebred.Types.String
                      , Purebred.Plugin.Internal
                      , Purebred.Plugin.UserAgent
   autogen-modules:     Paths_purebred

--- a/src/Purebred/Config.hs
+++ b/src/Purebred/Config.hs
@@ -60,6 +60,7 @@ import Purebred.UI.ComposeEditor.Keybindings
         composeCcKeybindings, composeBccKeybindings)
 
 import Purebred.Types
+import Purebred.Types.Mailcap
 import Purebred.Plugin.Internal
 import qualified Purebred.Plugin.UserAgent
 import Purebred.System.Process

--- a/src/Purebred/Storage/Mail.hs
+++ b/src/Purebred/Storage/Mail.hs
@@ -60,10 +60,12 @@ import Purebred.Types
 import Purebred.System (tryIO)
 import Purebred.Types.Error
 import Purebred.Types.IFC (sanitiseText)
+import Purebred.Types.Mailcap
+  ( MailcapHandler, mhMakeProcess, mpCommand, hasCopiousoutput
+  , mailcapHandlerToEntityCommand
+  )
 import Purebred.Storage.Client (Server, mailFilepath)
-import Purebred.System.Process
-  (runEntityCommand, tmpfileResource, toProcessConfigWithTempfile,
-  tryReadProcessStdout, handleExitCodeThrow)
+import Purebred.System.Process (runEntityCommand)
 
 {- $synopsis
 
@@ -180,24 +182,8 @@ entityPiped ::
   -> WireEntity
   -> m T.Text
 entityPiped handler msg =
-  entityToBytes msg >>= mkConfig handler >>= runEntityCommand
-
--- | Create an entity command which writes our entity to a tempfile,
--- runs the command given by the 'MailcapHandler' over it and grab the
--- stdout for later display.
---
-mkConfig ::
-     (MonadError Error m, MonadIO m)
-  => MailcapHandler
-  -> B.ByteString
-  -> m (EntityCommand m FilePath)
-mkConfig cmd =
-  pure .
-  EntityCommand
-    handleExitCodeThrow
-    (tmpfileResource (view mhKeepTemp cmd))
-    (\_ fp -> toProcessConfigWithTempfile (view mhMakeProcess cmd) fp)
-    tryReadProcessStdout
+  entityToBytes msg
+  >>= runEntityCommand . mailcapHandlerToEntityCommand handler
 
 quoteText :: T.Text -> T.Text
 quoteText = ("> " <>)

--- a/src/Purebred/Types.hs
+++ b/src/Purebred/Types.hs
@@ -200,11 +200,10 @@ module Purebred.Types
   , ListWithLength(..)
   , listList
   , listLength
-  , decodeLenient
 
   , module Purebred.Types.Event
-  , module Purebred.Types.Mailcap
   , module Purebred.Types.UI
+  , module Purebred.Types.String
   ) where
 
 import Prelude hiding (Word)
@@ -225,8 +224,6 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as B
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
-import qualified Data.Text.Encoding as T
-import qualified Data.Text.Encoding.Error as T
 import qualified Graphics.Vty.Input.Events as Vty
 import Data.Time (UTCTime)
 import qualified Data.CaseInsensitive as CI
@@ -243,6 +240,7 @@ import Purebred.Types.Event
 import Purebred.Types.Items
 import Purebred.Types.Mailcap
 import Purebred.Types.UI
+import Purebred.Types.String
 
 {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
@@ -837,7 +835,3 @@ thReplies = lens _thReplies (\m t -> m { _thReplies = t })
 
 thId :: Lens' NotmuchThread B.ByteString
 thId = lens _thId (\m t -> m { _thId = t })
-
--- | Utility for safe conversion from bytestring to text
-decodeLenient :: B.ByteString -> T.Text
-decodeLenient = T.decodeUtf8With T.lenientDecode

--- a/src/Purebred/Types/String.hs
+++ b/src/Purebred/Types/String.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2019 Róman Joost
+-- Copyright (C) 2022  Fraser Tweedale
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -14,21 +14,20 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE FlexibleContexts #-}
+{- |
 
-module Purebred.System
-  ( tryIO
+String and text processing.
+
+-}
+module Purebred.Types.String
+  ( decodeLenient
   ) where
 
-import Control.Exception (IOException, try)
-import Control.Monad.Except (MonadError, throwError)
-import Control.Monad.IO.Class (MonadIO, liftIO)
+import qualified Data.ByteString as B
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.Encoding.Error as T
 
-import Purebred.Types.Error
-
--- | "Try" a computation but return a Purebred error in the exception case
-tryIO :: (MonadError Error m, MonadIO m) => IO a -> m a
-tryIO m = liftIO (try m) >>= either (throwError . exceptionToError) pure
-
-exceptionToError :: IOException -> Error
-exceptionToError = ProcessError . show
+-- | Safe conversion from bytestring to text
+decodeLenient :: B.ByteString -> T.Text
+decodeLenient = T.decodeUtf8With T.lenientDecode


### PR DESCRIPTION
(draft PR; I might add more commits)

"Minor" in the sense that it's mostly just moving definitions around.  Definition or type changes are few, and trivial.

- Move `ResourceSpec`, `EntityCommand` and `TempfileOnExit` types, and their companion optics, from `Purebred.Types.Mailcap` to `Purebred.System.Process`  This is a more appropriate home.

- Remove unused function `handleIOException`

- Move `decodeLenient` to new module `Purebred.Types.String`. This avoids the full import of `Purebred.Types` in `Purebred.System.Process`, which avoids an import cycle due to the moved definitions.

- Move `toProcessConfigWithTemplate` from `Purebred.System.Process` to `Purebred.Types.Mailcap`.  It becomes a non-exported helper function.

- Move `Purebred.Storage.Mail.mkConfig` to `Purebred.Types.Mailcap.mailcapHandlerToEntityCommand`.  It becomes a pure function (previously had a redundant use of `pure` and a redundant constraints).  The implementation is otherwise the same.  Refactor call sites.

- Refactor `openCommand'` to use `mailcapHandlerToEntityCommand`.