### PR TITLE
deps: drop support for GHC < 9.6

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250605
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250605",["--haddock","--apt","elinks tmux vim less notmuch libnotmuch-dev libtalloc-dev","--github-patches",".github/haskell-ci-github.patch","github","purebred.cabal"])
+# REGENDATA ("0.19.20250821",["--haddock","--apt","elinks tmux vim less notmuch libnotmuch-dev libtalloc-dev","--github-patches",".github/haskell-ci-github.patch","github","purebred.cabal"])
 #
 name: Haskell-CI
 on:
@@ -48,31 +48,6 @@ jobs:
             compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.8
-            compilerKind: ghc
-            compilerVersion: 9.4.8
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-9.2.8
-            compilerKind: ghc
-            compilerVersion: 9.2.8
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-9.0.2
-            compilerKind: ghc
-            compilerVersion: 9.0.2
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.10.7
-            compilerKind: ghc
-            compilerVersion: 8.10.7
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.8.4
-            compilerKind: ghc
-            compilerVersion: 8.8.4
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt-get install
@@ -87,8 +62,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -189,7 +164,11 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_purebred}" >> cabal.project
           echo "package purebred" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          echo "package purebred" >> cabal.project
+          echo "    ghc-options: -Werror=unused-packages" >> cabal.project
+          echo "package purebred" >> cabal.project
+          echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(purebred)$/; }' >> cabal.project.local

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An MUA built around [_notmuch_](https://notmuchmail.org/).
 
 ## Requirements
 
-- GHC >= 8.8
+- GHC >= 9.6
 - notmuch
 - a local mailer (e.g. `sendmail`)
 

--- a/purebred.cabal
+++ b/purebred.cabal
@@ -10,7 +10,7 @@ description:
   .
   = Requirements
   .
-  * GHC >= 8.8
+  * GHC >= 9.6
   * notmuch
   * a local mailer (e.g. @sendmail@)
   .
@@ -38,7 +38,7 @@ extra-source-files:
   configs/aliases
 
 tested-with:
-  GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2 || ==9.12.2
+  GHC ==9.6.7 || ==9.8.4 || ==9.10.2 || ==9.12.2
 
 source-repository head
   type: git
@@ -49,7 +49,7 @@ flag with_lazyvector
   default: False
 
 common common
-  default-language: Haskell2010
+  default-language: GHC2021
   ghc-options:
     -fhide-source-paths
     -Wall
@@ -62,23 +62,15 @@ common common
     -Wredundant-constraints
     -Wmissing-export-lists
     -Wpartial-fields
-  if impl(ghc >= 8.10)
-    ghc-options:
-      -Wunused-packages
-  if impl(ghc >= 9.0)
-    ghc-options:
-      -Winvalid-haddock
-      -Werror=unicode-bidirectional-format-characters
-  if impl(ghc >= 9.2)
-    ghc-options:
-      -Wimplicit-lift
-      -Woperator-whitespace
-      -Wredundant-bang-patterns
-  if impl(ghc >= 9.4)
-    ghc-options:
-      -Wredundant-strictness-flags
+    -Wunused-packages
+    -Winvalid-haddock
+    -Werror=unicode-bidirectional-format-characters
+    -Wimplicit-lift
+    -Woperator-whitespace
+    -Wredundant-bang-patterns
+    -Wredundant-strictness-flags
   build-depends:
-    base >= 4.13 && < 5
+    base >= 4.18 && < 5
 
 library
   import: common

--- a/src/Purebred.hs
+++ b/src/Purebred.hs
@@ -160,7 +160,7 @@ import Control.Concurrent (rtsSupportsBoundThreads)
 import Purebred.System.Logging (setupLogsink)
 import qualified Config.Dyre as Dyre
 import qualified Control.DeepSeq
-import Control.Monad ((>=>), void, unless)
+import Control.Monad ((>=>), unless)
 import Options.Applicative hiding (str)
 import qualified Options.Applicative.Builder as Builder
 import qualified Data.Text as T

--- a/src/Purebred/Config.hs
+++ b/src/Purebred/Config.hs
@@ -25,7 +25,7 @@ module Purebred.Config
   , tagReplacementMapEmoji
   ) where
 
-import Control.Applicative ((<|>), liftA2)
+import Control.Applicative ((<|>))
 import Data.List.NonEmpty (fromList)
 import Data.Maybe (fromMaybe)
 import System.Environment (lookupEnv)

--- a/src/Purebred/Plugin/Internal.hs
+++ b/src/Purebred/Plugin/Internal.hs
@@ -14,12 +14,8 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Purebred.Plugin.Internal

--- a/src/Purebred/Plugin/TweakConfig.hs
+++ b/src/Purebred/Plugin/TweakConfig.hs
@@ -15,7 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-| Plugins for adjusting Purebred's configuration.

--- a/src/Purebred/Plugin/UserAgent.hs
+++ b/src/Purebred/Plugin/UserAgent.hs
@@ -14,7 +14,6 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-| Add a User-Agent header to outgoing messages. -}

