### PR TITLE
Allow to expand receipients from addressbook

### DIFF
--- a/configs/aliases
+++ b/configs/aliases
@@ -1,0 +1,4 @@
+alias jen Jennifer Charles <jencharles@example.test>
+alias el "Elwood B.Mack" <elwood@test.example>
+alias bob Robby Cullen <rcullen@example.test>
+alias addy "Addy Mc. Donald" <admcdonald@test.example>

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -35,6 +35,7 @@ extra-source-files:
   test/data/Maildir/**/*.url
   "test/data/Maildir/**/*.url_2,RS"
   configs/purebred.hs
+  configs/aliases
 
 tested-with:
   GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2
@@ -88,6 +89,8 @@ library
                      , Purebred.Plugin.TweakConfig
                      , Purebred.Storage.Mail
                      , Purebred.Storage.Tags
+                     , Purebred.Storage.AddressBook
+                     , Purebred.Storage.AddressBook.MuttAliasFile
                      , Purebred.System
                      , Purebred.System.Process
                      , Purebred.System.Logging
@@ -101,6 +104,7 @@ library
                      , Purebred.Types.Presentation
                      , Purebred.Types.Presentation.MailBody
                      , Purebred.Types.UI
+                     , Purebred.Types.AddressBook
                      , Purebred.UI.Actions
                      , Purebred.UI.App
                      , Purebred.UI.Attr
@@ -180,8 +184,10 @@ test-suite unit
   other-modules:       TestMail
                      , TestActions
                      , TestTagParser
+                     , TestAddressBook
                      , LazyVector
   build-depends:       purebred
+                     , purebred-email
                      , tasty
                      , tasty-hunit
                      , tasty-quickcheck

--- a/src/Purebred/Config.hs
+++ b/src/Purebred/Config.hs
@@ -237,6 +237,7 @@ defaultConfig = do
     , _confPlugins = set pluginBuiltIn True <$>
         [ usePlugin Purebred.Plugin.UserAgent.plugin
         ]
+    , _confAddressBook = []
     }
 
 -- | Replace some special tags with ASCII chars.

--- a/src/Purebred/Storage/AddressBook.hs
+++ b/src/Purebred/Storage/AddressBook.hs
@@ -1,0 +1,47 @@
+-- This file is part of purebred
+-- Copyright (C) 2022 - Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Purebred.Storage.AddressBook
+  ( -- * Synopsis
+    -- $synopsis
+
+    -- * API
+    queryAddresses
+  )
+where
+
+import qualified Data.Text as T
+
+import Control.Lens
+import Control.Monad.Except (MonadError)
+import Control.Monad.IO.Class (MonadIO)
+
+import Data.IMF (Address)
+
+import Purebred.Types.Error
+import Purebred.Types.AddressBook
+import Purebred.System (tryIO)
+
+-- $synopsis
+--
+-- This module provides an API to retrieve Address information for Purebred
+
+-- | query addresses matching given needle
+--
+queryAddresses :: (MonadError Error m, MonadIO m) => T.Text -> [AddressBook] -> m [Address]
+queryAddresses needle = fmap concat . traverse (tryIO . flip (view addressBookSearch) needle)

