### PR TITLE
ui: enable tag replacement in thread and mail list

### DIFF
--- a/configs/purebred.hs
+++ b/configs/purebred.hs
@@ -90,6 +90,7 @@ main =
     . set (confComposeView . cvSendMailCmd) writeMailtoFile
     . set (confComposeView . cvIdentities) fromMail
     . over confTheme (applyAttrMappings myColoredTags)
+    . set (confIndexView . ivTagReplacementMap) tagReplacementMapAscii
 
 myColoredTags :: [(AttrName, Attr)]
 myColoredTags =

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -122,9 +122,11 @@ To avoid this, don't use stack.  But if you insist, you can run
 @stack exec purebred@ from the source tree.
 
 -}
-module Purebred (
-  purebred,
-  module Purebred.Plugin,
+module Purebred
+  ( purebred
+  , tagReplacementMapAscii
+  , tagReplacementMapEmoji
+  , module Purebred.Plugin,
   module Purebred.Plugin.TweakConfig,
   module Purebred.Storage.Tags,
   module Purebred.Types,
@@ -176,7 +178,8 @@ import Purebred.UI.Mail.Keybindings
 import Purebred.UI.Actions
 import Purebred.UI.Status.Main (rescheduleMailcheck)
 import Purebred.Config
-  ( defaultConfig, solarizedDark, sendmail, getDatabasePath )
+  ( defaultConfig, solarizedDark, sendmail, getDatabasePath
+  , tagReplacementMapAscii, tagReplacementMapEmoji )
 import Purebred.Types
 import Purebred.Plugin
 import Purebred.Plugin.Internal

--- a/src/Purebred/Config.hs
+++ b/src/Purebred/Config.hs
@@ -28,6 +28,7 @@ import Control.Lens (set)
 import Control.Monad.Except (runExceptT)
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as L
+import qualified Data.Map as M
 import qualified Data.Text as T
 import System.Directory (getHomeDirectory)
 
@@ -208,6 +209,7 @@ defaultConfig = do
       , _ivFromKeybindings = gatherFromKeybindings
       , _ivToKeybindings = gatherToKeybindings
       , _ivSubjectKeybindings = gatherSubjectKeybindings
+      , _ivTagReplacementMap = tagReplacementMapEmoji
       }
     , _confComposeView = ComposeViewSettings
       { _cvFromKeybindings = composeFromKeybindings
@@ -234,3 +236,40 @@ defaultConfig = do
         [ usePlugin Purebred.Plugin.UserAgent.plugin
         ]
     }
+
+-- | Replace some special tags with ASCII chars.
+--
+-- * @flagged@ → @!@
+-- * @attachment@ → @A@
+-- * @inbox@ → @I@
+-- * @replied@ → @r@
+--
+tagReplacementMapAscii :: M.Map T.Text T.Text
+tagReplacementMapAscii = M.fromList
+  [ ("flagged", "!")
+  , ("attachment", "A")
+  , ("inbox", "I")
+  , ("replied", "r")
+  ]
+
+-- | Replace some special tags with emoji.
+--
+-- * @flagged@ → 📌
+-- * @attachment@ → 📎
+-- * @inbox@ → 📥
+-- * @replied@ → ↩️
+--
+tagReplacementMapEmoji :: M.Map T.Text T.Text
+tagReplacementMapEmoji = M.fromList
+  [ ("flagged", "📌")
+  , ("attachment", "📎")
+  , ("inbox", "📥")
+  -- Note: there's a trailing space here because most terminals render
+  -- it as a double-width char but only advance the cursor one position.
+  --
+  -- That is because this emoji is U+21A9 (↩) + U+FE0F (Variation selector
+  -- 16) which in this context is "emoji presentation selector".  So
+  -- terminals see it as a single-width character.
+  --
+  , ("replied", "↩️ ")
+  ]

--- a/src/Purebred/Types.hs
+++ b/src/Purebred/Types.hs
@@ -166,6 +166,7 @@ module Purebred.Types
   , ivFromKeybindings
   , ivToKeybindings
   , ivSubjectKeybindings
+  , ivTagReplacementMap
 
   -- ** Mail Composer
   , ComposeViewSettings(..)
@@ -217,6 +218,7 @@ import Control.DeepSeq (NFData(rnf), force)
 import Control.Concurrent (ThreadId)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as B
+import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import qualified Graphics.Vty.Input.Events as Vty
@@ -547,6 +549,7 @@ data IndexViewSettings = IndexViewSettings
     , _ivFromKeybindings :: [Keybinding 'Threads 'ComposeFrom]
     , _ivToKeybindings :: [Keybinding 'Threads 'ComposeTo]
     , _ivSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]
+    , _ivTagReplacementMap :: M.Map T.Text T.Text
     }
     deriving (Generic, NFData)
 
@@ -567,6 +570,9 @@ ivToKeybindings = lens _ivToKeybindings (\s x -> s { _ivToKeybindings = x })
 
 ivSubjectKeybindings :: Lens' IndexViewSettings [Keybinding 'Threads 'ComposeSubject]
 ivSubjectKeybindings = lens _ivSubjectKeybindings (\s x -> s { _ivSubjectKeybindings = x })
