### PR TITLE
nix: update dependencies for brick 2.1

### DIFF
--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -1,7 +1,7 @@
 { mkDerivation, base, bimap, bytestring, config-ini, containers
 , contravariant, data-clist, deepseq, directory, exceptions
 , filepath, lib, microlens, microlens-mtl, microlens-th, mtl
-, QuickCheck, stm, template-haskell, text, text-zipper, unix
+, QuickCheck, stm, template-haskell, text, text-zipper, unix-compat
 , vector, vty, word-wrap
 }:
 mkDerivation {
@@ -14,7 +14,7 @@ mkDerivation {
     base bimap bytestring config-ini containers contravariant
     data-clist deepseq directory exceptions filepath microlens
     microlens-mtl microlens-th mtl stm template-haskell text
-    text-zipper unix vector vty word-wrap
+    text-zipper unix-compat vector vty word-wrap
   ];
   testHaskellDepends = [
     base containers microlens QuickCheck vector vty

--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -6,8 +6,8 @@
 }:
 mkDerivation {
   pname = "brick";
-  version = "1.5";
-  sha256 = "6290081719d68c149dc9bd0098f36aac235b615334a3510fda89e19bbdb95f4f";
+  version = "2.1";
+  sha256 = "4edb005d87defbbbdda9d81e0f9fc5432b75f2787d4b7f490908fc4df5db8c9d";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -6,8 +6,8 @@
 }:
 mkDerivation {
   pname = "brick";
-  version = "2.1";
-  sha256 = "4edb005d87defbbbdda9d81e0f9fc5432b75f2787d4b7f490908fc4df5db8c9d";
+  version = "2.1.1";
+  sha256 = "30280d6f7130eb3e6cbf5a55465a06a825169cb536d3b2e91883aec23532b31e";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/.nix/text-zipper.nix
+++ b/.nix/text-zipper.nix
@@ -2,8 +2,8 @@
 }:
 mkDerivation {
   pname = "text-zipper";
-  version = "0.12";
-  sha256 = "86aba7244c9ed0d8e24e9d1fa64ee317a062e7bd777018053517daefb0696702";
+  version = "0.13";
+  sha256 = "06521cc7c435f8e85aeb3ed3f2b872000c52087d73518de31e65bdca072a98a9";
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [ base deepseq text vector ];
   testHaskellDepends = [ base hspec QuickCheck text ];

--- a/.nix/vty.nix
+++ b/.nix/vty.nix
@@ -8,8 +8,8 @@
 }:
 mkDerivation {
   pname = "vty";
-  version = "5.36";
-  sha256 = "f1bb8d161f467801404b60d8754c496af66cb741a3f04e5b013a6890390c04a5";
+  version = "6.1";
+  sha256 = "2fc64b7d09f16bce9c6456e234e6aca3a86be9a40f360435499fc087b94f7bd6";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [


### PR DESCRIPTION
Fix #512 

This still fails because of missing dependencies. Feel free to add more commits, I don't know how much time I have in the following days.

From the [brick changelog](https://hackage.haskell.org/package/brick-2.1.1/changelog):
> - Added dependency on vty-crossplatform.
> - Migrated from unix dependency to unix-compat.

So we should probably also package the missing vty-crossplatform and  vty-unix from the build og:
~~~
configuring
configureFlags: --verbose --prefix=/nix/store/3xj0f2c4jy2brzi0lcky7y1804kla84s-brick-2.1.1 --libdir=$prefix/lib/$compiler --libsubdir=$abi/$libname --docdir=/nix/store/dp849yq7s7pd8lfbj2386kbb8r16cgv7-brick-2.1.1-doc/share/doc/brick-2.1.1 --with-gcc=gcc --package-db=/build/tmp.jWJYssY18F/package.conf.d --ghc-options=-j4 +RTS -A64M -RTS --disable-split-objs --enable-library-profiling --profiling-detail=exported-functions --disable-profiling --enable-shared --disable-coverage --enable-static --disable-executable-dynamic --enable-tests --disable-benchmarks --enable-library-vanilla --disable-library-for-ghci --ghc-option=-split-sections --ghc-options=-haddock --extra-lib-dirs=/nix/store/vhgj0kyl1ijq408w9j0n4iq1ycrhhhfl-ncurses-6.3-p20220507/lib --extra-lib-dirs=/nix/store/94p2qrkvb9h0m7h5p0by88z0gzzaxl36-libffi-3.4.2/lib --extra-lib-dirs=/nix/store/14aarvmjm8xcq3ma0mxdfh59xmbpw284-gmp-with-cxx-6.2.1/lib
Using Parsec parser
Configuring brick-2.1.1...

Setup: Encountered missing or private dependencies:
vty-crossplatform, vty-unix
~~~