### PR TITLE
Revert "fix flake when removing xapian directory"

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -145,7 +145,7 @@ library
                      , notmuch >= 0.3.1 && < 0.4
                      , text
                      , typed-process >= 0.2.8.0
-                     , directory >= 1.2.7.0
+                     , directory >= 1.2.5.0
                      , bytestring
                      , time >= 1.8
                      , case-insensitive

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -51,7 +51,7 @@ import System.Exit (die)
 import Control.Lens (Lens', _init, _last, at, lens, preview, set, to, view)
 import System.Directory
   ( copyFile, getCurrentDirectory, listDirectory, removeDirectoryRecursive
-  , removePathForcibly, removeFile, doesPathExist, findExecutable
+  , removeFile, doesPathExist, findExecutable
   )
 import System.Posix.Files (getFileStatus, isRegularFile)
 import System.Process.Typed
@@ -1814,7 +1814,7 @@ envSessionName = lens _envSessionName (\s b -> s { _envSessionName = b })
 tearDown :: Env -> IO ()
 tearDown (Env confdir mdir _ _) = do
   removeDirectoryRecursive confdir
-  removePathForcibly mdir
+  removeDirectoryRecursive mdir
 
 -- | Set up a test session.
 setUp :: GlobalEnv -> TmuxSession -> IO Env


### PR DESCRIPTION
Reverts purebred-mua/purebred#502 because now we get:

```
Exception: /tmp/purebredtest-5149f9bf1e0a5186/Maildir/.notmuch/xapian: removePathForcibly:removePathForcibly:removePathForcibly:removeDirectory: unsatisfied constraints (Directory not empty)
```
The patch unfortunately had no effect.