--- a/src/Purebred/Storage/AddressBook/MuttAliasFile.hs
+++ b/src/Purebred/Storage/AddressBook/MuttAliasFile.hs
@@ -1,0 +1,95 @@
+-- This file is part of purebred
+-- Copyright (C) 2022 - Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Purebred.Storage.AddressBook.MuttAliasFile
+  ( -- * Synopsis
+    -- $synopsis
+
+    -- * API
+    initMuttAliasFileAddressBook
+
+    -- * Muttalias Parser
+  , MuttAlias(..)
+  , muttAliasNick
+  , muttAliasAddress
+  , parseMuttAliasFile
+  ) where
+
+import Data.Attoparsec.ByteString (Parser, parseOnly, sepBy, string, takeTill)
+import Data.Attoparsec.ByteString.Char8 (endOfLine, isSpace_w8, skipSpace, space)
+import Data.Bifunctor (bimap)
+import qualified Data.ByteString as B
+import qualified Data.Text as T
+import qualified Data.Text.Internal.Search as T
+import Control.Lens (Lens', lens, toListOf, folded, filtered, view)
+
+import Data.MIME (defaultCharsets)
+import Data.IMF (address, Address)
+
+import Purebred.Types.Error (Error(ParseError))
+import Purebred.Types.AddressBook (AddressBook(..))
+import Purebred.Types.String (decodeLenient)
+
+-- $synopsis
+--
+-- This module provides functions to retrieve addresses from an alias
+-- file formatted in an mutt-alias compatible format.
+--
+-- https://gitlab.com/muttmua/mutt/-/wikis/MuttGuide/Aliases
+
+initMuttAliasFileAddressBook :: FilePath -> IO (Either Error AddressBook)
+initMuttAliasFileAddressBook filePath = do
+  contents <- B.readFile filePath
+  let mk addrs = AddressBook
+        (\substr -> pure $ filterMuttAliases substr addrs)
+        Nothing
+  pure $ bimap ParseError mk $ parseMuttAliasFile contents
+
+filterMuttAliases :: T.Text -> [MuttAlias] -> [Address]
+filterMuttAliases substr =
+  toListOf
+    ( folded
+        . filtered (matchesSubstring substr . view muttAliasNick)
+        . muttAliasAddress
+    )
+
+matchesSubstring :: T.Text -> T.Text -> Bool
+matchesSubstring needle haystack = not $ null $ T.indices needle haystack
+
+-- | Parser functions to parse a mutt alias file
+parseMuttAliasFile :: B.ByteString -> Either String [MuttAlias]
+parseMuttAliasFile = parseOnly (muttalias `sepBy` endOfLine)
+
+muttalias :: Parser MuttAlias
+muttalias = do
+ nick <- string "alias" *> space *> takeTill isSpace_w8
+ add <- skipSpace *> address defaultCharsets
+ pure $ MuttAlias (decodeLenient nick) add
+
+-- | Parser Datatypes
+data MuttAlias = MuttAlias
+  { _muttAliasNick :: T.Text,
+    _muttAliasAddress :: Address
+  } deriving (Show, Eq)
+
+muttAliasNick :: Lens' MuttAlias T.Text
+muttAliasNick = lens _muttAliasNick (\m x -> m { _muttAliasNick = x })
+
+muttAliasAddress :: Lens' MuttAlias Address
+muttAliasAddress = lens _muttAliasAddress (\m x -> m { _muttAliasAddress = x })

--- a/src/Purebred/Types.hs
+++ b/src/Purebred/Types.hs
@@ -125,6 +125,7 @@ module Purebred.Types
   , confFileBrowserView
   , confCharsets
   , confPlugins
+  , confAddressBook
 
     -- ** Notmuch Configuration
   , NotmuchSettings(..)
@@ -180,7 +181,7 @@ module Purebred.Types
   , cvSubjectKeybindings
   , cvListOfAttachmentsKeybindings
   , cvConfirmKeybindings
-  
+
   -- ** Help Viewer
   , HelpViewSettings(..)
   , hvKeybindings
@@ -191,6 +192,10 @@ module Purebred.Types
   -- *** Keybindings
   , fbKeybindings
   , fbSearchPathKeybindings
+
+  -- ** AddressBook
+  , AddressBook(..)
+  , addressBookSearch
 
   -- * Internals
   , ListWithLength(..)
@@ -239,6 +244,7 @@ import Purebred.Types.Mailcap
 import Purebred.Types.UI
 import Purebred.Types.String
 import Purebred.Types.Presentation
+import Purebred.Types.AddressBook
 
 {-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
@@ -457,6 +463,7 @@ data Configuration = Configuration
     , _confFileBrowserView :: FileBrowserSettings
     , _confCharsets :: CharsetLookup
     , _confPlugins :: [PluginDict]
+    , _confAddressBook :: [AddressBook]
     }
     deriving (Generic, NFData)
 
@@ -492,6 +499,9 @@ confCharsets = lens _confCharsets (\conf x -> conf { _confCharsets = x })
 
 confPlugins :: Lens' Configuration [PluginDict]
 confPlugins = lens _confPlugins (\conf x -> conf { _confPlugins = x })
+
+confAddressBook :: Lens' Configuration [AddressBook]
+confAddressBook = lens _confAddressBook (\conf x -> conf { _confAddressBook = x })
 
 
 data ComposeViewSettings = ComposeViewSettings

--- a/src/Purebred/Types/AddressBook.hs
+++ b/src/Purebred/Types/AddressBook.hs
@@ -1,0 +1,53 @@
+-- This file is part of purebred
+-- Copyright (C) 2022 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+{- |
+
+Types for handling the retrieval of addresses
+
+-}
+module Purebred.Types.AddressBook
+  (
+    AddressBook(AddressBook)
+  , addressBookSearch
+  , addressBookRefresh
+  ) where
+
+import Control.Lens (Lens', lens)
+import qualified Data.Text as T
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData(rnf))
+
+import Data.IMF (Address)
+
+data AddressBook = AddressBook
+  { _addressBookSearch :: T.Text -> IO [Address]
+  , _addressBookRefresh :: Maybe (IO AddressBook)
+  }
+  deriving (Generic)
+
+instance NFData AddressBook where
+  rnf (AddressBook refresh search) = AddressBook refresh search `seq` ()
+
+addressBookSearch :: Lens' AddressBook (T.Text -> IO [Address])
+addressBookSearch = lens _addressBookSearch (\r x -> r { _addressBookSearch = x })
+
+addressBookRefresh :: Lens' AddressBook (Maybe (IO AddressBook))
+addressBookRefresh = lens _addressBookRefresh (\r x -> r { _addressBookRefresh = x })

--- a/src/Purebred/UI/ComposeEditor/Keybindings.hs
+++ b/src/Purebred/UI/ComposeEditor/Keybindings.hs
@@ -60,6 +60,8 @@ composeToKeybindings =
         (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
     , Keybinding (V.EvKey V.KEnter [])
         (done *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '\t') [])
+        (done *> fromAddressBook *> switchView @'ComposeView @'ComposeTo)
     ]
 
 composeCcKeybindings :: [Keybinding 'ComposeView 'ComposeCc]
