### PR TITLE
ui: handle Vi keys in Brick list fallbacks

### DIFF
--- a/src/Purebred/UI/Keybindings.hs
+++ b/src/Purebred/UI/Keybindings.hs
@@ -167,7 +167,7 @@ nullEventHandler = EventHandler (\f s -> s <$ f []) (\_e -> pure ())
 eventHandlerListOfThreads :: EventHandler 'Threads 'ListOfThreads
 eventHandlerListOfThreads = EventHandler
   (asConfig . confIndexView . ivBrowseThreadsKeybindings)
-  (Brick.zoom (asThreadsView . miListOfThreads) . L.handleListEvent)
+  (Brick.zoom (asThreadsView . miListOfThreads) . L.handleListEventVi L.handleListEvent)
 
 eventHandlerSearchThreadsEditor :: EventHandler 'Threads 'SearchThreadsEditor
 eventHandlerSearchThreadsEditor = EventHandler
@@ -182,7 +182,7 @@ eventHandlerViewMailManageMailTagsEditor = EventHandler
 eventHandlerMailsListOfAttachments:: EventHandler 'ViewMail 'MailListOfAttachments
 eventHandlerMailsListOfAttachments = EventHandler
   (asConfig . confMailView . mvMailListOfAttachmentsKeybindings)
-  (Brick.zoom (asMailView . mvAttachments) . L.handleListEvent)
+  (Brick.zoom (asMailView . mvAttachments) . L.handleListEventVi L.handleListEvent)
 
 eventHandlerMailAttachmentOpenWithEditor :: EventHandler 'ViewMail 'MailAttachmentOpenWithEditor
 eventHandlerMailAttachmentOpenWithEditor = EventHandler
@@ -274,7 +274,7 @@ eventHandlerConfirm = EventHandler
 eventHandlerComposeListOfAttachments :: EventHandler 'ComposeView 'ComposeListOfAttachments
 eventHandlerComposeListOfAttachments = EventHandler
   (asConfig . confComposeView . cvListOfAttachmentsKeybindings)
-  (Brick.zoom (asCompose . cAttachments) . L.handleListEvent)
+  (Brick.zoom (asCompose . cAttachments) . L.handleListEventVi L.handleListEvent)
 
 eventHandlerComposeFileBrowser :: EventHandler 'FileBrowser 'ListOfFiles
 eventHandlerComposeFileBrowser = EventHandler


### PR DESCRIPTION
An easy fix to allow Brick to also handle C-f and C-b while scrolling lists.

Is there an IRC / Discord / Zulip / other chat group where prospective contributors can chat about potential changes prior to creating an issue or pull request?