--- a/src/Purebred/Storage/AddressBook.hs
+++ b/src/Purebred/Storage/AddressBook.hs
@@ -13,8 +13,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module Purebred.Storage.AddressBook
   ( -- * Synopsis

--- a/src/Purebred/Storage/AddressBook/MuttAliasFile.hs
+++ b/src/Purebred/Storage/AddressBook/MuttAliasFile.hs
@@ -13,9 +13,8 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module Purebred.Storage.AddressBook.MuttAliasFile
   ( -- * Synopsis

--- a/src/Purebred/Storage/Client.hs
+++ b/src/Purebred/Storage/Client.hs
@@ -15,9 +15,7 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Purebred.Storage.Client
   (

--- a/src/Purebred/Storage/Mail.hs
+++ b/src/Purebred/Storage/Mail.hs
@@ -14,9 +14,7 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
 
 module Purebred.Storage.Mail (
   -- * Synopsis

--- a/src/Purebred/Storage/Server.hs
+++ b/src/Purebred/Storage/Server.hs
@@ -15,9 +15,7 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Purebred.Storage.Server
   (

--- a/src/Purebred/System.hs
+++ b/src/Purebred/System.hs
@@ -14,8 +14,6 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE FlexibleContexts #-}
-
 module Purebred.System
   ( tryIO
   ) where

--- a/src/Purebred/System/Process.hs
+++ b/src/Purebred/System/Process.hs
@@ -15,8 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module Purebred.System.Process
   ( tryReadProcessStderr

--- a/src/Purebred/Types.hs
+++ b/src/Purebred/Types.hs
@@ -16,9 +16,7 @@
 
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 {- |
 
@@ -547,7 +545,8 @@ cvConfirmKeybindings = lens _cvConfirmKeybindings (\cv x -> cv { _cvConfirmKeybi
 newtype HelpViewSettings = HelpViewSettings
   { _hvKeybindings :: [Keybinding 'Help 'ScrollingHelpView]
   }
-  deriving (Generic, NFData)
+  deriving (Generic)
+  deriving anyclass (NFData)
 
 hvKeybindings :: Lens' HelpViewSettings [Keybinding 'Help 'ScrollingHelpView]
 hvKeybindings f (HelpViewSettings a) = fmap (\a' -> HelpViewSettings a') (f a)

--- a/src/Purebred/Types/AddressBook.hs
+++ b/src/Purebred/Types/AddressBook.hs
@@ -14,10 +14,6 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DeriveGeneric #-}
-
 {- |
 
 Types for handling the retrieval of addresses

--- a/src/Purebred/Types/LazyVector.hs
+++ b/src/Purebred/Types/LazyVector.hs
@@ -14,9 +14,7 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {- |

--- a/src/Purebred/Types/Mailcap.hs
+++ b/src/Purebred/Types/Mailcap.hs
@@ -15,8 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 {- |
 

--- a/src/Purebred/Types/UI.hs
+++ b/src/Purebred/Types/UI.hs
@@ -15,8 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {- |

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -15,16 +15,9 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Purebred.UI.Actions (

--- a/src/Purebred/UI/App.hs
+++ b/src/Purebred/UI/App.hs
@@ -16,7 +16,6 @@
 
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Purebred.UI.App
   ( theApp

--- a/src/Purebred/UI/ComposeEditor/Keybindings.hs
+++ b/src/Purebred/UI/ComposeEditor/Keybindings.hs
@@ -15,7 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Purebred.UI.ComposeEditor.Keybindings
   ( composeSubjectKeybindings

--- a/src/Purebred/UI/ComposeEditor/Main.hs
+++ b/src/Purebred/UI/ComposeEditor/Main.hs
@@ -16,7 +16,6 @@
 
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
 
 module Purebred.UI.ComposeEditor.Main
   ( attachmentsEditor

--- a/src/Purebred/UI/Draw/Main.hs
+++ b/src/Purebred/UI/Draw/Main.hs
@@ -15,8 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- | Module holding generic widgets.
 module Purebred.UI.Draw.Main

--- a/src/Purebred/UI/FileBrowser/Keybindings.hs
+++ b/src/Purebred/UI/FileBrowser/Keybindings.hs
@@ -15,7 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Purebred.UI.FileBrowser.Keybindings
   ( fileBrowserKeybindings

--- a/src/Purebred/UI/GatherHeaders/Keybindings.hs
+++ b/src/Purebred/UI/GatherHeaders/Keybindings.hs
@@ -15,7 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Purebred.UI.GatherHeaders.Keybindings
   ( gatherFromKeybindings

--- a/src/Purebred/UI/Help/Keybindings.hs
+++ b/src/Purebred/UI/Help/Keybindings.hs
@@ -15,7 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Purebred.UI.Help.Keybindings
   ( helpKeybindings

--- a/src/Purebred/UI/Keybindings.hs
+++ b/src/Purebred/UI/Keybindings.hs
@@ -15,8 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Purebred.UI.Keybindings (
   -- * API

--- a/src/Purebred/UI/Mail/Keybindings.hs
+++ b/src/Purebred/UI/Mail/Keybindings.hs
@@ -15,7 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Purebred.UI.Mail.Keybindings
   ( displayMailKeybindings

--- a/src/Purebred/UI/Notifications.hs
+++ b/src/Purebred/UI/Notifications.hs
@@ -14,8 +14,6 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE FlexibleContexts #-}
-
 module Purebred.UI.Notifications (
   -- * Overview
   -- $overview

--- a/src/Purebred/UI/Status/Main.hs
+++ b/src/Purebred/UI/Status/Main.hs
@@ -15,8 +15,6 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# OPTIONS_HADDOCK hide #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Purebred.UI.Status.Main

--- a/src/Purebred/UI/Validation.hs
+++ b/src/Purebred/UI/Validation.hs
@@ -14,8 +14,6 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE FlexibleContexts #-}
-
 {- | Asynchronous validation for input from widgets -}
 module Purebred.UI.Validation
   ( dispatchValidation

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -16,10 +16,8 @@
 
 {-# OPTIONS_GHC -fno-warn-unused-do-bind -fno-warn-missing-signatures #-}
 
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 
 import Data.Char (chr)
 import System.IO.Temp


### PR DESCRIPTION
The platforms we care about all have GHC 9.6 or later, so drop support for older versions.  Clean up redundant extensions and imports, and avoid some warnings.