@@ -70,6 +72,8 @@ composeCcKeybindings =
         (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
     , Keybinding (V.EvKey V.KEnter [])
         (done *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '\t') [])
+        (done *> fromAddressBookCC *> switchView @'ComposeView @'ComposeCc)
     ]
 
 composeBccKeybindings :: [Keybinding 'ComposeView 'ComposeBcc]
@@ -80,6 +84,8 @@ composeBccKeybindings =
         (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
     , Keybinding (V.EvKey V.KEnter [])
         (done *> switchView @'ComposeView @'ComposeListOfAttachments)
+    , Keybinding (V.EvKey (V.KChar '\t') [])
+        (done *> fromAddressBookBCC *> switchView @'ComposeView @'ComposeBcc)
     ]
 
 confirmKeybindings :: [Keybinding 'ComposeView 'ConfirmDialog]

--- a/src/Purebred/UI/GatherHeaders/Keybindings.hs
+++ b/src/Purebred/UI/GatherHeaders/Keybindings.hs
@@ -39,6 +39,7 @@ gatherToKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'Threads @'ListOfThreads)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'Threads @'ListOfThreads)
     , Keybinding (V.EvKey V.KEnter []) (switchView @'Threads @'ComposeSubject)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (done *> fromAddressBookThreads)
     ]
 
 gatherSubjectKeybindings :: [Keybinding 'Threads 'ComposeSubject]

