### PR TITLE
provide a way to undo tag operations #2

### DIFF
--- a/purebred.cabal
+++ b/purebred.cabal
@@ -119,6 +119,7 @@ library
                      , Purebred.UI.Validation
                      , Purebred.UI.Views
                      , Purebred.UI.Widgets
+                     , Purebred.Undo
                      , Purebred.Version
   other-modules:       Paths_purebred
                      , Purebred.Storage.Client
@@ -197,6 +198,8 @@ test-suite uat
   hs-source-dirs:      test
   ghc-options:         -threaded
   main-is:             TestUserAcceptance.hs
+  other-modules:       UAT.UndoRedo
+                     , UAT.Common
   build-depends:       purebred-email
                      , tasty
                      , tasty-hunit

--- a/src/Purebred/Storage/Client.hs
+++ b/src/Purebred/Storage/Client.hs
@@ -23,6 +23,7 @@ module Purebred.Storage.Client
     -- ** Threads
     getThreads
   , getThreadMessages
+  , getThreadsByIds
   , countMessages
 
     -- ** Messages
@@ -41,11 +42,14 @@ import Control.Lens (firstOf, folded, view)
 import Control.Monad ((<=<), void, when)
 import Control.Monad.Except (ExceptT, MonadError, liftEither, throwError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import qualified Data.Map as Map
+import Data.ByteString (ByteString)
 import Data.Foldable (toList)
 import Data.Function (on)
 import Data.Functor.Compose (Compose(..))
 import Data.Maybe (fromMaybe)
 import Data.List (nub, sort)
+import qualified Data.Set as S
 import qualified Data.Text as T
 import Data.Traversable (for)
 import qualified System.Directory
@@ -117,10 +121,11 @@ messageTagModify
 messageTagModify ops msgs = runCommand $ \db ->
   for msgs $ \m -> do
     let m' = tagItem ops m
-    -- only act if tags actually changed
-    when (((/=) `on` (sort . nub . view tags)) m m') $
-      getMessage db (view mailId m')
-      >>= Notmuch.messageSetTags (view tags m')
+    dbMsg <- getMessage db (view mailId m')
+    dbTags <- Notmuch.tags dbMsg
+    -- only act if tags actually changed from what's in the DB
+    when (S.fromList (view tags m') /= S.fromList dbTags) $
+      Notmuch.messageSetTags (view tags m') dbMsg
     pure m'
 
 -- | Returns the absolute path to the email. Typically used by the
@@ -146,18 +151,25 @@ getThreads expr = runCommand $ \db ->
     -- whether it will actually be lazy depends on the variant of
     -- 'Items' in use.  For a Vector, it is strict and non-chunked.
     >>= liftIO . fmap (fromList 128) . lazyTraverse threadToThread
-  where
-  threadToThread :: Notmuch.Thread a -> IO NotmuchThread
-  threadToThread m = do
+
+threadToThread :: Notmuch.Thread a -> IO NotmuchThread
+threadToThread m = do
     tgs <- Notmuch.tags m
     auth <- Notmuch.threadAuthors m
     NotmuchThread
-      <$> (fixupWhitespace . decodeLenient <$> Notmuch.threadSubject m)
-      <*> pure (view Notmuch.matchedAuthors auth)
-      <*> Notmuch.threadNewestDate m
-      <*> pure tgs
-      <*> Notmuch.threadTotalMessages m
-      <*> Notmuch.threadId m
+        <$> (fixupWhitespace . decodeLenient <$> Notmuch.threadSubject m)
+        <*> pure (view Notmuch.matchedAuthors auth)
+        <*> Notmuch.threadNewestDate m
+        <*> pure tgs
+        <*> Notmuch.threadTotalMessages m
+        <*> Notmuch.threadId m
+
+-- | Returns a vector of threads that match the Thread Id's
+--
+getThreadsByIds :: (Traversable t) => Call (t Notmuch.ThreadId) (V.Vector NotmuchThread)
+getThreadsByIds tids = runCommand $ \db -> do
+  threads <- traverse (liftIO . threadToThread <=< getThread db) tids
+  pure . V.fromList . toList $ threads
 
 -- | Returns a vector of *all* messages belonging to a collection of threads
 --
@@ -169,14 +181,6 @@ getThreadMessages threads = runCommand $ \db -> do
   pure . V.fromList . toList $ mails
 
   where
-  -- Retrieve thread by ID.  libnotmuch does not provide a direct
-  -- way to query a thread.  Perform a general query and pop the
-  -- first result, or fail if the result is empty.
-  --
-  getThread db tid = do
-    t <- Notmuch.query db (Notmuch.Thread tid) >>= Notmuch.threads
-    maybe (throwError (ThreadNotFound tid)) pure (firstOf folded t)
-
   messageToMail m = do
     tgs <- Notmuch.tags m
     NotmuchMail
@@ -185,6 +189,20 @@ getThreadMessages threads = runCommand $ \db -> do
       <*> Notmuch.messageDate m
       <*> pure tgs
       <*> Notmuch.messageId m
+      <*> Notmuch.threadId m
+
+-- | Retrieve thread by ID.  libnotmuch does not provide a direct
+-- way to query a thread.  Perform a general query and pop the
+-- first result, or fail if the result is empty.
+--
+getThread
+  :: (MonadError Error m, MonadIO m)
+  => Notmuch.Database a
+  -> Notmuch.ThreadId
+  -> m (Notmuch.Thread a)
+getThread db tid = do
+  t <- Notmuch.query db (Notmuch.Thread tid) >>= Notmuch.threads
+  maybe (throwError (ThreadNotFound tid)) pure (firstOf folded t)
 
 indexFilePath :: Call2 FilePath [Notmuch.Tag] ()
 indexFilePath path tags_ = runCommand $ \db ->

--- a/src/Purebred/Storage/Tags.hs
+++ b/src/Purebred/Storage/Tags.hs
@@ -36,6 +36,7 @@ module Purebred.Storage.Tags
   , tagItem
   , addTags
   , removeTags
+  , restoreOps
   ) where
 
 import Control.Applicative ((<|>), optional)
@@ -53,10 +54,6 @@ import Notmuch (mkTag)
 import Purebred.Types
 import Purebred.Types.Parser.ByteString (niceEndOfInput, skipSpaces)
 import Purebred.UI.Notifications (makeWarning)
-
--- | Tag operations
-data TagOp = RemoveTag Tag | AddTag Tag | ResetTags
-  deriving (Eq, Show)
 
 tagOp :: Parser TagOp
 tagOp =
@@ -106,6 +103,9 @@ applyTagOp ResetTags = setTags []
 
 class ManageTags a  where
     tags :: Lens' a [Tag]
+
+restoreOps :: (ManageTags a) => a -> [TagOp]
+restoreOps x = ResetTags : fmap AddTag (view tags x)
 
 setTags :: (ManageTags a) => [Tag] -> a -> a
 setTags = set tags

--- a/src/Purebred/Types.hs
+++ b/src/Purebred/Types.hs
@@ -36,6 +36,7 @@ module Purebred.Types
   , asUserMessage
   , asViews
   , asFileBrowser
+  , asUndoStack
   , asLocalTime
   , Async(..)
   , asAsync
@@ -57,6 +58,7 @@ module Purebred.Types
   , mailDate
   , mailTags
   , mailId
+  , mailThreadId
   , NotmuchThread(..)
   , thSubject
   , thAuthors
@@ -64,6 +66,13 @@ module Purebred.Types
   , thTags
   , thReplies
   , thId
+  , TagOp(..)
+
+    -- ** Undo Operations
+  , Undoable(..)
+  , UndoStack(..)
+  , usUndo
+  , usRedo
 
     -- ** Mail Viewer
   , MailView(..)
@@ -686,6 +695,7 @@ data AppState = AppState
     , _asUserMessage :: Maybe UserMessage
     , _asViews     :: ViewSettings -- ^ stores widget and focus information
     , _asFileBrowser :: FileBrowser
+    , _asUndoStack :: UndoStack
     , _asLocalTime :: UTCTime
     , _asAsync :: Async
     }
@@ -719,6 +729,9 @@ asViews = lens _asViews (\appstate x -> appstate { _asViews = x })
 
 asFileBrowser :: Lens' AppState FileBrowser
 asFileBrowser = lens _asFileBrowser (\as x -> as { _asFileBrowser = x })
+
+asUndoStack :: Lens' AppState UndoStack
+asUndoStack = lens _asUndoStack (\as x -> as { _asUndoStack = x })
 
 asLocalTime :: Lens' AppState UTCTime
 asLocalTime = lens _asLocalTime (\as x -> as { _asLocalTime = x })
@@ -771,6 +784,7 @@ data NotmuchMail = NotmuchMail
     , _mailDate :: UTCTime
     , _mailTags :: [Tag]
     , _mailId :: B.ByteString
+    , _mailThreadId :: B.ByteString
     } deriving (Show, Eq)
 
 mailSubject :: Lens' NotmuchMail T.Text
@@ -788,6 +802,8 @@ mailTags = lens _mailTags (\m t -> m { _mailTags = t })
 mailId :: Lens' NotmuchMail B.ByteString
 mailId = lens _mailId (\m i -> m { _mailId = i })
 
+mailThreadId :: Lens' NotmuchMail B.ByteString
+mailThreadId = lens _mailThreadId (\m i -> m { _mailThreadId = i })
 -- | A thread of mails from the notmuch database represented in Purebred.
 data NotmuchThread = NotmuchThread
     { _thSubject :: T.Text
@@ -815,3 +831,22 @@ thReplies = lens _thReplies (\m t -> m { _thReplies = t })
 
 thId :: Lens' NotmuchThread B.ByteString
 thId = lens _thId (\m t -> m { _thId = t })
+
+-- | Tag operations
+data TagOp = RemoveTag Tag | AddTag Tag | ResetTags
+  deriving (Eq, Show)
+
+data Undoable
+  = UndoMailTags [TagOp] [NotmuchMail]
+  deriving (Show)
+
+data UndoStack = UndoStack
+  { _usUndo :: [Undoable]
+  , _usRedo :: [Undoable]
+  }
+
+usUndo :: Lens' UndoStack [Undoable]
+usUndo = lens _usUndo (\us t -> us { _usUndo = t })
+
+usRedo :: Lens' UndoStack [Undoable]
+usRedo = lens _usRedo (\us t -> us { _usRedo = t })

--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -16,6 +16,7 @@
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -88,6 +89,8 @@ module Purebred.UI.Actions (
   , fromAddressBookMail
   , fromAddressBookBCC
   , fromAddressBookCC
+  , undo
+  , redo
 
   -- ** Actions for scrolling
   , scrollUp
@@ -162,6 +165,7 @@ import System.Random (getStdRandom, uniform)
 import qualified Data.IMF.Text as AddressText
 import Data.MIME
 import qualified Purebred.Storage.Client
+import Purebred.Undo (applyTagOps, applyTagOpsWithUndo, popApply, runForward, runReverse)
 import Purebred.Storage.Mail
        ( parseMail, toQuotedMail, entityToDisplay, findAutoview
        , entityToBytes, toMIMEMessage, takeFileName, bodyToDisplay
@@ -170,7 +174,7 @@ import Purebred.UI.Views
        (mailView, toggleLastVisibleWidget, indexView, resetView,
         focusedViewWidget)
 import Purebred.Plugin.Internal
-import Purebred.Storage.Tags (TagOp(AddTag, RemoveTag), hasTag, parseTagOps, tagItem)
+import Purebred.Storage.Tags (hasTag, parseTagOps, tagItem)
 import Purebred.System (tryIO)
 import Purebred.System.Process
 import Purebred.Types
@@ -1435,6 +1439,16 @@ fromAddressBookThreads = Action [fromAddressBookDescription] fromAddressBookForT
 fromAddressBookMail :: Action 'ViewMail 'ComposeTo ()
 fromAddressBookMail = Action [fromAddressBookDescription] fromAddressBookForTo
 
+undo :: Action v ctx ()
+undo = Action
+  ["undo last tagging operation"]
+  (popApply (asUndoStack . usUndo) (asUndoStack . usRedo) runReverse "undo")
+
+redo :: Action v ctx ()
+redo = Action
+  ["redo last tagging operation"]
+  (popApply (asUndoStack . usRedo) (asUndoStack . usUndo) runForward "redo")
+
 -- Function definitions for actions
 --
 
@@ -1532,17 +1546,6 @@ getEditorTagOps s =
   let contents = (foldr (<>) "" $ E.getEditContents $ view (editorL @n) s)
   in parseTagOps contents
 
--- | Apply given tag operations on all mails
---
-applyTagOps
-  :: (Traversable t, MonadIO m, MonadState AppState m)
-  => [TagOp]
-  -> t NotmuchMail
-  -> m (Either Error (t NotmuchMail))
-applyTagOps ops mails = do
-  server <- use storageServer
-  runExceptT (Purebred.Storage.Client.messageTagModify ops mails server)
-
 updateStateWithParsedMail :: T.EventM Name AppState ()
 updateStateWithParsedMail = do
   server <- use storageServer
@@ -1580,9 +1583,15 @@ updateReadState con = do
   op <- con <$> use (asConfig . confNotmuch . nmNewTag)
   toggledOrSelectedItemHelper
     @'ScrollingMailView
-    (manageMailTags [op])
+    (apply [op])
     (tagItem [op])
   modifying (asThreadsView . miListOfThreads) (L.listModify (over _2 $ tagItem [op]))
+  where
+    apply :: (Traversable t, MonadIO m, MonadState AppState m) => [TagOp] -> t NotmuchMail -> m ()
+    apply ops ms = do
+        applyTagOps ops ms >>= \case
+          Left e -> showError e
+          Right _ -> pure ()
 
 manageMailTags ::
      (Traversable t, MonadIO m, MonadState AppState m)
@@ -1590,7 +1599,7 @@ manageMailTags ::
   -> t NotmuchMail
   -> m ()
 manageMailTags ops ms = do
-  result <- applyTagOps ops ms
+  result <- applyTagOpsWithUndo ops ms
   case result of
     Left e -> showError e
     Right _ -> pure ()
@@ -1810,7 +1819,7 @@ manageThreadTags ops ts = do
   server <- use storageServer
   runExceptT
     ( Purebred.Storage.Client.getThreadMessages ts server
-      >>= applyTagOps ops
+      >>= applyTagOpsWithUndo ops
     )
     >>= either showError (const $ pure ())
 

--- a/src/Purebred/UI/App.hs
+++ b/src/Purebred/UI/App.hs
@@ -234,10 +234,11 @@ initialState conf chan server sink = do
     fb = CreateFileBrowser
          fb'
          (statefulEditor $ E.editor ManageFileBrowserSearchPath Nothing path)
+    undostack = UndoStack [] []
     mailboxes = view (confComposeView . cvIdentities) conf
     epoch = UTCTime (fromGregorian 2018 07 18) 1
     async = Async Nothing
-    s = AppState conf chan server sink mi mv (initialCompose mailboxes) Nothing viewsettings fb epoch async
+    s = AppState conf chan server sink mi mv (initialCompose mailboxes) Nothing viewsettings fb undostack epoch async
   execStateT applySearch s
 
 -- | Application event loop.

--- a/src/Purebred/UI/Index/Keybindings.hs
+++ b/src/Purebred/UI/Index/Keybindings.hs
@@ -45,6 +45,8 @@ browseThreadsKeybindings =
     , Keybinding (V.EvKey (V.KChar '1') []) listJumpToStart
     , Keybinding (V.EvKey (V.KChar '*') []) (toggleListItem *> listDown)
     , Keybinding (V.EvKey (V.KChar '+') []) searchRelated
+    , Keybinding (V.EvKey (V.KChar 'u') [V.MCtrl]) undo
+    , Keybinding (V.EvKey (V.KChar 'r') [V.MCtrl]) redo
     ]
 
 searchThreadsKeybindings :: [Keybinding 'Threads 'SearchThreadsEditor]

--- a/src/Purebred/UI/Mail/Keybindings.hs
+++ b/src/Purebred/UI/Mail/Keybindings.hs
@@ -41,6 +41,8 @@ displayMailKeybindings =
     , Keybinding (V.EvKey (V.KChar ' ') []) scrollPageDown
     , Keybinding (V.EvKey (V.KChar 'h') []) toggleHeaders
     , Keybinding (V.EvKey (V.KChar '`') []) (switchView @'ViewMail @'ManageMailTagsEditor)
+    , Keybinding (V.EvKey (V.KChar 'u') [V.MCtrl]) undo
+    , Keybinding (V.EvKey (V.KChar 'r') [V.MCtrl]) redo
 
     , Keybinding (V.EvKey V.KUp [])
         (switchView @'ViewMail @'ListOfMails *> listUp *> displayMail)

--- a/src/Purebred/UI/Status/Main.hs
+++ b/src/Purebred/UI/Status/Main.hs
@@ -113,12 +113,16 @@ renderStatusbar w s = withAttr statusbarAttr $ hBox
   , renderNewMailIndicator s
   , renderMatches s
   , padLeft (Pad 1) (str "]")
+  , padLeft (Pad 2) (str $ "↶ " <> undos <> " " <> redos <> " ↷")
   , fillLine
   , txt (
       titleize (focusedViewName s) <> "-"
       <> titleize (focusedViewWidget s) <> " "
       )
   ]
+  where
+    undos = show $ length $ view (asUndoStack . usUndo) s
+    redos = show $ length $ view (asUndoStack . usRedo) s
 
 renderMatches :: AppState -> Widget n
 renderMatches s =

--- a/src/Purebred/Undo.hs
+++ b/src/Purebred/Undo.hs
@@ -1,0 +1,134 @@
+-- This file is part of purebred
+-- Copyright (C) 20216 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-| Undo System -}
+module Purebred.Undo
+  ( maxUndo
+  , recordUndo
+  , popApply
+  , applyTagOps
+  , applyTagOpsWithUndo
+  , runReverse
+  , runForward
+  ) where
+
+import qualified Brick.Widgets.List as L
+import Data.Foldable (toList)
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import qualified Data.Map as Map
+import Control.Monad.State (MonadState)
+import Control.Monad.Reader (MonadIO)
+import Control.Monad.Except (ExceptT(..), runExceptT, MonadError)
+import Control.Lens (Lens', (&), set, each, view, use, modifying, assign, _2)
+
+import Purebred.Types
+import Purebred.Types.Error
+import qualified Purebred.Storage.Client
+import qualified Purebred.Storage.Tags
+
+
+maxUndo :: Int
+maxUndo = 50
+
+recordUndo :: MonadState AppState m => Undoable -> m ()
+recordUndo u = do
+  modifying (asUndoStack . usUndo) (take maxUndo . (u :))
+  assign (asUndoStack . usRedo) []
+
+-- | undo: per-mail, because each snapshot has its own prior tags
+runReverse :: (MonadIO m, MonadState AppState m) => Undoable -> m (Either Error ())
+runReverse (UndoMailTags _ before) = runExceptT $ do
+  traverse apply before >>= reconcileTags . concat
+  where
+    apply m = ExceptT (applyTagOps (Purebred.Storage.Tags.restoreOps m) [m])
+
+runForward :: (MonadIO m, MonadState AppState m) => Undoable -> m (Either Error ())
+runForward (UndoMailTags ops before) = runExceptT $
+  ExceptT (applyTagOps ops before) >>= reconcileTags
+
+reconcileTags :: (MonadError Error m, MonadIO m, MonadState AppState m) => [NotmuchMail] -> m ()
+reconcileTags updated = do
+  let byMailId = Map.fromList [ (view mailId m, view Purebred.Storage.Tags.tags m) | m <- updated ]
+      patchMail m = maybe m (\ts -> m & set Purebred.Storage.Tags.tags ts) (Map.lookup (view mailId m) byMailId)
+  modifying (asThreadsView . miListOfMails . L.listElementsL . each . _2) patchMail
+
+  server <- use storageServer
+  let tids = Set.toList . Set.fromList $ view mailThreadId <$> updated
+  v <- Purebred.Storage.Client.getThreadsByIds tids server
+  let byThreadId = Map.fromList [ (view thId t, t) | t <- toList v ]
+      patchThread t = Map.findWithDefault t (view thId t) byThreadId
+  modifying (asThreadsView . miListOfThreads . L.listElementsL . each . _2) patchThread
+
+popApply
+  :: (MonadIO m, MonadState AppState m)
+  => Lens' AppState [Undoable]
+  -> Lens' AppState [Undoable]
+  -> (Undoable -> m (Either Error ()))
+  -> T.Text
+  -> m ()
+popApply src dst run verb = do
+  stack <- use src
+  case stack of
+    [] -> assign asUserMessage (Just $ UserMessage StatusBar $ Info (verb <> ": nothing to do"))
+    (u : undostack) ->
+        run u >>= \case
+          Left err -> assign asUserMessage (Just $ UserMessage ManageMailTagsEditor $ Error err)
+          Right () -> do
+            assign src undostack
+            modifying dst (u :)
+            let remaining = length undostack
+                msg = verb <> ": " <> describeUndoable u
+                      <> if remaining > 0
+                         then T.pack $ " (" <> show remaining <> "more)"
+                         else ""
+            assign asUserMessage (Just $ UserMessage StatusBar $ Info msg)
+
+describeUndoable :: Undoable -> T.Text
+describeUndoable (UndoMailTags _ mails) =
+  let amount = length mails
+  in T.pack $ show amount <> " message(s)"
+
+-- | Apply given tag operations on all mails
+--
+applyTagOps
+  :: (Traversable t, MonadIO m, MonadState AppState m)
+  => [TagOp]
+  -> t NotmuchMail
+  -> m (Either Error (t NotmuchMail))
+applyTagOps ops mails = do
+  server <- use storageServer
+  runExceptT (Purebred.Storage.Client.messageTagModify ops mails server)
+
+-- | Apply given tag operations on all mails
+--
+applyTagOpsWithUndo
+  :: (Traversable t, MonadIO m, MonadState AppState m)
+  => [TagOp]
+  -> t NotmuchMail
+  -> m (Either Error (t NotmuchMail))
+applyTagOpsWithUndo ops mails = do
+  server <- use storageServer
+  result <- runExceptT (Purebred.Storage.Client.messageTagModify ops mails server)
+  case result of
+    Right newMails -> do
+      let undoop = UndoMailTags ops (toList mails)
+      recordUndo undoop
+      pure (Right newMails)
+    Left e -> pure (Left e)

--- a/test/TestMail.hs
+++ b/test/TestMail.hs
@@ -61,7 +61,7 @@ testRemovingTags = testProperty "remove tags" propRemoveTags
 testTagOpsWithReset :: TestTree
 testTagOpsWithReset = testCase "tag ops with reset" $ ["archive"] @=? view mailTags actual
   where
-    m = NotmuchMail "subject" "from" time ["foo", "bar"] "asdf"
+    m = NotmuchMail "subject" "from" time ["foo", "bar"] "asdf" "threadId"
     time = UTCTime (fromGregorian 2018 1 15) (secondsToDiffTime 123)
     actual = tagItem [ResetTags, AddTag "archive"] m
 
@@ -78,4 +78,5 @@ instance Arbitrary NotmuchMail where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> (T.encodeUtf8 <$> arbitrary)
         <*> (T.encodeUtf8 <$> arbitrary)

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -1,5 +1,5 @@
 -- This file is part of purebred
--- Copyright (C) 2017-2019 Róman Joost
+-- Copyright (C) 2017-2026 Róman Joost
 --
 -- purebred is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
@@ -14,46 +14,40 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# OPTIONS_GHC -fno-warn-unused-do-bind -fno-warn-missing-signatures #-}
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 import Data.Char (chr)
-import System.IO.Temp
-  ( createTempDirectory, getCanonicalTemporaryDirectory
-  , emptySystemTempFile)
+import System.IO.Temp (emptySystemTempFile)
 import Data.Either (isRight)
-import Data.Functor (($>))
 import Data.Foldable (for_)
 import Control.Concurrent (threadDelay)
 import System.IO (hPutStr, stderr)
-import System.Environment (lookupEnv, getEnvironment)
+import System.Environment (lookupEnv)
 import qualified System.Environment as Env
-import System.FilePath.Posix
-  ( (</>)
-  , getSearchPath, isAbsolute, searchPathSeparator
-  )
+import System.FilePath.Posix ((</>))
 import Control.Monad (filterM, void, when)
 import Data.Maybe (fromMaybe, isJust)
-import Data.List (intercalate, isInfixOf, sort, sortBy)
+import Data.List (isInfixOf, sort, sortBy)
 import qualified Data.ByteString.Char8 as B
 import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader (MonadIO, MonadReader, runReaderT)
+import Control.Monad.Reader (MonadIO, MonadReader)
 import Control.Monad.State (MonadState)
 import System.Exit (die)
 
-import Control.Lens (Lens', _init, _last, at, lens, preview, set, to, view)
+import Control.Lens (_init, _last, at, preview, set, to, view)
 import System.Directory
-  ( copyFile, getCurrentDirectory, listDirectory, removeDirectoryRecursive
+  ( getCurrentDirectory, listDirectory, removeDirectoryRecursive
   , removeFile, doesPathExist, findExecutable
   )
 import System.Posix.Files (getFileStatus, isRegularFile)
 import System.Process.Typed
-  (byteStringInput, proc, readProcess_, runProcess_, setEnv, setStdin)
+  (byteStringInput, proc, readProcess_, setStdin)
 import Test.Tasty (defaultMain)
 import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure)
 import Test.Tasty.Tmux
@@ -62,9 +56,10 @@ import Data.MIME
   (MIMEMessage, createTextPlainMessage, message, mime, parse,
   headers, buildMessage)
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+import UAT.Common
+import UAT.UndoRedo (testUndoRedo)
 
-type PurebredTestCase = TestCase GlobalEnv
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
 
 main :: IO ()
 main = do
@@ -134,6 +129,7 @@ main = do
       , testGroupReply
       , testSenderAttachmentReply
       , testAddressBookExpansion
+      , testUndoRedo
       ]
 
 testAddressBookExpansion :: PurebredTestCase
@@ -558,7 +554,7 @@ testSubstringMatchesAreCleared = purebredTmuxSession "substring match indicator 
 
     step "No match indicator is shown"
     snapshot
-    assertRegexS "New:[[:space:]][0-9][[:space:]]+\\][[:space:]]+Threads"
+    assertSubstringS "List of Threads"
 
     step "search for Lorem mail"
     sendKeys ":" (Regex ("Query: " <> buildAnsiRegex [] ["37"] [] <> "tag:inbox"))
@@ -583,7 +579,7 @@ testSubstringMatchesAreCleared = purebredTmuxSession "substring match indicator 
     sendKeys "\r" (Not (Substring "matches ]"))
 
     step "go back to threads"
-    sendKeys "Escape" (Regex "New:[[:space:]][0-9][[:space:]]+\\][[:space:]]+Threads")
+    sendKeys "Escape" (Substring "List of Threads")
 
 
 testSubstringSearchInMailBody :: PurebredTestCase
@@ -1862,152 +1858,12 @@ assertFileAmountInMaildir dir expected = liftIO (go (3 :: Int) 62500)
       _ | n > 0         -> go (n - 1) (d * 2)
       _                 -> assertFailure (errmsg files)
 
--- Global test environment (shared by all test cases)
-newtype GlobalEnv = GlobalEnv FilePath
-
--- Session test environment
-data Env = Env
-  { _envConfigDir :: FilePath
-  , _envMaildir :: FilePath
-  , _envNotmuchConfig :: FilePath
-  , _envSessionName :: String
-  }
-
-instance HasTmuxSession Env where
-  tmuxSession = envSessionName
-
--- | Session-specific config dir
-envConfigDir :: Lens' Env FilePath
-envConfigDir = lens _envConfigDir (\s b -> s { _envConfigDir = b })
-
-envMaildir :: Lens' Env FilePath
-envMaildir = lens _envMaildir (\s b -> s { _envMaildir = b })
-
-envNotmuchConfig :: Lens' Env FilePath
-envNotmuchConfig = lens _envNotmuchConfig (\s b -> s { _envNotmuchConfig = b })
-
-envSessionName :: Lens' Env String
-envSessionName = lens _envSessionName (\s b -> s { _envSessionName = b })
-
--- | Tear down a test session
-tearDown :: Env -> IO ()
-tearDown (Env confdir mdir _ _) = do
-  removeDirectoryRecursive confdir
-  removeDirectoryRecursive mdir
-
--- | Set up a test session.
-setUp :: GlobalEnv -> TmuxSession -> IO Env
-setUp (GlobalEnv globalConfigDir) sessionName = do
-  maildir <- setUpTempMaildir
-  nmCfg <- setUpNotmuchCfg maildir
-  setUpNotmuch nmCfg
-
-  confdir <- mkTempDir
-  runProcess_ $ proc "sh" ["-c", "cp -a " <> globalConfigDir <> "/* " <> confdir]
-
-  flip runReaderT sessionName $ do
-    -- a) Make the regex less color code dependent by setting the TERM to 'screen'.
-    -- This can happen if different environments support more than 16 colours (e.g.
-    -- background values > 37), while our CI environment only supports 16 colours.
-    --
-    -- Previously we used value "ansi".  But we changed this because
-    -- "ansi" can have different capabilities on different platforms,
-    -- including missing ones.  On the other hand, "screen" triggers
-    -- special handling within vty.
-    setEnvVarInSession "TERM" "screen"
-
-    -- set the config dir
-    setEnvVarInSession "PUREBRED_CONFIG_DIR" confdir
-    setEnvVarInSession "NOTMUCH_CONFIG" nmCfg
-
-  pure $ Env confdir maildir nmCfg sessionName
-
-precompileConfig :: FilePath -> IO ()
-precompileConfig testdir = do
-  env <- getEnvironment
-  let systemEnv = ("PUREBRED_CONFIG_DIR", testdir) : env
-      config = setEnv systemEnv $ proc "purebred" ["--version"]
-  runProcess_ config
-
--- | Get the explicitly-specified source directory via SRCDIR
--- env var, or fall back to CWD.
-getSourceDirectory :: IO FilePath
-getSourceDirectory = lookupEnv "SRCDIR" >>= maybe getCurrentDirectory pure
-
-setUpPurebredConfig :: FilePath -> IO ()
-setUpPurebredConfig testdir = do
-  c <- getSourceDirectory
-  copyFile (c <> "/configs/purebred.hs") (testdir <> "/purebred.hs")
-  copyFile (c <> "/configs/aliases") (testdir <> "/aliases")
-
-mkTempDir :: IO FilePath
-mkTempDir = getCanonicalTemporaryDirectory >>= flip createTempDirectory "purebredtest"
-
--- | Set up a temporary Maildir containing the test database
--- The returned directory contains the 'Maildir' subdirectory.
-setUpTempMaildir :: IO FilePath
-setUpTempMaildir = do
-  basedir <- mkTempDir
-  cwd <- getSourceDirectory
-  runProcess_ $ proc "cp" ["-R", cwd <> "/test/data/Maildir", basedir]
-  let mdir = basedir </> "Maildir"
-
-  -- Rename files with maildir flags ; these had to be renamed (':' replaced
-  -- with '_') to appease Hackage requirement that tarballs only contain
-  -- filenames that are valid on both POSIX and Windows.  We have to fix the
-  -- filenames here before using them.
-  --
-  -- In a Nix system the PATH environment may contain relative paths.
-  -- For security reasons find(1) refuses to run when -execdir is given
-  -- and PATH contains relative paths.  So we have to remove relative
-  -- dirs from PATH.
-  --
-  path <- intercalate [searchPathSeparator]
-          . filter isAbsolute
-          <$> getSearchPath
-  let
-    f (k, _) | k == "PATH" = (k, path)
-    f x = x
-  env <- fmap f <$> getEnvironment
-  runProcess_ $ setEnv env $ proc "find"
-    [ mdir, "-name", "*_2,*"
-    , "-execdir", "sh", "-c", "mv {} $(echo {} | sed s/_2,/:2,/)", ";"
-    ]
-
-  pure mdir
-
--- | run notmuch to create the notmuch database
--- Note: discard stdout which otherwise clobbers the test output
-setUpNotmuch :: FilePath -> IO ()
-setUpNotmuch notmuchcfg = void $ readProcess_ $ proc "notmuch" ["--config=" <> notmuchcfg, "new" ]
-
--- | Write a minimal notmuch config pointing to the given maildir.
--- Returns the path to the notmuch configuration file (which is
--- created under the given maildir directory).
---
-setUpNotmuchCfg :: FilePath -> IO FilePath
-setUpNotmuchCfg dir = do
-  let cfgData = "[database]\npath=" <> dir <> "\n"
-      cfgFile = dir <> "/notmuch-config"
-  writeFile cfgFile cfgData $> cfgFile
-
-purebredTmuxSession = withTmuxSession setUp tearDown
 
 -- | convenience function to print captured output to STDERR
 _debugOutput :: String -> IO ()
 _debugOutput out = do
   d <- lookupEnv "DEBUG"
   when (isJust d) $ hPutStr stderr ("\n\n" <> out)
-
--- | start the application
--- Note: this is currently defined as an additional test step for no good
--- reason.
-startApplication :: (MonadReader Env m, MonadIO m) => m ()
-startApplication = do
-  srcdir <- liftIO getSourceDirectory
-  tmuxSendKeys LiteralKeys ("cd " <> srcdir <> "\r")
-  tmuxSendKeys InterpretKeys "purebred\r"
-  void $ waitForCondition (Substring "Purebred: Item") defaultRetries defaultBackoff
 
 -- | A list item which is toggled for a batch operation
 --

--- a/test/UAT/Common.hs
+++ b/test/UAT/Common.hs
@@ -1,0 +1,202 @@
+-- This file is part of purebred
+-- Copyright (C) 2026 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module UAT.Common
+  ( PurebredTestCase
+  , GlobalEnv(..)
+  , purebredTmuxSession
+  , envConfigDir
+  , envMaildir
+  , envNotmuchConfig
+  , envSessionName
+  , startApplication
+  , mkTempDir
+  , setUpPurebredConfig
+  , precompileConfig
+  , getSourceDirectory
+  ) where
+
+import Data.Functor (($>))
+import System.IO.Temp
+  ( createTempDirectory, getCanonicalTemporaryDirectory)
+import Data.List (intercalate)
+import System.FilePath.Posix
+  ( (</>)
+  , getSearchPath, isAbsolute, searchPathSeparator
+  )
+import System.Environment (lookupEnv, getEnvironment)
+import System.Process.Typed
+  (proc, readProcess_, runProcess_, setEnv)
+import System.Directory
+  ( copyFile, getCurrentDirectory, removeDirectoryRecursive
+  )
+import Control.Monad.IO.Class (liftIO)
+import Control.Lens (Lens', lens)
+import Control.Monad (void)
+import Control.Monad.State (MonadState)
+import Control.Monad.Reader (MonadIO, MonadReader, runReaderT)
+
+import Test.Tasty (TestName)
+import Test.Tasty.Tmux
+
+-- Global test environment (shared by all test cases)
+newtype GlobalEnv = GlobalEnv FilePath
+
+type PurebredTestCase = TestCase GlobalEnv
+
+purebredTmuxSession ::
+  TestName
+  -> (forall m. (MonadReader Env m, MonadState Capture m, MonadIO m) => (String -> m()) -> m a)
+  -> TestCase GlobalEnv
+purebredTmuxSession = withTmuxSession setUp tearDown
+
+-- Session test environment
+data Env = Env
+  { _envConfigDir :: FilePath
+  , _envMaildir :: FilePath
+  , _envNotmuchConfig :: FilePath
+  , _envSessionName :: String
+  }
+
+instance HasTmuxSession Env where
+  tmuxSession = envSessionName
+
+-- | Session-specific config dir
+envConfigDir :: Lens' Env FilePath
+envConfigDir = lens _envConfigDir (\s b -> s { _envConfigDir = b })
+
+envMaildir :: Lens' Env FilePath
+envMaildir = lens _envMaildir (\s b -> s { _envMaildir = b })
+
+envNotmuchConfig :: Lens' Env FilePath
+envNotmuchConfig = lens _envNotmuchConfig (\s b -> s { _envNotmuchConfig = b })
+
+envSessionName :: Lens' Env String
+envSessionName = lens _envSessionName (\s b -> s { _envSessionName = b })
+
+-- | Tear down a test session
+tearDown :: Env -> IO ()
+tearDown (Env confdir mdir _ _) = do
+  removeDirectoryRecursive confdir
+  removeDirectoryRecursive mdir
+
+-- | Set up a test session.
+setUp :: GlobalEnv -> TmuxSession -> IO Env
+setUp (GlobalEnv globalConfigDir) sessionName = do
+  maildir <- setUpTempMaildir
+  nmCfg <- setUpNotmuchCfg maildir
+  setUpNotmuch nmCfg
+
+  confdir <- mkTempDir
+  runProcess_ $ proc "sh" ["-c", "cp -a " <> globalConfigDir <> "/* " <> confdir]
+
+  flip runReaderT sessionName $ do
+    -- a) Make the regex less color code dependent by setting the TERM to 'screen'.
+    -- This can happen if different environments support more than 16 colours (e.g.
+    -- background values > 37), while our CI environment only supports 16 colours.
+    --
+    -- Previously we used value "ansi".  But we changed this because
+    -- "ansi" can have different capabilities on different platforms,
+    -- including missing ones.  On the other hand, "screen" triggers
+    -- special handling within vty.
+    setEnvVarInSession "TERM" "screen"
+
+    -- set the config dir
+    setEnvVarInSession "PUREBRED_CONFIG_DIR" confdir
+    setEnvVarInSession "NOTMUCH_CONFIG" nmCfg
+
+  pure $ Env confdir maildir nmCfg sessionName
+
+precompileConfig :: FilePath -> IO ()
+precompileConfig testdir = do
+  env <- getEnvironment
+  let systemEnv = ("PUREBRED_CONFIG_DIR", testdir) : env
+      config = setEnv systemEnv $ proc "purebred" ["--version"]
+  runProcess_ config
+
+-- | Get the explicitly-specified source directory via SRCDIR
+-- env var, or fall back to CWD.
+getSourceDirectory :: IO FilePath
+getSourceDirectory = lookupEnv "SRCDIR" >>= maybe getCurrentDirectory pure
+
+setUpPurebredConfig :: FilePath -> IO ()
+setUpPurebredConfig testdir = do
+  c <- getSourceDirectory
+  copyFile (c <> "/configs/purebred.hs") (testdir <> "/purebred.hs")
+  copyFile (c <> "/configs/aliases") (testdir <> "/aliases")
+
+mkTempDir :: IO FilePath
+mkTempDir = getCanonicalTemporaryDirectory >>= flip createTempDirectory "purebredtest"
+
+-- | Set up a temporary Maildir containing the test database
+-- The returned directory contains the 'Maildir' subdirectory.
+setUpTempMaildir :: IO FilePath
+setUpTempMaildir = do
+  basedir <- mkTempDir
+  cwd <- getSourceDirectory
+  runProcess_ $ proc "cp" ["-R", cwd <> "/test/data/Maildir", basedir]
+  let mdir = basedir </> "Maildir"
+
+  -- Rename files with maildir flags ; these had to be renamed (':' replaced
+  -- with '_') to appease Hackage requirement that tarballs only contain
+  -- filenames that are valid on both POSIX and Windows.  We have to fix the
+  -- filenames here before using them.
+  --
+  -- In a Nix system the PATH environment may contain relative paths.
+  -- For security reasons find(1) refuses to run when -execdir is given
+  -- and PATH contains relative paths.  So we have to remove relative
+  -- dirs from PATH.
+  --
+  path <- intercalate [searchPathSeparator]
+          . filter isAbsolute
+          <$> getSearchPath
+  let
+    f (k, _) | k == "PATH" = (k, path)
+    f x = x
+  env <- fmap f <$> getEnvironment
+  runProcess_ $ setEnv env $ proc "find"
+    [ mdir, "-name", "*_2,*"
+    , "-execdir", "sh", "-c", "mv {} $(echo {} | sed s/_2,/:2,/)", ";"
+    ]
+
+  pure mdir
+
+-- | run notmuch to create the notmuch database
+-- Note: discard stdout which otherwise clobbers the test output
+setUpNotmuch :: FilePath -> IO ()
+setUpNotmuch notmuchcfg = void $ readProcess_ $ proc "notmuch" ["--config=" <> notmuchcfg, "new" ]
+
+-- | Write a minimal notmuch config pointing to the given maildir.
+-- Returns the path to the notmuch configuration file (which is
+-- created under the given maildir directory).
+--
+setUpNotmuchCfg :: FilePath -> IO FilePath
+setUpNotmuchCfg dir = do
+  let cfgData = "[database]\npath=" <> dir <> "\n"
+      cfgFile = dir <> "/notmuch-config"
+  writeFile cfgFile cfgData $> cfgFile
+
+-- | start the application
+-- Note: this is currently defined as an additional test step for no good
+-- reason.
+startApplication :: (MonadReader Env m, MonadIO m) => m ()
+startApplication = do
+  srcdir <- liftIO getSourceDirectory
+  tmuxSendKeys LiteralKeys ("cd " <> srcdir <> "\r")
+  tmuxSendKeys InterpretKeys "purebred\r"
+  void $ waitForCondition (Substring "Purebred: Item") defaultRetries defaultBackoff

--- a/test/UAT/UndoRedo.hs
+++ b/test/UAT/UndoRedo.hs
@@ -1,0 +1,61 @@
+-- This file is part of purebred
+-- Copyright (C) 2026 Róman Joost
+--
+-- purebred is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module UAT.UndoRedo
+  ( testUndoRedo
+  ) where
+
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.ByteString.Char8 as B
+import Test.Tasty.Tmux
+import UAT.Common
+
+testUndoRedo :: PurebredTestCase
+testUndoRedo = purebredTmuxSession "undo and redo a tag operation" $
+  \step -> do
+    startApplication
+
+    step "nothing to undo or redo on a fresh session"
+    snapshot
+    assertRegexS (undoRedoIndicator 0 0)
+
+    -- use the configured 'a' (archive) short cut from the config to
+    -- tag the thread with +archive
+    step "archive the selected thread"
+    sendKeys "a" (Substring "archive") >>= put
+    assertRegexS (undoRedoIndicator 1 0)
+
+    step "undo reverts the change and moves it onto the redo stack"
+    sendKeys "C-u" (Not (Substring "archive")) >>= put
+    assertSubstringS "undo: 1 message"
+
+    step "clear status message"
+    sendKeys "j" (Regex (undoRedoIndicator 0 1))
+
+    step "redo re-applies the change"
+    sendKeys "C-r" (Substring "archive") >>= put
+    assertSubstringS "redo: 1 message"
+
+    step "clear status message for redo"
+    sendKeys "j" (Regex (undoRedoIndicator 1 0))
+
+undoRedoIndicator :: Int -> Int -> B.ByteString
+undoRedoIndicator nundo nredo = T.encodeUtf8 . T.pack $
+  "\x21b6 " <> show nundo <> " " <> show nredo <> " \x21b7"


### PR DESCRIPTION
This adds/undo redo support of .. tagging. I couldn't really think of any else you would want to undo, except taking back a sent mail perhaps you realise you wrote to the wrong person. Not supported tho haha.

In all seriousness, hope this is useful as I had a few instances I mistakenly tagged something and had to "manually" fix it up again.

E2Es: instead of adding yet another test to the long list, added the happy path to a separate module. Had to obviously refactor the common functions slightly.