### PR TITLE
fix flaky UAT test

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -75,7 +75,7 @@ If you run into compilation errors like:
     |
     33 | import Data.MIME (matchContentType)
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    
+
 check your [GHC package
 environment](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/packages.html?highlight=ghc%20pkg#package-environments). Most
 likely, the package is not listed and needs to be added.
@@ -95,6 +95,12 @@ example:
     Purebred.dyn_hi
     Purebred.hi
     Purebred.p_hi
+
+### User Acceptance Test Flakes
+
+* Flakes can be caused by late running validations from input fields
+  (`To:`, `From:`) overwriting any status reports (see
+  https://github.com/purebred-mua/purebred/issues/429)
 
 ### Differences to Brick
 

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -155,7 +155,7 @@ testAbortsCompositionIfEditorExits = purebredTmuxSession "aborts composition if 
   \step -> do
     setEnvVarInSession "EDITOR" "doesnotexistFoo"
     startApplication
-    
+
     step "start composition"
     sendKeys "m" (Substring "From")
 
@@ -164,6 +164,10 @@ testAbortsCompositionIfEditorExits = purebredTmuxSession "aborts composition if 
 
     step "enter to: email"
     sendLine "user@to.test" (Substring "Subject")
+
+    -- wait for the validation to fire to avoid overriding the error
+    -- in the status bar (see https://github.com/purebred-mua/purebred/issues/429)
+    liftIO $ threadDelay (500*1000)
 
     step "enter subject"
     sendLine "Draft mail subject" (Substring "Editor exited abnormally")
@@ -187,8 +191,6 @@ testAbortsCompositionIfEditorExits = purebredTmuxSession "aborts composition if 
 
     step "back to thread list"
     sendKeys "Escape" (Substring "Item 2 of 4")
-    
-    
 
 -- https://github.com/purebred-mua/purebred/issues/395
 testReloadsThreadListAfterReply :: PurebredTestCase
@@ -1724,6 +1726,10 @@ composeNewMail step = do
 
     step "enter to: email"
     sendKeys "user@to.test\r" (Substring "Subject")
+
+    -- wait for the validation to fire to avoid overriding the error
+    -- in the status bar (see https://github.com/purebred-mua/purebred/issues/429)
+    liftIO $ threadDelay (500*1000)
 
     step "leave default"
     sendKeys "Draft mail subject\r" (Substring "~")


### PR DESCRIPTION
The test flaked because of a race condition between showing the error message and our validation on the input fields. The validation would race with rendering the error and showing the "all clear".

Fixes https://github.com/purebred-mua/purebred/issues/429