### PR TITLE
fix flake when removing xapian directory

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -145,7 +145,7 @@ library
                      , notmuch >= 0.3.1 && < 0.4
                      , text
                      , typed-process >= 0.2.8.0
-                     , directory >= 1.2.5.0
+                     , directory >= 1.2.7.0
                      , bytestring
                      , time >= 1.8
                      , case-insensitive

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -51,7 +51,7 @@ import System.Exit (die)
 import Control.Lens (Lens', _init, _last, at, lens, preview, set, to, view)
 import System.Directory
   ( copyFile, getCurrentDirectory, listDirectory, removeDirectoryRecursive
-  , removeFile, doesPathExist, findExecutable
+  , removePathForcibly, removeFile, doesPathExist, findExecutable
   )
 import System.Posix.Files (getFileStatus, isRegularFile)
 import System.Process.Typed
@@ -1802,7 +1802,7 @@ envSessionName = lens _envSessionName (\s b -> s { _envSessionName = b })
 tearDown :: Env -> IO ()
 tearDown (Env confdir mdir _ _) = do
   removeDirectoryRecursive confdir
-  removeDirectoryRecursive mdir
+  removePathForcibly mdir
 
 -- | Set up a test session.
 setUp :: GlobalEnv -> TmuxSession -> IO Env


### PR DESCRIPTION
On CI we ran into an error during `tearDown`:

```
file browser handles invalid path input:                  FAIL
    Exception: /tmp/purebredtest-a77e114bdea2381d/Maildir/.notmuch/xapian: removeDirectoryRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removeDirectory: unsatisfied constraints (Directory not empty)
    Use -p '/file browser handles invalid path input/' to rerun this test only.
```

The function `removeDirectoryRecursive` will not delete files marked as read only. However the `removePathForcibly` will change read only files in order to force remove the directory.