+
+ivTagReplacementMap :: Lens' IndexViewSettings (M.Map T.Text T.Text)
+ivTagReplacementMap = lens _ivTagReplacementMap (\s x -> s { _ivTagReplacementMap = x })
 
 
 data MailViewSettings = MailViewSettings

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -1068,12 +1068,17 @@ testUpdatesReadState = purebredTmuxSession "updates read state for mail and thre
 
     step "set one mail to unread"
     sendKeys "Enter" (Substring "Beginning of large text")
-    sendKeys "t" (Regex (buildAnsiRegex [] ["37"] []
-                           <> "[[:space:]]Re: WIP Refactor[[:space:]]+"
-                           <> buildAnsiRegex [] ["34"] ["49"]))
+    sendKeys "t" $ Regex $
+      "I"
+      <> "[[:space:]]"
+      <> "Re: WIP Refactor[[:space:]]+"
+      <> buildAnsiRegex [] ["34"] ["49"]
 
     step "returning to thread list shows entire thread as unread"
-    sendKeys "q" (Regex (buildAnsiRegex [] ["37"] [] <> "[[:space:]]WIP Refactor[[:space:]]"))
+    sendKeys "q" $ Regex $
+      "I"
+      <> "[[:space:]]"
+      <> "WIP Refactor[[:space:]]"
 
 testConfig :: PurebredTestCase
 testConfig = purebredTmuxSession "test custom config" $
@@ -1284,14 +1289,13 @@ testManageTagsOnThreads = purebredTmuxSession "manage tags on threads" $
     sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] []))
 
     step "add new tag"
-    sendLine "+replied -inbox" (Substring "replied")
+    sendLine "+replied -inbox" (Substring "r")
 
     step "thread tags shows new tags"
-    sendKeys "Escape" (Regex ("archive"
-                              <> buildAnsiRegex [] ["30"] []
-                              <> "[[:space:]]"
-                              <> buildAnsiRegex [] ["36"] []
-                              <> "replied"))
+    sendKeys "Escape" $ Regex $
+      "r"  -- replied
+      <> "[[:space:]]"
+      <> buildAnsiRegex [] ["36"] [] <> "archive" <> buildAnsiRegex [] ["30"] []
 
     step "open thread tag editor"
     sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] []))
@@ -1300,24 +1304,24 @@ testManageTagsOnThreads = purebredTmuxSession "manage tags on threads" $
     -- "cheating" here a bit, since just invoking tmux with sending literally
     -- "-only" will fail due to tmux parsing it as an argument, but the mail is
     -- already tagged with "thread" so the additional adding won't do anything
-    sendLine "+thread" (Regex ("archive"
-                             <> buildAnsiRegex [] ["30"] []
-                             <> "[[:space:]]"
-                             <> buildAnsiRegex [] ["36"] [] <> "replied" <> buildAnsiRegex [] ["30"] []
-                             <> "[[:space:]]"
-                             <> buildAnsiRegex [] ["36"] [] <> "thread"))
+    sendLine "+thread" $ Regex $
+      "r"  -- replied
+      <> "[[:space:]]"
+      <> buildAnsiRegex [] ["36"] [] <> "archive" <> buildAnsiRegex [] ["30"] []
+      <> "[[:space:]]"
+      <> buildAnsiRegex [] ["36"] [] <> "thread" <> buildAnsiRegex [] ["30"] []
 
     step "show thread mails"
     sendKeys "Enter" (Substring "ViewMail")
 
     step "second mail shows old tag"
-    sendKeys "Escape" (Regex ("replied"
-                              <> buildAnsiRegex [] ["30"] []
-                              <> "[[:space:]]"
-                              <> buildAnsiRegex [] ["36"] []
-                              <> "thread"
-                              <> buildAnsiRegex [] ["30"] []
-                              <> "[[:space:]]WIP Refactor"))
+    sendKeys "Escape" $ Regex $
+      "r"  -- replied
+      <> "[[:space:]]"
+      <> buildAnsiRegex [] ["36"] [] <> "archive" <> buildAnsiRegex [] ["30"] []
+      <> "[[:space:]]"
+      <> buildAnsiRegex [] ["36"] [] <> "thread" <> buildAnsiRegex [] ["30"] []
+      <> "[[:space:]]WIP Refactor"
 
     step "open thread tag editor"
     sendKeys "`" (Regex ("Labels:." <> buildAnsiRegex [] ["37"] []))


### PR DESCRIPTION
Add a "tag replacement map" config.  Update tags widget rendering to
gather the replacements and render them together, ahead of remaining
tags.  This enables users to define symbolic replacements for
particular tags.

The default config replaces `flagged`, `attachment` and `replied`
with emoji.  We also export and ASCII variant of this map.  Users
can extend or replace the map via the `TweakConfig` plugin.

Fixes: https://github.com/purebred-mua/purebred/issues/492