### PR TITLE
Allow to "escape" the confirmation dialog

### DIFF
--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -499,6 +499,9 @@ instance Resetable 'ComposeView 'ComposeSubject where
 instance Resetable 'ComposeView 'ComposeListOfAttachments where
   reset = modify clearMailComposition
 
+instance Resetable 'ComposeView 'ConfirmDialog where
+  reset = hide ComposeView 0 ConfirmDialog
+
 instance Resetable 'FileBrowser 'ManageFileBrowserSearchPath where
   reset = modifying (asFileBrowser . fbSearchPath) revertEditorState
 

--- a/src/Purebred/UI/ComposeEditor/Keybindings.hs
+++ b/src/Purebred/UI/ComposeEditor/Keybindings.hs
@@ -89,10 +89,10 @@ confirmKeybindings =
       (handleConfirm !*> reloadList)
   , Keybinding
       (V.EvKey (V.KChar 'q') [])
-      (switchView @'ComposeView @'ComposeListOfAttachments)
+      (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
   , Keybinding
       (V.EvKey V.KEsc [])
-      (switchView @'ComposeView @'ComposeListOfAttachments)
+      (abort *> switchView @'ComposeView @'ComposeListOfAttachments)
   ]
 
 confirmAbort :: Action 'ComposeView 'ComposeListOfAttachments ()

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -614,6 +614,12 @@ testConfirmDialogResets = purebredTmuxSession "confirm dialog resets state" $
     step "abort composition"
     sendKeys "q" (Substring "Keep draft?")
 
+    step "Cancel dialog"
+    sendKeys "Escape" (Not (Substring "Keep draft?"))
+
+    step "abort composition"
+    sendKeys "q" (Substring "Keep draft?")
+
     step "choose Discard"
     sendKeys "Tab" (Substring "Discard")
 


### PR DESCRIPTION
When we want to abort the composition of an email a confirmation dialog is shown. This allows to either discard or save the mail as a draft.

The only problem is, if we by mistake pressed the keys aborting the composition of the mail and the conformation dialog pops up. Currently there is no way back, you either discard or save the mail as a draft.

That is annoying. Allow aborting the confirmation dialog so you can go back to composing the mail if you wish.