### PR TITLE
fix: allow parsing of mutt aliases using non-ASCII characters

### DIFF
--- a/configs/aliases
+++ b/configs/aliases
@@ -1,4 +1,4 @@
 alias jen Jennifer Charles <jencharles@example.test>
-alias el "Elwood B.Mack" <elwood@test.example>
+alias el "鈴木 一郎" <elwood@test.example>
 alias bob Robby Cullen <rcullen@example.test>
 alias addy "Addy Mc. Donald" <admcdonald@test.example>

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -149,7 +149,7 @@ library
                      , filepath
                      , mtl >= 2.2 && < 2.4
                      , exceptions
-                     , purebred-email >= 0.5 && <= 0.7
+                     , purebred-email >= 0.7 && <= 0.8
                      , attoparsec
                      , containers
                      , mime-types

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -129,6 +129,7 @@ module Purebred
   , module Purebred.Plugin,
   module Purebred.Plugin.TweakConfig,
   module Purebred.Storage.Tags,
+  module Purebred.Storage.AddressBook.MuttAliasFile,
   module Purebred.Types,
   module Purebred.Types.Error,
   module Purebred.UI.Actions,
@@ -188,6 +189,7 @@ import Purebred.Plugin.Internal
 import Purebred.Plugin.TweakConfig
 import Purebred.Storage.Server
 import Purebred.Storage.Tags (TagOp(..))
+import Purebred.Storage.AddressBook.MuttAliasFile
 import Purebred.Types.Error
 
 -- re-exports for configuration

--- a/test/TestAddressBook.hs
+++ b/test/TestAddressBook.hs
@@ -23,7 +23,7 @@ module TestAddressBook (
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit ((@?=), testCase)
 
-import Data.IMF (Address(..))
+import Data.MIME (Address(..))
 
 import Purebred.Storage.AddressBook.MuttAliasFile
 
@@ -50,11 +50,11 @@ testParseMuttAlias =
         }
       ]
     , testCase "with long names" $
-        parseMuttAliasFile "alias nick1 Mr Nick Name <nick1@test.example>\nalias nick2 Nick Test Name <nick2@foo.test>"
+        parseMuttAliasFile "alias nick1 Mr Nück Name <nick1@test.example>\nalias nick2 Nick Test Name <nick2@foo.test>"
           @?= Right [
           MuttAlias {
               _muttAliasNick = "nick1"
-            , _muttAliasAddress = Single "Mr Nick Name <nick1@test.example>"
+            , _muttAliasAddress = Single "Mr Nück Name <nick1@test.example>"
             }
         , MuttAlias {
               _muttAliasNick = "nick2"

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -150,10 +150,10 @@ testAddressBookExpansion = purebredTmuxSession "addressbook expands To: by nick 
     assertRegexS ("To:[[:blank:]]+" <> buildAnsiRegex ["37"] [] [] <> "[[:blank:]]+[[:space:]]")
 
     step "enter substring nick alias"
-    sendKeys "j\t" (Substring "Jennifer Charles")
+    sendKeys "je\t" (Substring "Jennifer Charles")
 
     step "add an additional address"
-    sendKeys ", el\t" (Regex "jencharles.*Elwood")
+    sendKeys ", el\t" (Regex "jencharles.*elwood")
 
     step "accept receipients"
     sendKeys "\r" (Substring "Subject:")
@@ -171,7 +171,7 @@ testAddressBookExpansion = purebredTmuxSession "addressbook expands To: by nick 
     sendKeys ": x\r" (Regex "To:\\s\"Jennifer")
 
     capture >>= put
-    assertRegexS "To: \"Jennifer Charles\".*, \"Elwood B.Mack\""
+    assertRegexS (T.encodeUtf8 "To: \"Jennifer Charles\" <jencharles@example\\.test>,.*鈴木")
     assertRegexS "Bcc:[[:space:]]+$"
     assertRegexS "Cc:[[:space:]]+$"
 
@@ -1415,7 +1415,7 @@ testShowsAndClearsError = purebredTmuxSession "shows and clears error" $
 
     step "shows error message"
     sendKeys "Enter" (Substring "FileReadError")
-      >>= assertRegex "(open|with)(Binary)?File:.*does not exist"
+      >>= assertRegex "(open|with)(Binary)?File:.*\\s*does not exist"
 
     step "error is cleared with next registered keybinding"
     sendKeys "Up" (Substring "Purebred: Item 1 of 5")


### PR DESCRIPTION
This uses the improvements from https://github.com/purebred-mua/purebred-email/pull/88 as the current code is unable to parse addresses in the mutt alias file using non-ASCII characters.

This uses the text address parser since the `ByteString` parser would expect the addresses in the mutt alias file to be content encoded. Don't think we want to expect users to do this.

Fixes #515 