### PR TITLE
fix: add cc/bcc headers to mail

### DIFF
--- a/src/Purebred/UI/Actions.hs
+++ b/src/Purebred/UI/Actions.hs
@@ -1632,12 +1632,18 @@ buildMail k = do
         (either (pure []) id . AT.parseOnly AddressText.addressList . T.unlines . E.getEditContents)
       from <- uses (asCompose . cFrom . editEditorL)
         (either (pure []) id . AT.parseOnly AddressText.mailboxList . T.unlines . E.getEditContents)
+      cc <- uses (asCompose . cCc . editEditorL)
+        (either (pure []) id . AT.parseOnly AddressText.addressList . T.unlines . E.getEditContents)
+      bcc <- uses (asCompose . cBcc . editEditorL)
+        (either (pure []) id . AT.parseOnly AddressText.addressList . T.unlines . E.getEditContents)
       subject <- uses (asCompose . cSubject . editEditorL) (T.unlines . E.getEditContents)
       let
         m' = m
           & set (headerSubject charsets) (Just subject)
           & set (headerFrom charsets) (Single <$> from)
           & set (headerTo charsets) to'
+          & set (headerCC charsets) cc
+          & set (headerBCC charsets) bcc
           & set headerDate (Just now)
           & sanitizeMail charsets
 

--- a/test/TestUserAcceptance.hs
+++ b/test/TestUserAcceptance.hs
@@ -493,6 +493,9 @@ testForwardsMailSuccessfully = purebredTmuxSession "forwards mail successfully" 
     contents <- liftIO $ B.readFile fpath
     let decoded = chr . fromEnum <$> B.unpack contents
     assertSubstr subject decoded
+    assertSubstr "To: to_user@foo.test" decoded
+    assertSubstr "Bcc: bcc_user@foo.test" decoded
+    assertSubstr "Cc: cc_user@foo.test" decoded
     assertSubstr "This is a test mail" decoded
     assertSubstr "Find attached a forwarded mail" decoded
 


### PR DESCRIPTION
I realised that we don't even write Bcc and CC headers in the mail we're sending m:(.

Adjusted the test and the code to actually encode the headers.