### PR TITLE
abstract EntityCommand over the output type

### DIFF
--- a/src/Purebred/Storage/Mail.hs
+++ b/src/Purebred/Storage/Mail.hs
@@ -65,7 +65,7 @@ import Purebred.Types.Mailcap
   , mailcapHandlerToEntityCommand
   )
 import Purebred.Storage.Client (Server, mailFilepath)
-import Purebred.System.Process (runEntityCommand)
+import Purebred.System.Process (outputToText, runEntityCommand)
 
 {- $synopsis
 
@@ -183,7 +183,7 @@ entityPiped ::
   -> m T.Text
 entityPiped handler msg =
   entityToBytes msg
-  >>= runEntityCommand . mailcapHandlerToEntityCommand handler
+  >>= fmap outputToText . runEntityCommand . mailcapHandlerToEntityCommand handler
 
 quoteText :: T.Text -> T.Text
 quoteText = ("> " <>)

--- a/src/Purebred/Types/LazyVector.hs
+++ b/src/Purebred/Types/LazyVector.hs
@@ -57,7 +57,6 @@ instance Semigroup (V a) where
 
 instance Monoid (V a) where
   mempty = V []
-  V l `mappend` V r = V (l `mappend` r)
 
 -- | /Θ(n)/ Concatenates chunks and checks equality.
 instance Eq a => Eq (V a) where

--- a/src/Purebred/Types/Mailcap.hs
+++ b/src/Purebred/Types/Mailcap.hs
@@ -46,6 +46,7 @@ import Control.DeepSeq (NFData)
 import Control.Lens (Lens', Traversal', filtered, lens, traversed, view)
 import Control.Monad.Except (MonadError, MonadIO)
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as L
 import System.Process.Typed (ProcessConfig, proc, shell)
 
 import Data.MIME (ContentType)
@@ -55,6 +56,7 @@ import Purebred.System.Process
   , handleExitCodeThrow, tmpfileResource, tryReadProcessStdout
   )
 import Purebred.Types.Error (Error)
+import Purebred.Types.IFC (Tainted)
 
 data MakeProcess
   = Shell (NonEmpty Char)
@@ -105,7 +107,7 @@ mailcapHandlerToEntityCommand
   :: (MonadError Error m, MonadIO m)
   => MailcapHandler
   -> B.ByteString
-  -> EntityCommand m FilePath
+  -> EntityCommand m FilePath (Tainted L.ByteString)
 mailcapHandlerToEntityCommand mh =
   EntityCommand
     handleExitCodeThrow


### PR DESCRIPTION
`EntityCommand` final output type was `T.Text`.  The `ccAfterExit`
must convert the raw command output from `Tainted L.ByteString` to
`T.Text`.  This was not ideal.  In general, features that execute
commands over body content might need the raw bytes, or might wish
to convert the raw bytes into something other than `T.Text`.

Therefore this commit makes the following changes:

- Add an output type parameter to `EntityCommand`.

- Equip `EntityCommand` with a `Functor` instance, which modifies
  the output value/type.

- Generalise the `ccAfterExit` optic to allow changing the output
  type.

- `handleExitCodeThrow` and `handleExitCodeTempfileContents` now
  return `Tainted L.ByteString`.

- Extract a helper function to avoid duplicate error handling code
  in `handleExitCodeThrow` and `handleExitCodeTempfileContents`.

- Update usage sites, including performing the conversion to
  `T.Text` that was previously done by the `ccAfterExit` value.

- For convenience, add the `EntityCommandAfterExit` type synonym.

- Remove unneeded constraints from the `ccResource` and
  `ccRunProcess` lenses.

This refactor will facilitate an upcoming generalisation of the
"mailcap" configuration.  It also enables more kinds of body
processing in the future.
