### PR TITLE
CI: only run on pull request

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,8 +14,13 @@
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - edited
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}

--- a/.github/workflows/nixos-ci-flakes.yml
+++ b/.github/workflows/nixos-ci-flakes.yml
@@ -1,7 +1,12 @@
 name: NixOS Build (Flakes - build only)
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - edited
 jobs:
   linux:
     name: Nix

--- a/.github/workflows/nixos-ci.yml
+++ b/.github/workflows/nixos-ci.yml
@@ -1,7 +1,12 @@
 name: NixOS Build
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - edited
 jobs:
   linux:
     name: Nix


### PR DESCRIPTION
Currently we run builds on push *and* pull request. However I find the push run superfluous given that we often just create/iterate on the pull request anyway. No point of running everything twice.

This changes the behaviour to run on:

* master merge
* pull requests when they're opened or edited.