--- a/src/Purebred/UI/Mail/Keybindings.hs
+++ b/src/Purebred/UI/Mail/Keybindings.hs
@@ -153,6 +153,7 @@ mailviewComposeToKeybindings :: [Keybinding 'ViewMail 'ComposeTo]
 mailviewComposeToKeybindings =
     [ Keybinding (V.EvKey V.KEsc []) (abort *> switchView @'ViewMail @'ScrollingMailView)
     , Keybinding (V.EvKey (V.KChar 'g') [V.MCtrl]) (abort *> switchView @'ViewMail @'ScrollingMailView)
+    , Keybinding (V.EvKey (V.KChar '\t') []) (done *> fromAddressBookMail *> switchView @'ViewMail @'ComposeTo)
     , Keybinding (V.EvKey V.KEnter []) (
         done `focus` (
             invokeEditor ViewMail ScrollingMailView

--- a/src/Purebred/UI/Utils.hs
+++ b/src/Purebred/UI/Utils.hs
@@ -20,6 +20,7 @@
 module Purebred.UI.Utils
   ( titleize
   , Titleize
+  , safeLast
   ) where
 
 import Data.Text (Text, pack)
@@ -51,3 +52,7 @@ instance Titleize Name where
 
 instance Titleize ViewName where
   titleize a = pack $ show a
+
+safeLast :: [a] -> Maybe a
+safeLast [] = Nothing
+safeLast (x:xs) = Just (foldl (\_ a -> a) x xs)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -20,11 +20,13 @@ import qualified LazyVector
 import qualified TestMail
 import qualified TestActions
 import qualified TestTagParser
+import qualified TestAddressBook
 
 main :: IO ()
 main = defaultMain $ testGroup "unit tests"
   [ TestMail.tests
   , TestTagParser.tests
   , TestActions.tests
+  , TestAddressBook.addressbookTests
   , LazyVector.tests
   ]

--- a/test/TestAddressBook.hs
+++ b/test/TestAddressBook.hs
@@ -1,0 +1,64 @@
+-- This file is part of purebred
+-- Copyright (C) 2022 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestAddressBook (
+  addressbookTests
+  ) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit ((@?=), testCase)
+
+import Data.IMF (Address(..))
+
+import Purebred.Storage.AddressBook.MuttAliasFile
+
+addressbookTests :: TestTree
+addressbookTests = testGroup "addressbook tests"
+  [ testParseMuttAlias
+  ]
+
+testParseMuttAlias :: TestTree
+testParseMuttAlias =
+  testGroup
+    "parse mutt alias file"
+    [
+      testCase "no long names" $
+        parseMuttAliasFile "alias nick1 <nick1@test.example>\nalias nick2 nick2@foo.test"
+          @?= Right [
+          MuttAlias {
+              _muttAliasNick = "nick1"
+            , _muttAliasAddress = Single "nick1@test.example"
+            }
+        , MuttAlias {
+              _muttAliasNick = "nick2"
+            , _muttAliasAddress = Single "nick2@foo.test"
+        }
+      ]
+    , testCase "with long names" $
+        parseMuttAliasFile "alias nick1 Mr Nick Name <nick1@test.example>\nalias nick2 Nick Test Name <nick2@foo.test>"
+          @?= Right [
+          MuttAlias {
+              _muttAliasNick = "nick1"
+            , _muttAliasAddress = Single "Mr Nick Name <nick1@test.example>"
+            }
+        , MuttAlias {
+              _muttAliasNick = "nick2"
+            , _muttAliasAddress = Single "Nick Test Name <nick2@foo.test>"
+            }
+        ]
+    ]


### PR DESCRIPTION
This implements an addressbook API and a way to expand addresses based on addressbook entries. The default retriever is based on the Mutt `alias` file using nick names.

The retrieval of Mutt aliases is not enabled by default, due to the fact that we need to use an absolute path to the alias file. Guessworking the possible location of the file goes against the current nature of being very explicit in the configuration.

Fixes https://github.com/purebred-mua/purebred/issues/17