### PR TITLE
ci: update cache action

### DIFF
--- a/.github/workflows/nixos-ci-flakes.yml
+++ b/.github/workflows/nixos-ci-flakes.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Local cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /nix/store
           key: "{{ runner.os }}-Nixpkgs-integration-test"

--- a/.github/workflows/nixos-ci.yml
+++ b/.github/workflows/nixos-ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Local cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /nix/store
           key: "{{ runner.os }}-Nixpkgs-integration-test"

--- a/.nix/brick.nix
+++ b/.nix/brick.nix
@@ -6,8 +6,8 @@
 }:
 mkDerivation {
   pname = "brick";
-  version = "2.1.1";
-  sha256 = "30280d6f7130eb3e6cbf5a55465a06a825169cb536d3b2e91883aec23532b31e";
+  version = "2.9";
+  sha256 = "c1017d80fd49d9b0484c0fa71a15818b49375c0d6b551b6f79e9c258f853b0c9";
   isLibrary = true;
   isExecutable = true;
   doCheck = false;


### PR DESCRIPTION
The builds are currently failing because the infrastructure behind the old version of the cache action was migrated:
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

There also is a note on the actions ui in github: https://github.com/purebred-mua/purebred/actions/runs/15842188147/job/44656791801

This might be a reason why #520 was not noticed by ci.