### PR TITLE
nix: nix run should work out of box

### DIFF
--- a/.nix/overlays.nix
+++ b/.nix/overlays.nix
@@ -32,6 +32,8 @@ let
       '';
       preferLocalBuild = true;
       allowSubstitutes = false;
+
+      meta.mainProgram = "purebred";
     };
     purebred-with-packages-icu = self.make-purebred-with-packages true;
     purebred-with-packages = self.make-purebred-with-packages false;

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
   outputs = { self, nixpkgs, utils }: {
 
-    overlay = final: prev:
+    overlays.default = final: prev:
     let
       overlays = import .nix/overlays.nix;
     in
@@ -16,9 +16,10 @@
 
   } // utils.lib.eachSystem ["x86_64-linux"] (system:
   let
-    pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
+    pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
   in rec {
     packages = {
+      default = self.packages.${system}.purebred-with-packages-icu;
       purebred-with-packages = pkgs.purebred-with-packages;
       purebred-with-packages-icu = pkgs.purebred-with-packages-icu;
       purebred = pkgs.haskellPackages.purebred;
@@ -30,7 +31,6 @@
       shell-without-icu = pkgs.make-purebred-shell false;
       shell-with-icu = pkgs.make-purebred-shell true;
     };
-    defaultPackage = packages.purebred-with-packages-icu;
-    devShell = packages.shell-without-icu;
+    devShells.default = packages.shell-without-icu;
   });
 }


### PR DESCRIPTION
`nix run github:purebred-mua/purebred` wouldn't work. One would need to list the flae packages to run ``nix run github:purebred-mua/purebred#purebred` which makes usage harder.