### PR TITLE
feat: allow to reply from a specific entity

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757981991,
-        "narHash": "sha256-vR6xwDIpFHAd+YhJaVK58mVsbgXEUm+8ORCEsOqy5lM=",
+        "lastModified": 1766622272,
+        "narHash": "sha256-tfK3rsGO510/kjxqmFGMZXxK3zscUTW33kbXvBbScT4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "65fd15657ce8467349506b07cda778e867bc09e0",
+        "rev": "a450a7c9795c2cb2cf45a980ed8fe3a35709183c",
         "type": "github"
       },
       "original": {

--- a/src/Purebred/Storage/Mail.hs
+++ b/src/Purebred/Storage/Mail.hs
@@ -24,6 +24,8 @@ module Purebred.Storage.Mail (
     parseMail
   , parseMailbody
   , bodyToDisplay
+  , entityToDisplay
+  , findAutoview
 
   -- ** Header data
   , toQuotedMail
@@ -94,16 +96,7 @@ bodyToDisplay s textwidth charsets prefCT msg =
     Nothing ->
       throwError
         (ParseError $ "Unable to find preferred entity with: " <> show prefCT)
-    Just entity ->
-      let output =
-            maybe
-              (pure $ parseMailbody textwidth "Internal Viewer" $ entityToText charsets entity)
-              (\handler ->
-                 parseMailbody textwidth (showHandler handler) <$>
-                 entityPiped handler entity)
-              (findAutoview s entity)
-          showHandler = view (mhMakeProcess . mpCommand . to (T.pack . toList))
-       in (msg, ) <$> output
+    Just entity -> (msg, ) <$> entityToDisplay entity textwidth charsets (findAutoview s entity)
 
 findAutoview :: AppState -> WireEntity -> Maybe MailcapHandler
 findAutoview s msg =
@@ -124,6 +117,24 @@ chooseEntity preferredContentType msg =
     -- select first entity with matching content-type;
     -- otherwise select first entity;
   in firstOf (entities . filtered match) msg <|> firstOf entities msg
+
+-- | Render an entity to a body representation. This is useful if we want to reply to a specific entity.
+entityToDisplay ::
+  (MonadMask m, MonadError Error m, MonadIO m)
+  => WireEntity
+  -> Int
+  -> CharsetLookup
+  -> Maybe MailcapHandler
+  -> m BodyPresentation
+entityToDisplay entity textwidth charsets autoview =
+  let showHandler = view (mhMakeProcess . mpCommand . to (T.pack . toList))
+   in maybe
+        (pure $ parseMailbody textwidth "Internal Viewer" $ entityToText charsets entity)
+        ( \handler ->
+            parseMailbody textwidth (showHandler handler)
+              <$> entityPiped handler entity
+        )
+        autoview
 
 -- | Render the entity to be written to the filesystem. In case of a
 -- decoding error propagates an 'Error'.

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -73,6 +73,8 @@ module Purebred.UI.Actions (
   , switchComposeEditor
   , senderReply
   , groupReply
+  , attachmentSenderReply
+  , attachmentGroupReply
   , encapsulateMail
   , selectNextUnread
   , composeAsNew
@@ -161,7 +163,7 @@ import qualified Data.IMF.Text as AddressText
 import Data.MIME
 import qualified Purebred.Storage.Client
 import Purebred.Storage.Mail
-       ( parseMail, toQuotedMail
+       ( parseMail, toQuotedMail, entityToDisplay, findAutoview
        , entityToBytes, toMIMEMessage, takeFileName, bodyToDisplay
        , writeEntityToPath)
 import Purebred.UI.Views
@@ -1175,12 +1177,44 @@ encapsulateMail =
 -- selected mail in order to reply to it.
 --
 senderReply, groupReply :: Action 'ViewMail 'ScrollingMailView ()
-senderReply = Action ["reply"] (replyWithMode ReplyToSender)
-groupReply = Action ["group-reply"] (replyWithMode ReplyToGroup)
-
-replyWithMode :: ReplyMode -> T.EventM Name AppState ()
-replyWithMode mode = do
+senderReply =
+  Action
+  ["reply"]
+  (do
       mail <- use (asMailView . mvMail)
+      mbody <- use (asMailView . mvBody)
+      replyWithMode mail mbody ReplyToSender
+  )
+groupReply =
+  Action
+    ["group-reply"]
+    ( do
+        mail <- use (asMailView . mvMail)
+        mbody <- use (asMailView . mvBody)
+        replyWithMode mail mbody ReplyToGroup
+    )
+
+attachmentSenderReply, attachmentGroupReply :: Action 'ViewMail 'MailListOfAttachments ()
+attachmentSenderReply = Action ["reply to sender"] (attachmentReplyWithMode ReplyToSender)
+attachmentGroupReply = Action ["reply to all"] (attachmentReplyWithMode ReplyToGroup)
+
+attachmentReplyWithMode :: ReplyMode -> T.EventM Name AppState ()
+attachmentReplyWithMode mode = do
+        selectedItemHelper (asMailView . mvAttachments) $ \entity ->
+          do
+            charsets <- use (asConfig . confCharsets)
+            textwidth <- use (asConfig . confMailView . mvTextWidth)
+            s <- get
+            runExceptT $ entityToDisplay entity textwidth charsets (findAutoview s entity)
+            >>= either
+              showError
+              ( \mbody -> do
+                  mail <- use (asMailView . mvMail)
+                  replyWithMode mail mbody mode
+              )
+
+replyWithMode :: Maybe MIMEMessage -> BodyPresentation -> ReplyMode -> T.EventM Name AppState ()
+replyWithMode mail mbody mode = do
       charsets <- use (asConfig . confCharsets)
       case mail of
         Nothing -> do
@@ -1193,7 +1227,6 @@ replyWithMode mode = do
               [] -> pure $ Mailbox Nothing (AddrSpec "CHANGE.ME" (DomainDotAtom $ "YOUR" :| ["DOMAIN"]))
               (x:xs) -> x :| xs
             settings = defaultReplySettings idents & set replyMode mode
-          mbody <- use (asMailView . mvBody)
           let
             quoted = toQuotedMail charsets settings mbody m
             setText l t = modifying (asCompose . l . editEditorL . E.editContentsL)

--- a/src/Purebred/UI/Mail/Keybindings.hs
+++ b/src/Purebred/UI/Mail/Keybindings.hs
@@ -107,6 +107,19 @@ mailAttachmentsKeybindings :: [Keybinding 'ViewMail 'MailListOfAttachments]
 mailAttachmentsKeybindings =
     [ Keybinding (V.EvKey (V.KChar 'j') []) listDown
     , Keybinding (V.EvKey (V.KChar 'k') []) listUp
+    , Keybinding (V.EvKey (V.KChar 'r') []) (
+       attachmentSenderReply
+        `focus` (
+            invokeEditor ViewMail ScrollingMailView
+            :: Action 'ComposeView 'ComposeListOfAttachments ()
+            )
+        )
+    , Keybinding (V.EvKey (V.KChar 'g') []) (
+       attachmentGroupReply
+        `focus` (
+            invokeEditor ViewMail ScrollingMailView :: Action 'ComposeView 'ComposeListOfAttachments ()
+            )
+        )
     , Keybinding (V.EvKey (V.KChar 'q') []) (abort *> switchView @'ViewMail @'ScrollingMailView)
     , Keybinding (V.EvKey V.KEnter []) openAttachment
     , Keybinding (V.EvKey (V.KChar 'o') []) (switchView @'ViewMail @'MailAttachmentOpenWithEditor)

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -132,6 +132,7 @@ main = do
       , testSearchRelated
       , testReplyRendersNonASCIIHeadersCorrectly
       , testGroupReply
+      , testSenderAttachmentReply
       , testAddressBookExpansion
       ]
 
@@ -1744,6 +1745,28 @@ testGroupReply =
     sendLine ": x" (Substring "Attachments") >>= put
     assertRegexS $ T.encodeUtf8 "To: frase@host.example"
     assertRegexS $ T.encodeUtf8 "Cc: roman@host.example, joe@host.example"
+
+testSenderAttachmentReply :: PurebredTestCase
+testSenderAttachmentReply =
+  purebredTmuxSession "reply uses specific entity" $ \step -> do
+    startApplication
+    step "focus search edit"
+    sendKeys ":" (Regex (buildAnsiRegex [] ["37"] [] <> "tag"))
+
+    step "delete all input"
+    sendKeys "C-u" (Regex ("Query: " <> buildAnsiRegex [] ["37"] []))
+
+    step "search for multipart message"
+    sendLine "multipart/mixed" (Substring "Item 1 of 1")
+
+    step "open thread"
+    sendKeys "Enter" (Substring "Hello, this is a plain text version with a different body")
+
+    step "show attachments"
+    sendKeys "v" (Substring "Attachments")
+
+    step "reply and expect first attachment quoted in reply"
+    sendKeys "r" (Substring "Hello, this is a different sentence in the main body")
 
 findMail ::
      ( HasTmuxSession testEnv

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -199,7 +199,7 @@ testSearchRelated = purebredTmuxSession "searches related" $
     startApplication
 
     capture >>= put
-    assertSubstringS "Item 1 of 4"
+    assertSubstringS "Item 1 of 5"
     assertRegexS (buildAnsiRegex ["37"] ["43"] [] <> "Aug'17 frase@host.exa")
 
     step "search related"
@@ -231,7 +231,7 @@ testAbortsCompositionIfEditorExits = purebredTmuxSession "aborts composition if 
 
     -- check reply
     step "Navigate second mail"
-    sendKeys "Down" (Substring "Item 2 of 4")
+    sendKeys "Down" (Substring "Item 2 of 5")
 
     step "View mail"
     sendKeys "Enter" (Substring "HOLY PUREBRED")
@@ -247,7 +247,7 @@ testAbortsCompositionIfEditorExits = purebredTmuxSession "aborts composition if 
     sendKeys "Enter" (Substring "Editor exited abnormally")
 
     step "back to thread list"
-    sendKeys "Escape" (Substring "Item 2 of 4")
+    sendKeys "Escape" (Substring "Item 2 of 5")
 
 -- https://github.com/purebred-mua/purebred/issues/395
 testReloadsThreadListAfterReply :: PurebredTestCase
@@ -349,8 +349,8 @@ testBulkActionsOnMailsByInput = purebredTmuxSession "perform bulk labeling on ma
     startApplication
 
     step "navigate to thread with two mails"
-    sendKeys "Down" (Substring "Item 2 of 4")
-    sendKeys "Down" (Substring "Item 3 of 4")
+    sendKeys "Down" (Substring "Item 2 of 5")
+    sendKeys "Down" (Substring "Item 3 of 5")
     sendKeys "Enter" (Substring "Lorem ipsum dolor sit amet")
 
     step "toggle first mail"
@@ -433,7 +433,7 @@ testBulkActionsOnThreadsByKeybinding =
     sendKeys "*" (Regex $ selectedListItem <> "Feb'17.*WIP Refactor")
 
     step "Tag toggled list items using key binding"
-    sendKeys "a" (Substring "New: 3  ]")
+    sendKeys "a" (Substring "New: 4  ]")
       -- untoggled
       >>= assertRegex (buildAnsiRegex [] ["37"] [] <> "Aug'17.*whitespace in the subject[[:space:]]+\n")
 
@@ -699,7 +699,7 @@ testShowsNewMail = purebredTmuxSession "shows newly delivered mail" $
     startApplication
 
     step "shows new mails"
-    sendKeys "Down" (Substring "New: 4")
+    sendKeys "Down" (Substring "New: 5")
 
     notmuchcfg <- view envNotmuchConfig
 
@@ -716,7 +716,7 @@ testShowsNewMail = purebredTmuxSession "shows newly delivered mail" $
     void $ readProcess_ config
 
     step "shows new delivered mail"
-    sendKeys "Up" (Substring "New: 5")
+    sendKeys "Up" (Substring "New: 6")
 
     -- reload mails to see the new e-mail
     step "focus query widget"
@@ -1108,10 +1108,10 @@ testCanJumpToFirstListItem = purebredTmuxSession "can jump to first and last mai
     startApplication
 
     step "Jump to last mail"
-    sendKeys "G" (Substring "4 of 4")
+    sendKeys "G" (Substring "5 of 5")
 
     step "Jump to first mail"
-    sendKeys "1" (Substring "1 of 4")
+    sendKeys "1" (Substring "1 of 5")
 
 testUpdatesReadState :: PurebredTestCase
 testUpdatesReadState = purebredTmuxSession "updates read state for mail and thread" $
@@ -1333,8 +1333,8 @@ testManageTagsOnThreads = purebredTmuxSession "manage tags on threads" $
     -- tag the thread as a whole with a new tag. All mails should keep their
     -- distinct tags, while having received a new tag.
     step "navigate to thread"
-    sendKeys "Down" (Substring "Item 2 of 4")
-    sendKeys "Down" (Substring "Item 3 of 4")
+    sendKeys "Down" (Substring "Item 2 of 5")
+    sendKeys "Down" (Substring "Item 3 of 5")
 
     step "show thread mails"
     sendKeys "Enter" (Substring "ViewMail")
@@ -1418,7 +1418,7 @@ testShowsAndClearsError = purebredTmuxSession "shows and clears error" $
       >>= assertRegex "(open|with)(Binary)?File:.*does not exist"
 
     step "error is cleared with next registered keybinding"
-    sendKeys "Up" (Substring "Purebred: Item 1 of 4")
+    sendKeys "Up" (Substring "Purebred: Item 1 of 5")
 
 testSetsMailToRead :: PurebredTestCase
 testSetsMailToRead = purebredTmuxSession "user can toggle read tag" $
@@ -1474,8 +1474,8 @@ testUserViewsMailSuccessfully = purebredTmuxSession "user can view mail" $
     sendKeys "q" (Substring "WIP Refactor")
 
     step "Move down to threaded mails"
-    sendKeys "Down" (Substring "Purebred: Item 2 of 4")
-    sendKeys "Down" (Substring "Purebred: Item 3 of 4")
+    sendKeys "Down" (Substring "Purebred: Item 2 of 5")
+    sendKeys "Down" (Substring "Purebred: Item 3 of 5")
     sendKeys "Enter" (Substring "Re: WIP Refactor")
 
     step "Scroll down"

--- a/test/data/Maildir/cur/20251225123045.12345_6789.url
+++ b/test/data/Maildir/cur/20251225123045.12345_6789.url
@@ -1,0 +1,38 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Example multipart/mixed with quoted‑printable “=3D” escapes
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="boundary1"
+
+--boundary1
+Content-Type: text/html; charset=UTF-8
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<body>
+<p>Hello, this is a different sentence in the main body of the email.=0A</p>
+</body>
+</html>
+
+--boundary1
+Content-Type: multipart/alternative; boundary="boundary2"
+
+--boundary2
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello, this is a plain text version with a different body.=0A
+
+--boundary2
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<body>
+<p>Hello, this is the HTML version with a different body.=0A</p>
+</body>
+</html>
+
+--boundary2--
+--boundary1--


### PR DESCRIPTION
This is one of those odd ones. I prefer to view text/plain, however when I received mails from an insurance company it had multipart mixed entities while the actual mail was in the first text/html entity and the additional parts essentially contained some disclaimer.

It's currently possible to view all entities (even tho if you prefer text/plain it picks unfortunately the wrong entity), but reply is difficult because Purebred picks the text plain part which is unfortunately breaking conversation.

So this is a way to be able to reply to a specific entity rather than your preferred pick.